### PR TITLE
Redirect Sphinx's build output to the LSP client

### DIFF
--- a/lib/esbonio/changes/28.feature.rst
+++ b/lib/esbonio/changes/28.feature.rst
@@ -1,0 +1,2 @@
+**Language Server** Sphinx's build output is now redirected to the LSP client as log
+messages.

--- a/lib/esbonio/esbonio/__main__.py
+++ b/lib/esbonio/esbonio/__main__.py
@@ -17,15 +17,25 @@ def configure_logging(verbose, server):
     except IndexError:
         level = LOG_LEVELS[-1]
 
-    logger = logging.getLogger("esbonio")
-    logger.setLevel(level)
+    lsp_logger = logging.getLogger("esbonio.lsp")
+    lsp_logger.setLevel(level)
 
-    handler = LspHandler(server)
-    handler.setLevel(level)
+    lsp_handler = LspHandler(server)
+    lsp_handler.setLevel(level)
 
     formatter = logging.Formatter("[%(name)s] %(message)s")
-    handler.setFormatter(formatter)
-    logger.addHandler(handler)
+    lsp_handler.setFormatter(formatter)
+    lsp_logger.addHandler(lsp_handler)
+
+    sphinx_logger = logging.getLogger("esbonio.sphinx")
+    sphinx_logger.setLevel(level)
+
+    sphinx_handler = LspHandler(server)
+    sphinx_handler.setLevel(level)
+
+    formatter = logging.Formatter("%(message)s")
+    sphinx_handler.setFormatter(formatter)
+    sphinx_logger.addHandler(sphinx_handler)
 
 
 def start_server(verbose):

--- a/lib/esbonio/esbonio/lsp/__init__.py
+++ b/lib/esbonio/esbonio/lsp/__init__.py
@@ -1,162 +1,24 @@
-import inspect
-import importlib
-import logging
-import pathlib
-import re
+from pygls.features import COMPLETION, INITIALIZED, TEXT_DOCUMENT_DID_SAVE
 
-import appdirs
-import docutils.parsers.rst.directives as directives
-import docutils.parsers.rst.roles as roles
+from pygls.types import CompletionParams, InitializeParams, DidSaveTextDocumentParams
 
-from pygls.features import COMPLETION, INITIALIZED
-from pygls.server import LanguageServer
-from pygls.types import (
-    CompletionItem,
-    CompletionItemKind,
-    CompletionList,
-    CompletionParams,
-    InsertTextFormat,
-    MessageType,
-    Position,
-)
-from pygls.workspace import Document
-
-from sphinx.application import Sphinx
-
-
-def completion_from_directive(name, directive) -> CompletionItem:
-    """Convert an rst directive to a completion item we can return to the client."""
-
-    # 'Core' docutils directives are listed as tuples (modulename, ClassName) so we
-    # have to go and look them up ourselves.
-    if isinstance(directive, tuple):
-        mod, cls = directive
-
-        modulename = "docutils.parsers.rst.directives.{}".format(mod)
-        module = importlib.import_module(modulename)
-        directive = getattr(module, cls)
-
-    documentation = inspect.getdoc(directive)
-    return CompletionItem(
-        name,
-        kind=CompletionItemKind.Class,
-        detail="directive",
-        documentation=documentation,
-        insert_text=" {}:: ".format(name),
-    )
-
-
-def completion_from_role(name, role) -> CompletionItem:
-    """Convert an rst directive to a completion item we can return to the client."""
-    return CompletionItem(
-        name,
-        kind=CompletionItemKind.Function,
-        detail="role",
-        insert_text="{}:`$1`".format(name),
-        insert_text_format=InsertTextFormat.Snippet,
-    )
-
-
-def discover_roles(app: Sphinx):
-    """Discover roles that we can offer as autocomplete suggestions."""
-    # Pull out the roles that are available via docutils.
-    local_roles = {
-        k: v for k, v in roles._roles.items() if v != roles.unimplemented_role
-    }
-
-    role_registry = {
-        k: v for k, v in roles._role_registry.items() if v != roles.unimplemented_role
-    }
-
-    # Don't forget to include the roles that are stored under Sphinx domains.
-    # TODO: Implement proper domain handling, focus on std + python for now.
-    domains = app.registry.domains
-    std_roles = domains["std"].roles
-    py_roles = domains["py"].roles
-
-    return {**local_roles, **role_registry, **py_roles, **std_roles}
-
-
-class RstLanguageServer(LanguageServer):
-    def __init__(self):
-        super().__init__()
-        self.logger = logging.getLogger(__name__)
-
-        self.app = None
-        """Sphinx application instance configured for the current project."""
-
-        self.directives = {}
-        """Dictionary holding the directives that have been registered."""
-
-        self.roles = {}
-        """Dictionary holding the roles that have been registered."""
-
-
-server = RstLanguageServer()
+from esbonio.lsp.completion import completions
+from esbonio.lsp.initialize import initialized
+from esbonio.lsp.server import RstLanguageServer, server
 
 
 @server.feature(INITIALIZED)
