### PR TITLE
Fallback to using the Python extension's interpreter if available

### DIFF
--- a/code/changes/9.feature.rst
+++ b/code/changes/9.feature.rst
@@ -1,0 +1,4 @@
+If there is no Python interpreter configured and the
+`Python extension <https://marketplace.visualstudio.com/items?itemName=ms-python.python>`_
+is available, then esbonio will now use the interpreter that's been configured for the
+Python extension

--- a/code/package.json
+++ b/code/package.json
@@ -54,7 +54,7 @@
                     "scope": "window",
                     "type": "string",
                     "default": "",
-                    "description": "The path to the python interpreter used to build your docs."
+                    "description": "The path to the python interpreter used to build your docs.\nIf not set and the Python extension is available, this will fall back to using the interpreter configured there."
                 }
             }
         },

--- a/code/package.json
+++ b/code/package.json
@@ -46,6 +46,28 @@
                 "title": "Esbonio: Restart Language Server"
             }
         ],
+        "configuration": {
+            "type": "object",
+            "title": "Esbonio",
+            "properties": {
+                "esbonio.pythonPath": {
+                    "scope": "window",
+                    "type": "string",
+                    "default": "",
+                    "description": "The path to the python interpreter used to build your docs."
+                }
+            }
+        },
+        "grammars": [
+            {
+                "language": "rst",
+                "scopeName": "source.rst",
+                "path": "./syntaxes/rst.tmLanguage.json",
+                "embeddedLanguages": {
+                    "source.python": "python"
+                }
+            }
+        ],
         "languages": [
             {
                 "id": "rst",
@@ -57,28 +79,6 @@
                 ],
                 "configuration": "./rst-language-configuration.json"
             }
-        ],
-        "grammars": [
-            {
-                "language": "rst",
-                "scopeName": "source.rst",
-                "path": "./syntaxes/rst.tmLanguage.json",
-                "embeddedLanguages": {
-                    "source.python": "python"
-                }
-            }
-        ],
-        "configuration": {
-            "type": "object",
-            "title": "Esbonio",
-            "properties": {
-                "esbonio.python.path": {
-                    "scope": "window",
-                    "type": "string",
-                    "default": "python3",
-                    "description": "The path to the python interpreter used to build your docs."
-                }
-            }
-        }
+        ]
     }
 }

--- a/code/src/commands.ts
+++ b/code/src/commands.ts
@@ -1,96 +1,138 @@
-import { commands, Disposable, ExtensionContext, ProcessExecution, Task, tasks, TaskScope, Terminal, window, workspace } from "vscode";
+import * as vscode from "vscode";
 import { getOutputLogger } from "./log";
