### PR TITLE
Incorporate improvements from the Python CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
     name: VSCode
     needs: trigger
     if: ${{ needs.trigger.outputs.vscode }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest # TODO: Enable windows, macOS builds.
     steps:
     - uses: 'actions/checkout@v2'
 
@@ -60,11 +60,43 @@ jobs:
       with:
         node-version: 12.x
 
+    - uses: 'actions/setup-python@v1'
+      with:
+        python-version: 3.8
+
+    - run: |
+        python --version
+        python -m pip install --upgrade pip
+        python -m pip install --upgrade tox bump2version towncrier docutils
+      name: Install Build Tools
+
+    - run: |
+        set -e
+
+        ./scripts/make-release.sh vscode
+      name: Set Version
+      id: info
+
     - run: |
         cd code
         npm install
         npm run compile
       name: Build Extension
+
+    - run:
+        cd code
+        npm run package
+
+        vsix=$(find . -name '*.vsix' -exec basename {} \;)
+        echo "::set-output name=VSIX::$vsix"
+      id: assets
+      name: Package
+
+    - name: 'Upload Artifact'
+      uses: actions/upload-artifact@v1.0.0
+      with:
+        name: 'vsix'
+        path: code/${{ assets.outputs.VSIX }}
 
     - name: 'Publish Extension'
       run: |
@@ -72,6 +104,29 @@ jobs:
         npm run deploy
       env:
         VSCE_PAT: ${{ secrets.VSCODE_PAT }}
+      if: success() && startsWith(github.ref, 'refs/heads/release')
+
+    - name: Create Release
+      id: release
+      uses: actions/create-release@v1
+      with:
+        tag_name: ${{ steps.info.outputs.TAG }}
+        release_name: Esbonio VSCode Extension v${{ steps.info.outputs.VERSION  }} - ${{ steps.info.outputs.DATE }}
+        body_path: code/.changes.html
+        draft: false
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      if: success() && startsWith(github.ref, 'refs/heads/release')
+
+    - name: Upload Release Asset
+      uses: actions/upload-release-asset@v1.0.1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.release.outputs.upload_url }}
+        asset_path: code/${{ steps.assets.outputs.VSIX }}
+        asset_name: ${{ steps.assets.outputs.VSIX }}
+        asset_content_type: application/octet-stream
       if: success() && startsWith(github.ref, 'refs/heads/release')
 
   python:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,7 +83,7 @@ jobs:
         npm run compile
       name: Build Extension
 
-    - run:
+    - run: |
         cd code
         npm run package
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,7 +96,7 @@ jobs:
       uses: actions/upload-artifact@v1.0.0
       with:
         name: 'vsix'
-        path: code/${{ assets.outputs.VSIX }}
+        path: code/${{ steps.assets.outputs.VSIX }}
 
     - name: 'Publish Extension'
       run: |

--- a/code/.bumpversion.cfg
+++ b/code/.bumpversion.cfg
@@ -1,0 +1,10 @@
+[bumpversion]
+current_version = 0.0.2
+commit = False
+tag = False
+parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(-dev(?P<dev>\d+))?
+serialize =
+	{major}.{minor}.{patch}-dev{dev}
+	{major}.{minor}.{patch}
+
+[bumpversion:file:package.json]

--- a/code/changes/10.misc.rst
+++ b/code/changes/10.misc.rst
@@ -1,0 +1,2 @@
+Update build pipeline to use ``towncrier`` to autogenerate release notes and changelog
+entries

--- a/code/changes/github-template.html
+++ b/code/changes/github-template.html
@@ -1,0 +1,3 @@
+%(body_pre_docinfo)s
+%(docinfo)s
+%(body)s

--- a/code/package.json
+++ b/code/package.json
@@ -11,7 +11,8 @@
     "scripts": {
         "compile": "tsc -b",
         "watch": "tsc -b -w",
-        "deploy": "vsce publish"
+        "deploy": "vsce publish",
+        "package": "vsce package"
     },
     "main": "dist/extension",
     "dependencies": {

--- a/code/pyproject.toml
+++ b/code/pyproject.toml
@@ -1,7 +1,3 @@
-[build-system]
-requires = ["setuptools >= 35.0.2", "wheel >= 0.29.0"]
-build-backend = "setuptools.build_meta"
-
 [tool.towncrier]
 filename = "CHANGES.rst"
 directory = "changes/"
@@ -38,23 +34,3 @@ underlines = ["-", "^", "\""]
      directory = "misc"
      name = "Misc"
      showcontent = true
-
-[tool.tox]
-legacy_tox_ini = """
-[tox]
-isolated_build = True
-
-[testenv]
-deps =
-    pytest
-commands =
-    pytest
-
-[testenv:pkg]
-deps =
-    wheel
-usedevelop = True
-commands =
-    python setup.py clean --all
-    python setup.py sdist bdist_wheel
-"""

--- a/scripts/make-release.sh
+++ b/scripts/make-release.sh
@@ -10,6 +10,8 @@ SRC=
 TAG_PREFIX=
 COMMIT_MSG=
 
+
+COMPONENT=$1
 case $1 in
     vscode)
         SRC="code"
@@ -77,7 +79,13 @@ if [[ "${GITHUB_REF}" == refs/pull/* ]]; then
     echo "Build number is ${BUILD}"
     echo
 
-    VERSION="${VERSION}.dev${BUILD}"
+    # Annoying that this can't be the same...
+    if [ "${COMPONENT}" = "vscode" ]; then
+        VERSION="${VERSION}-dev${BUILD}"
+    else
+        VERSION="${VERSION}.dev${BUILD}"
+    fi
+
     echo "Dev version number is: ${VERSION}"
 
     python -m bumpversion --allow-dirty --new-version "${VERSION}" dev

--- a/scripts/make-release.sh
+++ b/scripts/make-release.sh
@@ -12,6 +12,9 @@ COMMIT_MSG=
 
 case $1 in
     vscode)
+        SRC="code"
+        TAG_PREFIX="esbonio-vscode"
+        COMMIT_MSG="Esbonio VSCode Ext Release v"
         ;;
     python)
         SRC="lib/esbonio"
@@ -55,7 +58,7 @@ elif [ ! -z "$(find changes -name '*.feature.rst')" ]; then
     echo "New features found, doing minor release!"
     KIND="minor"
 else
-    echo "Nothing significant detected, doing patch release"
+    echo "Doing patch release"
     KIND="patch"
 fi
 

--- a/scripts/should-build.sh
+++ b/scripts/should-build.sh
@@ -4,7 +4,7 @@
 # File patterns to check for each component, if there's a match a build will be
 # triggered
 VSCODE="^code"
-PYTHON="^lib/esbonio"
+PYTHON="^lib/esbonio/.*\.py"
 
 # Determine which files have changed
 git diff --name-only ${BASE}..HEAD -- >> changes


### PR DESCRIPTION
- Auto version numbers based on changelog entries
- Publishing artifacts with dev version numbers in PR builds
- Auto release notes and changelog entries via `towncrier`