### PR TITLE
Flesh out directive and role based completions

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -21,7 +21,9 @@
         "**/.pyc": true,
         "**/__pycache__": true,
         "**/*.egg-info": true,
-        "**/.tox": true
+        "**/.tox": true,
+        "**/.pytest_cache": true,
+        "**/.ipynb_checkpoints": true,
     },
     "python.pythonPath": ".env/bin/python3",
     "python.formatting.provider": "black",

--- a/lib/esbonio/changes/23.feature.rst
+++ b/lib/esbonio/changes/23.feature.rst
@@ -1,0 +1,2 @@
+The language server can now offer completion suggestions for ``directives`` and
+``roles``

--- a/lib/esbonio/esbonio/lsp/__init__.py
+++ b/lib/esbonio/esbonio/lsp/__init__.py
@@ -105,7 +105,7 @@ def on_initialized(rst: RstLanguageServer, params):
 
 
 NEW_DIRECTIVE = re.compile(r"^\s*\.\.[ ]*([\w-]+)?$")
-NEW_ROLE = re.compile("(^|\\s+):([\\w-]+)?")
+NEW_ROLE = re.compile(r".*(?<!:):(?!:)[\w-]*")
 
 
 def get_line_til_position(doc: Document, position: Position) -> str:
@@ -126,7 +126,7 @@ def completions(rst: RstLanguageServer, params: CompletionParams):
 
     doc = rst.workspace.get_document(uri)
     line = get_line_til_position(doc, pos)
-    print("Line: '{}'".format(line))
+    rst.logger.debug("Line: '{}'".format(line))
 
     if NEW_DIRECTIVE.match(line):
         candidates = list(rst.directives.values())

--- a/lib/esbonio/esbonio/lsp/__init__.py
+++ b/lib/esbonio/esbonio/lsp/__init__.py
@@ -3,7 +3,6 @@ import importlib
 import logging
 import pathlib
 import re
-from typing import Dict, Optional
 
 import appdirs
 import docutils.parsers.rst.directives as directives
@@ -66,10 +65,10 @@ class RstLanguageServer(LanguageServer):
         self.app = None
         """Sphinx application instance configured for the current project."""
 
-        self.directives: Optional[Dict[str, CompletionItem]] = None
+        self.directives = {}
         """Dictionary holding the directives that have been registered."""
 
-        self.roles: Optional[Dict[str, CompletionItem]] = None
+        self.roles = {}
         """Dictionary holding the roles that have been registered."""
 
 

--- a/lib/esbonio/pyproject.toml
+++ b/lib/esbonio/pyproject.toml
@@ -48,6 +48,7 @@ isolated_build = True
 deps =
     mock
     pytest
+extras = lsp
 commands =
     pytest
 

--- a/lib/esbonio/pyproject.toml
+++ b/lib/esbonio/pyproject.toml
@@ -46,6 +46,7 @@ isolated_build = True
 
 [testenv]
 deps =
+    mock
     pytest
 commands =
     pytest

--- a/lib/esbonio/setup.cfg
+++ b/lib/esbonio/setup.cfg
@@ -31,5 +31,5 @@ install_requires =
 exclude = tests
 
 [options.extras_require]
-dev = black ; flake8 ; pytest ; pytest-cov
+dev = black ; flake8 ; pytest ; pytest-cov ; mock
 lsp = appdirs ; pygls

--- a/lib/esbonio/tests/lsp/test_completions.py
+++ b/lib/esbonio/tests/lsp/test_completions.py
@@ -1,0 +1,105 @@
+"""Testing the logic behind suggesting completions.
+
+This assumes that the objects we can complete, directives, roles, references etc have
+already been discovered. So these tests focus on "given a completion request at this
+position, what should the suggestions be?"
+
+These tests rely heavily on mocking, it might be better to replace them with more
+integration style tests once the end-to-end picture is better understood.
+"""
+from typing import Optional
+import py.test
+
+from mock import Mock
+from pygls.types import (
+    CompletionItem,
+    CompletionContext,
+    CompletionItemKind,
+    CompletionTriggerKind,
+    CompletionParams,
+    Position,
+    TextDocumentIdentifier,
+)
+from pygls.workspace import Document, Workspace
+
+from esbonio.lsp import completions
+
+
+def make_document(contents) -> Document:
+    """Helper that constructs a document that can be placed in a workspace."""
+
+    uri = "file://fake_doc.rst"
+    return Document(uri, contents)
+
+
+def make_params(
+    line: int = 0, character: int = 0, trigger: Optional[str] = None
+) -> CompletionParams:
+    """Helper that makes it easier to construct the completion params."""
+
+    trigger_kind = CompletionTriggerKind.Invoked
+
+    if trigger is not None:
+        trigger_kind = CompletionTriggerKind.TriggerCharacter
+
+    return CompletionParams(
+        text_document=TextDocumentIdentifier(uri="file://fake_doc.rst"),
+        position=Position(line=line, character=character),
+        context=CompletionContext(trigger_kind=trigger_kind, trigger_character=trigger),
+    )
+
+
+EXAMPLE_DIRECTIVES = [CompletionItem("doctest", kind=CompletionItemKind.Class)]
+
+
+@py.test.fixture()
+def rst():
+    """A mock rst language server instance.
+
+    Originally based on:
+    https://github.com/openlawlibrary/pygls/blob/aee66189e8233c34dba4c13a9a87e6708fb03810/examples/json-extension/server/tests/unit/test_features.py
+    """
+
+    class LanguageServer:
+        def __init__(self):
+            self.workspace = Workspace("", None)
+
+    server = LanguageServer()
+    server.publish_diagnostics = Mock()
+    server.show_message = Mock()
+    server.show_message_log = Mock()
+
+    # Mock the data that is used to provide the completions.
+    server.directives = {c.label: c for c in EXAMPLE_DIRECTIVES}
+
+    return server
+
+
+@py.test.mark.parametrize(
+    "doc,params,expected",
+    [
+        (".", make_params(character=1, trigger="."), []),
+        ("..", make_params(character=2, trigger="."), EXAMPLE_DIRECTIVES),
+        (".. ", make_params(character=3), EXAMPLE_DIRECTIVES),
+        (".. d", make_params(character=4), EXAMPLE_DIRECTIVES),
+        (".. code-b", make_params(character=9), EXAMPLE_DIRECTIVES),
+        (".. doctest:: ", make_params(character=13), []),
+        (".. code-block:: ", make_params(character=16), []),
+        ("   .", make_params(character=4, trigger="."), []),
+        ("   ..", make_params(character=5, trigger="."), EXAMPLE_DIRECTIVES),
+        ("   .. ", make_params(character=6), EXAMPLE_DIRECTIVES),
+        ("   .. d", make_params(character=7), EXAMPLE_DIRECTIVES),
+        ("   .. code-b", make_params(character=12), EXAMPLE_DIRECTIVES),
+        ("   .. doctest:: ", make_params(character=16), []),
+        ("   .. code-block:: ", make_params(character=19), []),
+    ],
+)
+def test_completion_suggestions(rst, doc, params, expected):
+    """Ensure that the correct type of completions are suggested based on the location
+    and type of completion asked for."""
+
+    document = make_document(doc)
+    rst.workspace.get_document = Mock(return_value=document)
+
+    actual = completions(rst, params).items
+    assert actual == expected


### PR DESCRIPTION
- Set `insert_text` so that selecting a completion will fill in the additional syntax
- Start adding test cases around the language server