-def on_initialized(rst: RstLanguageServer, params):
-    """Do set up once the initial handshake has been completed."""
-    rst.logger.debug("Workspace root %s", rst.workspace.root_uri)
-
-    root = pathlib.Path(rst.workspace.root_uri.replace("file://", ""))
-    candidates = list(root.glob("**/conf.py"))
-
-    if len(candidates) == 0:
-        rst.show_message(
-            "Unable to find your 'conf.py', features will be limited",
-            msg_type=MessageType.Warning,
-        )
-
-    else:
-        src = candidates[0].parent
-        rst.logger.debug("Found config dir %s", src)
-        build = appdirs.user_cache_dir("esbonio", "swyddfa")
-        rst.app = Sphinx(src, src, build, build, "html", status=None, warning=None)
-
-    # Lookup the directives and roles that have been registered
-    dirs = {**directives._directive_registry, **directives._directives}
-    rst.directives = {k: completion_from_directive(k, v) for k, v in dirs.items()}
-
-    rst.roles = {
-        k: completion_from_role(k, v) for k, v in discover_roles(rst.app).items()
-    }
-    rst.logger.debug("Discovered %s roles", len(rst.roles))
-
-
-NEW_DIRECTIVE = re.compile(r"^\s*\.\.[ ]*([\w-]+)?$")
-NEW_ROLE = re.compile(r".*(?<!:):(?!:)[\w-]*")
-
-
-def get_line_til_position(doc: Document, position: Position) -> str:
-    """Return the line up until the position of the cursor."""
-
-    try:
-        line = doc.lines[position.line]
-    except IndexError:
-        return ""
-
-    return line[: position.character]
+def _(rst: RstLanguageServer, params):
+    return initialized(rst, params)
 
 
 @server.feature(COMPLETION, trigger_characters=[".", ":"])
-def completions(rst: RstLanguageServer, params: CompletionParams):
-    """Suggest completions based on the current context"""
-    uri = params.textDocument.uri
-    pos = params.position
+def _(rst: RstLanguageServer, params: CompletionParams):
+    return completions(rst, params)
 
-    doc = rst.workspace.get_document(uri)
-    line = get_line_til_position(doc, pos)
-    rst.logger.debug("Line: '{}'".format(line))
 
-    if NEW_DIRECTIVE.match(line):
-        candidates = list(rst.directives.values())
-
-    elif NEW_ROLE.match(line):
-        candidates = list(rst.roles.values())
-
-    else:
-        candidates = []
-
-    return CompletionList(False, candidates)
+@server.feature(TEXT_DOCUMENT_DID_SAVE)
+def _(rst: RstLanguageServer, params: DidSaveTextDocumentParams):
+    """Re-read sources on save so we get the latest completion targets."""
+    rst.app.builder.read()
+    return