+
+const PYTHON_EXT = "ms-python.python"
 
 export const INSTALL_LANGUAGE_SERVER = 'esbonio.languageServer.install'
 export const UPDATE_LANGUAGE_SERVER = 'esbonio.languageServer.update'
 export const RESTART_LANGUAGE_SERVER = 'esbonio.languageServer.restart'
 
 function installLanguageServer(): Promise<null> {
-  let python = getPython()
   let logger = getOutputLogger()
-
-  let process = new ProcessExecution(python, ["-m", "pip", "install", "esbonio[lsp]"])
-  let task = new Task({ type: 'process' }, TaskScope.Workspace, 'Install Language Server', 'esbonio', process)
-
   let promise: Promise<null> = new Promise((resolve, reject) => {
 
-    // Executing a one-shot task and waiting for it to finish seems a little awkward?
-    tasks.executeTask(task).then(texec => {
-      let listener: Disposable
-      listener = tasks.onDidEndTask(end => {
-        if (texec === end.execution) {
-          logger.debug("Installation task has completed.")
-          listener.dispose()
-          resolve(null)
-        }
-      })
-    })
+    getPython().then(python => {
+      let process = new vscode.ProcessExecution(python, ["-m", "pip", "install", "esbonio[lsp]"])
+      let task = new vscode.Task({ type: 'process' }, vscode.TaskScope.Workspace, 'Install Language Server', 'esbonio', process)
+
+      // Executing a one-shot task and waiting for it to finish seems a little awkward?
+      vscode.tasks.executeTask(task).then(texec => {
+        let listener: vscode.Disposable
+        listener = vscode.tasks.onDidEndTask(end => {
+          if (texec === end.execution) {
+            logger.debug("Installation task has completed.")
+            listener.dispose()
+            resolve(null)
+          }
+        })
+      }, err => reject(err))
+    }).catch(err => reject(err))
   })
 
   return promise
 }
 
 function updateLanguageServer(): Promise<null> {
-  let python = getPython()
   let logger = getOutputLogger()
-
-  let process = new ProcessExecution(python, ["-m", "pip", "install", "--upgrade", "esbonio[lsp]"])
-  let task = new Task({ type: 'process' }, TaskScope.Workspace, 'Update Language Server', 'esbonio', process)
   let promise: Promise<null> = new Promise((resolve, reject) => {
 
-    // Executing a one-shot task and waiting for it to finish seems a little awkward?
-    tasks.executeTask(task).then(texec => {
-      let listener: Disposable
-      listener = tasks.onDidEndTask(end => {
-        if (texec === end.execution) {
-          logger.debug("Update task has completed.")
-          listener.dispose()
-          resolve(null)
-        }
-      })
-    })
+    getPython().then(python => {
+      let process = new vscode.ProcessExecution(python, ["-m", "pip", "install", "--upgrade", "esbonio[lsp]"])
+      let task = new vscode.Task({ type: 'process' }, vscode.TaskScope.Workspace, 'Update Language Server', 'esbonio', process)
+
+      // Executing a one-shot task and waiting for it to finish seems a little awkward?
+      vscode.tasks.executeTask(task).then(texec => {
+        let listener: vscode.Disposable
+        listener = vscode.tasks.onDidEndTask(end => {
+          if (texec === end.execution) {
+            logger.debug("Update task has completed.")
+            listener.dispose()
+            resolve(null)
+          }
+        })
+      }, err => reject(err))
+    }).catch(err => reject(err))
   })
 
   return promise
 }
 
 function restartLanguageServer() {
-  window.showErrorMessage("Not yet implemented")
-}
-
-
-function findOrCreateTerminal(name: string): Terminal {
-  let terminal: Terminal
-  window.terminals.forEach(term => {
-    if (term.name === name) {
-      terminal = term
-    }
+  getPython().then(python => {
+    vscode.window.showInformationMessage(python)
+  }).catch(err => {
+    vscode.window.showErrorMessage(err)
   })
-
-  if (terminal) {
-    return terminal
-  }
-
-  terminal = window.createTerminal({ name: name })
-  return terminal
 }
-
 
 /**
- * Get the path to the right python environment to use.
- * TODO: Add a config option that lets people inherhit this from the python extension
- * if available.
+ * Get the path to the right Python environment to use.
+ *
+ * - If the user has set a value for `esbonio.pythonPath` use that.
+ * - Otherwise, if the official Python extension is available this function will attempt
+ *   to retrieve the Python
  */
-export function getPython(): string {
-  let python = workspace.getConfiguration('esbonio.python').get<string>('path')
-  return python
+export function getPython(): Promise<string> {
+  let logger = getOutputLogger()
+  let python = vscode.workspace.getConfiguration('esbonio').get<string>('pythonPath')
+
+  // If the user has set a value, use that.
+  //
+  // TODO: Implement variable expansions like ${workspaceRoot}, ${config:xxx} etc.
+  //       Ideally it would be something VSCode could do for us, but as far as I can
+  //       tell it's not available yet
+  //       https://github.com/microsoft/vscode/issues/46471
+  if (python) {
+    logger.debug(`Using user configured Python: ${python}`)
+    return Promise.resolve(python)
+  }
+
+  // If the  python extension's `python.pythonPath` is available, let's use that.
+  return getPythonExtPython()
+
+  // TODO: If the above fails, or the Python extension is not available, implement a
+  //       fallback that attempts to discover the system Python?
+}
+
+function getPythonExtPython(): Promise<string> {
+  let logger = getOutputLogger()
+  return new Promise((resolve, reject) => {
+    let root = vscode.workspace.workspaceFolders[0]
+    let options = {
+      workspaceFolder: root.uri.path
+    }
+
+    getPythonExtension().then(_ => {
+      vscode.commands.executeCommand<string>("python.interpreterPath", options).then(python => {
+        logger.debug(`Using python from the python extension: ${python}`)
+        resolve(python)
+      }, err => reject(err))
+    }).catch(err => reject(err))
+  })
+}
+
+function getPythonExtension(): Promise<vscode.Extension<any>> {
+  let logger = getOutputLogger()
+  let pythonExt = vscode.extensions.getExtension(PYTHON_EXT)
+  if (!pythonExt) {
+    return Promise.reject("The Python extension is not available.")
+  }
+
+  if (pythonExt.isActive) {
+    return Promise.resolve(pythonExt)
+  }
+
+  return new Promise((resolve, reject) => {
+    logger.debug("Python extension is available but not yet active, activating...")
+    pythonExt.activate().then(ext => resolve(ext), err => reject(err))
+  })
 }
 
 /**
  * Register all the commands we contribute to VSCode.
  */
-export function registerCommands(context: ExtensionContext) {
-  context.subscriptions.push(commands.registerCommand(INSTALL_LANGUAGE_SERVER, installLanguageServer))
-  context.subscriptions.push(commands.registerCommand(UPDATE_LANGUAGE_SERVER, updateLanguageServer))
-  context.subscriptions.push(commands.registerCommand(RESTART_LANGUAGE_SERVER, restartLanguageServer))
+export function registerCommands(context: vscode.ExtensionContext) {
+  context.subscriptions.push(vscode.commands.registerCommand(INSTALL_LANGUAGE_SERVER, installLanguageServer))
+  context.subscriptions.push(vscode.commands.registerCommand(UPDATE_LANGUAGE_SERVER, updateLanguageServer))
+  context.subscriptions.push(vscode.commands.registerCommand(RESTART_LANGUAGE_SERVER, restartLanguageServer))
 }

--- a/code/src/extension.ts
+++ b/code/src/extension.ts
@@ -1,4 +1,4 @@
-import { ExtensionContext, workspace, window } from "vscode";
+import * as vscode from "vscode";
 import { Executable, LanguageClient, LanguageClientOptions, ServerOptions } from "vscode-languageclient";
 import { getPython, registerCommands } from "./commands";
 import { bootstrapLanguageServer } from "./languageServer";
@@ -6,42 +6,43 @@ import { getOutputLogger } from "./log";
 
 let client: LanguageClient
 
-
-export function activate(context: ExtensionContext) {
+export function activate(context: vscode.ExtensionContext) {
 
     let logger = getOutputLogger()
     logger.debug("Extension activated.")
-    let python = getPython()
-
-    bootstrapLanguageServer(python).then(res => {
-        if (!res) {
-            logger.debug("Unable to bootstrap language server, will not attempt to start")
-            return
-        }
-        let exe: Executable = {
-            command: python,
-            args: ['-m', 'esbonio']
-        }
-        let serverOptions: ServerOptions = exe
-
-        let clientOptions: LanguageClientOptions = {
-            documentSelector: [{ scheme: 'file', language: 'rst' }]
-        }
-        client = new LanguageClient('esbonio', 'Esbonio', serverOptions, clientOptions)
-        client.start()
-    }).catch(err => {
-
-        logger.error(err)
-        let message = "Unable to start language server.\n" +
-            "See output window for more details"
-        window.showErrorMessage(message, { title: "Show Output" }).then(opt => {
-            if (opt.title === "Show Output") {
-                logger.show()
+    getPython().then(python => {
+        bootstrapLanguageServer(python).then(res => {
+            if (!res) {
+                logger.debug("Unable to bootstrap language server, will not attempt to start")
+                return
             }
-        })
-    })
+            let exe: Executable = {
+                command: python,
+                args: ['-m', 'esbonio']
+            }
+            let serverOptions: ServerOptions = exe
+
+            let clientOptions: LanguageClientOptions = {
+                documentSelector: [{ scheme: 'file', language: 'rst' }]
+            }
+            client = new LanguageClient('esbonio', 'Esbonio', serverOptions, clientOptions)
+            client.start()
+        }).catch(err => showError(err))
+    }).catch(err => showError(err))
 
     registerCommands(context)
+}
+
+function showError(error) {
+    let logger = getOutputLogger()
+    logger.error(error)
+    let message = "Unable to start language server.\n" +
+        "See output window for more details"
+    vscode.window.showErrorMessage(message, { title: "Show Output" }).then(opt => {
+        if (opt.title === "Show Output") {
+            logger.show()
+        }
+    })
 }
 
 export function deactivate(): Thenable<void> | undefined {


### PR DESCRIPTION
If the `esbonio.pythonPath` option is not configured and the Python extension is available, Esbonio will now fallback to using the interpreter that has been configured for use by the Python extension.

Closes #9 