--- a/lib/esbonio/esbonio/lsp/completion.py
+++ b/lib/esbonio/esbonio/lsp/completion.py
@@ -1,0 +1,42 @@
+"""Auto complete suggestions."""
+import re
+
+from pygls.types import CompletionList, CompletionParams, Position
+from pygls.workspace import Document
+
+from esbonio.lsp.server import RstLanguageServer
+
+NEW_DIRECTIVE = re.compile(r"^\s*\.\.[ ]*([\w-]+)?$")
+NEW_ROLE = re.compile(r".*(?<!:):(?!:)[\w-]*")
+
+
+def get_line_til_position(doc: Document, position: Position) -> str:
+    """Return the line up until the position of the cursor."""
+
+    try:
+        line = doc.lines[position.line]
+    except IndexError:
+        return ""
+
+    return line[: position.character]
+
+
+def completions(rst: RstLanguageServer, params: CompletionParams):
+    """Suggest completions based on the current context"""
+    uri = params.textDocument.uri
+    pos = params.position
+
+    doc = rst.workspace.get_document(uri)
+    line = get_line_til_position(doc, pos)
+    rst.logger.debug("Line: '{}'".format(line))
+
+    if NEW_DIRECTIVE.match(line):
+        candidates = list(rst.directives.values())
+
+    elif NEW_ROLE.match(line):
+        candidates = list(rst.roles.values())
+
+    else:
+        candidates = []
+
+    return CompletionList(False, candidates)

--- a/lib/esbonio/esbonio/lsp/initialize.py
+++ b/lib/esbonio/esbonio/lsp/initialize.py
@@ -1,0 +1,145 @@
+"""Server initialization logic."""
+import inspect
+import importlib
+import logging
+import pathlib
+
+import appdirs
+import sphinx.util.console as console
+
+from docutils.parsers.rst import directives
+from docutils.parsers.rst import roles
+from pygls.types import (
+    CompletionItem,
+    CompletionItemKind,
+    InitializeParams,
+    InsertTextFormat,
+    MessageType,
+)
+from sphinx.application import Sphinx
+
+from esbonio.lsp.server import RstLanguageServer
+from esbonio.lsp.logger import LspHandler
+
+
+def initialized(rst: RstLanguageServer, params: InitializeParams):
+    """Do set up once the initial handshake has been completed."""
+
+    init_sphinx(rst)
+    discover_completion_items(rst)
+
+
+def discover_completion_items(rst: RstLanguageServer):
+    """Discover the "static" completion items.
+
+    "Static" completion items are anything that are not likely to change much during the
+    course of an editing session. Currently this includes:
+
+    - roles
+    - directives
+    """
+    # Lookup the directives and roles that have been registered
+    dirs = {**directives._directive_registry, **directives._directives}
+    rst.directives = {k: completion_from_directive(k, v) for k, v in dirs.items()}
+
+    rst.roles = {
+        k: completion_from_role(k, v) for k, v in discover_roles(rst.app).items()
+    }
+
+    rst.logger.debug("Discovered %s directives", len(rst.directives))
+    rst.logger.debug("Discovered %s roles", len(rst.roles))
+
+
+def discover_roles(app: Sphinx):
+    """Discover roles that we can offer as autocomplete suggestions."""
+    # Pull out the roles that are available via docutils.
+    local_roles = {
+        k: v for k, v in roles._roles.items() if v != roles.unimplemented_role
+    }
+
+    role_registry = {
+        k: v for k, v in roles._role_registry.items() if v != roles.unimplemented_role
+    }
+
+    # Don't forget to include the roles that are stored under Sphinx domains.
+    # TODO: Implement proper domain handling, focus on std + python for now.
+    domains = app.registry.domains
+    std_roles = domains["std"].roles
+    py_roles = domains["py"].roles
+
+    return {**local_roles, **role_registry, **py_roles, **std_roles}
+
+
+def completion_from_directive(name, directive) -> CompletionItem:
+    """Convert an rst directive to a completion item we can return to the client."""
+
+    # 'Core' docutils directives are listed as tuples (modulename, ClassName) so we
+    # have to go and look them up ourselves.
+    if isinstance(directive, tuple):
+        mod, cls = directive
+
+        modulename = "docutils.parsers.rst.directives.{}".format(mod)
+        module = importlib.import_module(modulename)
+        directive = getattr(module, cls)
+
+    documentation = inspect.getdoc(directive)
+    return CompletionItem(
+        name,
+        kind=CompletionItemKind.Class,
+        detail="directive",
+        documentation=documentation,
+        insert_text=" {}:: ".format(name),
+    )
+
+
+def completion_from_role(name, role) -> CompletionItem:
+    """Convert an rst directive to a completion item we can return to the client."""
+    return CompletionItem(
+        name,
+        kind=CompletionItemKind.Function,
+        detail="role",
+        insert_text="{}:`$1`".format(name),
+        insert_text_format=InsertTextFormat.Snippet,
+    )
+
+
+class LogIO:
+    def __init__(self):
+        self.logger = logging.getLogger("esbonio.sphinx")
+
+    def write(self, line):
+        self.logger.info(line)
+
+
+def init_sphinx(rst: RstLanguageServer):
+    """Initialise a Sphinx application instance."""
+    rst.logger.debug("Workspace root %s", rst.workspace.root_uri)
+
+    root = pathlib.Path(rst.workspace.root_uri.replace("file://", ""))
+    candidates = list(root.glob("**/conf.py"))
+
+    if len(candidates) == 0:
+        rst.show_message(
+            "Unable to find your 'conf.py', features will be limited",
+            msg_type=MessageType.Warning,
+        )
+        return
+
+    src = candidates[0].parent
+    build = appdirs.user_cache_dir("esbonio", "swyddfa")
+    doctrees = pathlib.Path(build) / "doctrees"
+
+    rst.logger.debug("Config dir %s", src)
+    rst.logger.debug("Src dir %s", src)
+    rst.logger.debug("Build dir %s", build)
+    rst.logger.debug("Doctree dir %s", str(doctrees))
+
+    # Disable color codes in Sphinx's log messages.
+    console.nocolor()
+
+    # Create a 'LogIO' object which we use to redirect Sphinx's output to the LSP Client
+    log = LogIO()
+    rst.app = Sphinx(src, src, build, doctrees, "html", status=log, warning=log)
+
+    # Do a read of all the sources to populate the environment with completion targets
+    rst.app.builder.read()

--- a/lib/esbonio/esbonio/lsp/logger.py
+++ b/lib/esbonio/esbonio/lsp/logger.py
@@ -30,5 +30,5 @@ class LspHandler(logging.Handler):
         if "pygls" in record.name:
             return
 
-        log = self.format(record)
-        self.server.show_message_log(log, msg_type=_LOG_LEVELS[record.levelno])
+        log = self.format(record).strip()
+        self.server.show_message_log(log)

--- a/lib/esbonio/esbonio/lsp/server.py
+++ b/lib/esbonio/esbonio/lsp/server.py
@@ -1,0 +1,21 @@
+"""Our Lanague Server Class Definition."""
+import logging
+from pygls.server import LanguageServer
+
+
+class RstLanguageServer(LanguageServer):
+    def __init__(self):
+        super().__init__()
+        self.logger = logging.getLogger(__name__)
+
+        self.app = None
+        """Sphinx application instance configured for the current project."""
+
+        self.directives = {}
+        """Dictionary holding the directives that have been registered."""
+
+        self.roles = {}
+        """Dictionary holding the roles that have been registered."""
+
+
+server = RstLanguageServer()

--- a/lib/esbonio/tests/lsp/test_completions.py
+++ b/lib/esbonio/tests/lsp/test_completions.py
@@ -23,7 +23,8 @@ from pygls.types import (
 )
 from pygls.workspace import Document, Workspace
 
-from esbonio.lsp import completions, discover_roles
+from esbonio.lsp.completion import completions
+from esbonio.lsp.initialize import discover_roles
 
 
 def make_document(contents) -> Document:


### PR DESCRIPTION
- Reconfigure Sphinx's logging setup just enough so that we're able to present its output to the client in a readable manner
- Automatically re-read `.rst` sources on save.
- Refactored the `esbonio.lsp` module so that each major feature has its own `.py` file