### PR TITLE
Add commands that can be used to insert links

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,6 +93,8 @@ jobs:
     - run: |
         cd code
         npm install
+
+        mkdir dist
         npm run test
       name: Test Extension
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,7 +95,7 @@ jobs:
         npm install
 
         mkdir dist
-        npm run test
+        xvfb-run -a npm test
       name: Test Extension
 
     - run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,6 +100,8 @@ jobs:
 
     - run: |
         cd code
+
+        rm -r dist
         npm run compile
       name: Build Extension
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,6 +93,11 @@ jobs:
     - run: |
         cd code
         npm install
+        npm run test
+      name: Test Extension
+
+    - run: |
+        cd code
         npm run compile
       name: Build Extension
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,11 @@
 .env
 .tox
+.vscode-test
+
 *.pyc
 *.egg-info
 *.log
+
 __pycache__
 _build
 build

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,9 +2,9 @@
     "version": "0.2.0",
     "configurations": [
         {
+            "name": "Esbonio VSCode",
             "type": "extensionHost",
             "request": "launch",
-            "name": "Esbonio VSCode",
             "runtimeExecutable": "${execPath}",
             "args": [
                 "--extensionDevelopmentPath=${workspaceRoot}/code",
@@ -14,6 +14,19 @@
                 "${workspaceRoot}/code/dist/**/*.js"
             ],
             "preLaunchTask": "${defaultBuildTask}"
+        },
+        {
+            "name": "Esbonio VSCode Tests",
+            "type": "extensionHost",
+            "request": "launch",
+            "runtimeExecutable": "${execPath}",
+            "args": [
+                "--extensionDevelopmentPath=${workspaceFolder}/code",
+                "--extensionTestsPath=${workspaceFolder}/code/dist/test/suite/index"
+            ],
+            "outFiles": [
+                "${workspaceFolder}/code/dist/test/**/*.js"
+            ]
         }
     ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -26,7 +26,8 @@
             ],
             "outFiles": [
                 "${workspaceFolder}/code/dist/test/**/*.js"
-            ]
+            ],
+            "preLaunchTask": "Build Tests",
         }
     ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -21,6 +21,23 @@
             ]
         },
         {
+            "label": "Build Tests",
+            "type": "npm",
+            "script": "compile-test",
+            "isBackground": false,
+            "options": {
+                "cwd": "${workspaceRoot}/code"
+            },
+            "group": "build",
+            "presentation": {
+                "panel": "dedicated",
+                "reveal": "never",
+            },
+            "problemMatcher": [
+                "$tsc-watch"
+            ]
+        },
+        {
             "label": "Build Docs",
             "type": "shell",
             "command": "source ${workspaceRoot}/.env/bin/activate && make html",

--- a/code/changes/37.feature.rst
+++ b/code/changes/37.feature.rst
@@ -1,2 +1,2 @@
 Add 2 commands that can be used to insert links. One that uses the inline syntax
-for inserting links, the other, the named reference syntax.
+:kbd:`Alt+L`, the other, the named reference syntax :kbd:`Alt+Shift+L`

--- a/code/changes/37.feature.rst
+++ b/code/changes/37.feature.rst
@@ -1,0 +1,2 @@
+Add 2 commands that can be used to insert links. One that uses the inline syntax
+for inserting links, the other, the named reference syntax.

--- a/code/package-lock.json
+++ b/code/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "esbonio",
-    "version": "0.1.0",
+    "version": "0.2.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -30,10 +30,32 @@
             "integrity": "sha512-jnqIUKDUqJbDIUxm0Uj7bnlMnRm1T/eZ9N+AVMqhPgzrba2GhGG5o/jCTwmdPK709nEZsGoMzXEDUjcXHa3W0g==",
             "dev": true
         },
+        "@types/glob": {
+            "version": "7.1.3",
+            "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.3.tgz",
+            "integrity": "sha512-SEYeGAIQIQX8NN6LDKprLjbrd5dARM5EXsd8GI/A5l0apYI1fGMWgPHSe4ZKL4eozlAyI+doUE9XbYS4xCkQ1w==",
+            "dev": true,
+            "requires": {
+                "@types/minimatch": "*",
+                "@types/node": "*"
+            }
+        },
         "@types/json-schema": {
             "version": "7.0.6",
             "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.6.tgz",
             "integrity": "sha512-3c+yGKvVP5Y9TYBEibGNR+kLtijnj7mYrXRg+WpFb2X9xm04g/DXYkfg4hmzJQosc9snFNUPkbYIhu+KAm6jJw==",
+            "dev": true
+        },
+        "@types/minimatch": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
+            "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
+            "dev": true
+        },
+        "@types/mocha": {
+            "version": "8.2.0",
+            "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-8.2.0.tgz",
+            "integrity": "sha512-/Sge3BymXo4lKc31C8OINJgXLaw+7vL1/L1pGiBNpGrBiT8FQiaFpSYV0uhTaG4y78vcMBTMFsWaHDvuD+xGzQ==",
             "dev": true
         },
         "@types/node": {
@@ -46,6 +68,12 @@
             "version": "1.43.0",
             "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.43.0.tgz",
             "integrity": "sha512-kIaR9qzd80rJOxePKpCB/mdy00mz8Apt2QA5Y6rdrKFn13QNFNeP3Hzmsf37Bwh/3cS7QjtAeGSK7wSqAU0sYQ==",
+            "dev": true
+        },
+        "@ungap/promise-all-settled": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
+            "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
             "dev": true
         },
         "@webassemblyjs/ast": {
@@ -256,6 +284,15 @@
             "integrity": "sha512-XNP0PqF1XD19ZlLKvB7cMmnZswW4C/03pRHgirB30uSJTaS3A3V1/P4sS3HPvFmjoriPCJQs+JDSbm4bL1TxGQ==",
             "dev": true
         },
+        "agent-base": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
+            "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
+            "dev": true,
+            "requires": {
+                "es6-promisify": "^5.0.0"
+            }
+        },
         "ajv": {
             "version": "6.12.6",
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -280,6 +317,12 @@
             "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
             "dev": true
         },
+        "ansi-regex": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+            "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+            "dev": true
+        },
         "ansi-styles": {
             "version": "3.2.1",
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
@@ -287,6 +330,16 @@
             "dev": true,
             "requires": {
                 "color-convert": "^1.9.0"
+            }
+        },
+        "anymatch": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
+            "integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
+            "dev": true,
+            "requires": {
+                "normalize-path": "^3.0.0",
+                "picomatch": "^2.0.4"
             }
         },
         "argparse": {
@@ -328,6 +381,12 @@
             "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
             "dev": true
         },
+        "binary-extensions": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.1.0.tgz",
+            "integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ==",
+            "dev": true
+        },
         "boolbase": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
@@ -353,6 +412,12 @@
                 "fill-range": "^7.0.1"
             }
         },
+        "browser-stdout": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+            "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+            "dev": true
+        },
         "browserslist": {
             "version": "4.14.7",
             "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.14.7.tgz",
@@ -376,6 +441,12 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
             "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+            "dev": true
+        },
+        "camelcase": {
+            "version": "5.3.1",
+            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+            "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
             "dev": true
         },
         "caniuse-lite": {
@@ -409,6 +480,22 @@
                 "parse5": "^3.0.1"
             }
         },
+        "chokidar": {
+            "version": "3.4.3",
+            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.3.tgz",
+            "integrity": "sha512-DtM3g7juCXQxFVSNPNByEC2+NImtBuxQQvWlHunpJIS5Ocr0lG306cC7FCi7cEA0fzmybPUIl4txBIobk1gGOQ==",
+            "dev": true,
+            "requires": {
+                "anymatch": "~3.1.1",
+                "braces": "~3.0.2",
+                "fsevents": "~2.1.2",
+                "glob-parent": "~5.1.0",
+                "is-binary-path": "~2.1.0",
+                "is-glob": "~4.0.1",
+                "normalize-path": "~3.0.0",
+                "readdirp": "~3.5.0"
+            }
+        },
         "chrome-trace-event": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.2.tgz",
@@ -416,6 +503,45 @@
             "dev": true,
             "requires": {
                 "tslib": "^1.9.0"
+            }
+        },
+        "cliui": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+            "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+            "dev": true,
+            "requires": {
+                "string-width": "^3.1.0",
+                "strip-ansi": "^5.2.0",
+                "wrap-ansi": "^5.1.0"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+                    "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+                    "dev": true
+                },
+                "string-width": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+                    "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+                    "dev": true,
+                    "requires": {
+                        "emoji-regex": "^7.0.1",
+                        "is-fullwidth-code-point": "^2.0.0",
+                        "strip-ansi": "^5.1.0"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+                    "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^4.1.0"
+                    }
+                }
             }
         },
         "color-convert": {
@@ -498,6 +624,21 @@
             "integrity": "sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg==",
             "dev": true
         },
+        "debug": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+            "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
+            "dev": true,
+            "requires": {
+                "ms": "2.1.2"
+            }
+        },
+        "decamelize": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+            "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+            "dev": true
+        },
         "deep-extend": {
             "version": "0.6.0",
             "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
@@ -508,6 +649,12 @@
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/denodeify/-/denodeify-1.2.1.tgz",
             "integrity": "sha1-OjYof1A05pnnV3kBBSwubJQlFjE=",
+            "dev": true
+        },
+        "diff": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+            "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
             "dev": true
         },
         "dom-serializer": {
@@ -549,6 +696,12 @@
             "version": "1.3.610",
             "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.610.tgz",
             "integrity": "sha512-eFDC+yVQpEhtlapk4CYDPfV9ajF9cEof5TBcO49L1ETO+aYogrKWDmYpZyxBScMNe8Bo/gJamH4amQ4yyvXg4g==",
+            "dev": true
+        },
+        "emoji-regex": {
+            "version": "7.0.3",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+            "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
             "dev": true
         },
         "emojis-list": {
@@ -607,6 +760,21 @@
                 "prr": "~1.0.1"
             }
         },
+        "es6-promise": {
+            "version": "4.2.8",
+            "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+            "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
+            "dev": true
+        },
+        "es6-promisify": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+            "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
+            "dev": true,
+            "requires": {
+                "es6-promise": "^4.0.3"
+            }
+        },
         "escalade": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
@@ -628,6 +796,12 @@
                 "esrecurse": "^4.3.0",
                 "estraverse": "^4.1.1"
             }
+        },
+        "esprima": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+            "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+            "dev": true
         },
         "esrecurse": {
             "version": "4.3.0",
@@ -715,16 +889,35 @@
                 "path-exists": "^4.0.0"
             }
         },
+        "flat": {
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
+            "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
+            "dev": true
+        },
         "fs.realpath": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
             "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
             "dev": true
         },
+        "fsevents": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
+            "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
+            "dev": true,
+            "optional": true
+        },
         "function-bind": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
             "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+            "dev": true
+        },
+        "get-caller-file": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+            "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
             "dev": true
         },
         "get-stream": {
@@ -750,6 +943,15 @@
                 "path-is-absolute": "^1.0.0"
             }
         },
+        "glob-parent": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
+            "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+            "dev": true,
+            "requires": {
+                "is-glob": "^4.0.1"
+            }
+        },
         "glob-to-regexp": {
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
@@ -760,6 +962,12 @@
             "version": "4.2.4",
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
             "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
+            "dev": true
+        },
+        "growl": {
+            "version": "1.10.5",
+            "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
+            "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
             "dev": true
         },
         "has": {
@@ -777,6 +985,12 @@
             "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
             "dev": true
         },
+        "he": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+            "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+            "dev": true
+        },
         "htmlparser2": {
             "version": "3.10.1",
             "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.1.tgz",
@@ -789,6 +1003,54 @@
                 "entities": "^1.1.1",
                 "inherits": "^2.0.1",
                 "readable-stream": "^3.1.1"
+            }
+        },
+        "http-proxy-agent": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz",
+            "integrity": "sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==",
+            "dev": true,
+            "requires": {
+                "agent-base": "4",
+                "debug": "3.1.0"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+                    "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+                    "dev": true
+                }
+            }
+        },
+        "https-proxy-agent": {
+            "version": "2.2.4",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz",
+            "integrity": "sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==",
+            "dev": true,
+            "requires": {
+                "agent-base": "^4.3.0",
+                "debug": "^3.1.0"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "3.2.7",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+                    "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                }
             }
         },
         "human-signals": {
@@ -829,6 +1091,15 @@
             "integrity": "sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==",
             "dev": true
         },
+        "is-binary-path": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+            "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+            "dev": true,
+            "requires": {
+                "binary-extensions": "^2.0.0"
+            }
+        },
         "is-core-module": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.2.0.tgz",
@@ -838,10 +1109,37 @@
                 "has": "^1.0.3"
             }
         },
+        "is-extglob": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+            "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+            "dev": true
+        },
+        "is-fullwidth-code-point": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+            "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+            "dev": true
+        },
+        "is-glob": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+            "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+            "dev": true,
+            "requires": {
+                "is-extglob": "^2.1.1"
+            }
+        },
         "is-number": {
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
             "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+            "dev": true
+        },
+        "is-plain-obj": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+            "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
             "dev": true
         },
         "is-stream": {
@@ -888,6 +1186,16 @@
                         "has-flag": "^4.0.0"
                     }
                 }
+            }
+        },
+        "js-yaml": {
+            "version": "3.14.0",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.0.tgz",
+            "integrity": "sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==",
+            "dev": true,
+            "requires": {
+                "argparse": "^1.0.7",
+                "esprima": "^4.0.0"
             }
         },
         "json-parse-better-errors": {
@@ -957,6 +1265,66 @@
             "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
             "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
             "dev": true
+        },
+        "log-symbols": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.0.0.tgz",
+            "integrity": "sha512-FN8JBzLx6CzeMrB0tg6pqlGU1wCrXW+ZXGH481kfsBqer0hToTIiHdjH4Mq8xJUbvATujKCvaREGWpGUionraA==",
+            "dev": true,
+            "requires": {
+                "chalk": "^4.0.0"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "4.3.0",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+                    "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "chalk": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+                    "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+                    "dev": true
+                },
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+                    "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                }
+            }
         },
         "markdown-it": {
             "version": "10.0.0",
@@ -1085,10 +1453,115 @@
             "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
             "dev": true
         },
+        "mocha": {
+            "version": "8.2.1",
+            "resolved": "https://registry.npmjs.org/mocha/-/mocha-8.2.1.tgz",
+            "integrity": "sha512-cuLBVfyFfFqbNR0uUKbDGXKGk+UDFe6aR4os78XIrMQpZl/nv7JYHcvP5MFIAb374b2zFXsdgEGwmzMtP0Xg8w==",
+            "dev": true,
+            "requires": {
+                "@ungap/promise-all-settled": "1.1.2",
+                "ansi-colors": "4.1.1",
+                "browser-stdout": "1.3.1",
+                "chokidar": "3.4.3",
+                "debug": "4.2.0",
+                "diff": "4.0.2",
+                "escape-string-regexp": "4.0.0",
+                "find-up": "5.0.0",
+                "glob": "7.1.6",
+                "growl": "1.10.5",
+                "he": "1.2.0",
+                "js-yaml": "3.14.0",
+                "log-symbols": "4.0.0",
+                "minimatch": "3.0.4",
+                "ms": "2.1.2",
+                "nanoid": "3.1.12",
+                "serialize-javascript": "5.0.1",
+                "strip-json-comments": "3.1.1",
+                "supports-color": "7.2.0",
+                "which": "2.0.2",
+                "wide-align": "1.1.3",
+                "workerpool": "6.0.2",
+                "yargs": "13.3.2",
+                "yargs-parser": "13.1.2",
+                "yargs-unparser": "2.0.0"
+            },
+            "dependencies": {
+                "escape-string-regexp": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+                    "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+                    "dev": true
+                },
+                "find-up": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+                    "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+                    "dev": true,
+                    "requires": {
+                        "locate-path": "^6.0.0",
+                        "path-exists": "^4.0.0"
+                    }
+                },
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+                    "dev": true
+                },
+                "locate-path": {
+                    "version": "6.0.0",
+                    "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+                    "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+                    "dev": true,
+                    "requires": {
+                        "p-locate": "^5.0.0"
+                    }
+                },
+                "p-limit": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+                    "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+                    "dev": true,
+                    "requires": {
+                        "yocto-queue": "^0.1.0"
+                    }
+                },
+                "p-locate": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+                    "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+                    "dev": true,
+                    "requires": {
+                        "p-limit": "^3.0.2"
+                    }
+                },
+                "supports-color": {
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+                    "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                }
+            }
+        },
+        "ms": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+            "dev": true
+        },
         "mute-stream": {
             "version": "0.0.8",
             "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
             "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
+            "dev": true
+        },
+        "nanoid": {
+            "version": "3.1.12",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.12.tgz",
+            "integrity": "sha512-1qstj9z5+x491jfiC4Nelk+f8XBad7LN20PmyWINJEMRSf3wcAjAWysw1qaA8z6NSKe2sjq1hRSDpBH5paCb6A==",
             "dev": true
         },
         "neo-async": {
@@ -1101,6 +1574,12 @@
             "version": "1.1.67",
             "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.67.tgz",
             "integrity": "sha512-V5QF9noGFl3EymEwUYzO+3NTDpGfQB4ve6Qfnzf3UNydMhjQRVPR1DZTuvWiLzaFJYw2fmDwAfnRNEVb64hSIg==",
+            "dev": true
+        },
+        "normalize-path": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+            "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
             "dev": true
         },
         "npm-run-path": {
@@ -1319,6 +1798,15 @@
                 "util-deprecate": "^1.0.1"
             }
         },
+        "readdirp": {
+            "version": "3.5.0",
+            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.5.0.tgz",
+            "integrity": "sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==",
+            "dev": true,
+            "requires": {
+                "picomatch": "^2.2.1"
+            }
+        },
         "rechoir": {
             "version": "0.7.0",
             "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.7.0.tgz",
@@ -1332,6 +1820,18 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/reduce-flatten/-/reduce-flatten-2.0.0.tgz",
             "integrity": "sha512-EJ4UNY/U1t2P/2k6oqotuX2Cc3T6nxJwsM0N0asT7dhrtH1ltUxDn4NalSYmPE2rCkVpcf/X6R0wDwcFpzhd4w==",
+            "dev": true
+        },
+        "require-directory": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+            "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+            "dev": true
+        },
+        "require-main-filename": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+            "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
             "dev": true
         },
         "resolve": {
@@ -1358,6 +1858,15 @@
             "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
             "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
             "dev": true
+        },
+        "rimraf": {
+            "version": "2.7.1",
+            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+            "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+            "dev": true,
+            "requires": {
+                "glob": "^7.1.3"
+            }
         },
         "safe-buffer": {
             "version": "5.2.1",
@@ -1389,6 +1898,12 @@
             "requires": {
                 "randombytes": "^2.1.0"
             }
+        },
+        "set-blocking": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+            "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+            "dev": true
         },
         "shebang-command": {
             "version": "2.0.0",
@@ -1439,6 +1954,16 @@
             "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
             "dev": true
         },
+        "string-width": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+            "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+            "dev": true,
+            "requires": {
+                "is-fullwidth-code-point": "^2.0.0",
+                "strip-ansi": "^4.0.0"
+            }
+        },
         "string_decoder": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -1448,10 +1973,25 @@
                 "safe-buffer": "~5.2.0"
             }
         },
+        "strip-ansi": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+            "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+            "dev": true,
+            "requires": {
+                "ansi-regex": "^3.0.0"
+            }
+        },
         "strip-final-newline": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
             "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+            "dev": true
+        },
+        "strip-json-comments": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+            "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
             "dev": true
         },
         "supports-color": {
@@ -1714,6 +2254,17 @@
             "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.15.1.tgz",
             "integrity": "sha512-+a9MPUQrNGRrGU630OGbYVQ+11iOIovjCkqxajPa9w57Sd5ruK8WQNsslzpa0x/QJqC8kRc2DUxWjIFwoNm4ZQ=="
         },
+        "vscode-test": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/vscode-test/-/vscode-test-1.4.1.tgz",
+            "integrity": "sha512-Ls7+JyC06cUCuomlTYk4aNJI00Rri09hgtkNl3zfQ1bj6meXglpSPpuzJ/RPNetlUHFMm4eGs0Xr/H5pFPVwfQ==",
+            "dev": true,
+            "requires": {
+                "http-proxy-agent": "^2.1.0",
+                "https-proxy-agent": "^2.2.4",
+                "rimraf": "^2.6.3"
+            }
+        },
         "watchpack": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.0.1.tgz",
@@ -1823,6 +2374,21 @@
                 "isexe": "^2.0.0"
             }
         },
+        "which-module": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+            "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+            "dev": true
+        },
+        "wide-align": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+            "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+            "dev": true,
+            "requires": {
+                "string-width": "^1.0.2 || 2"
+            }
+        },
         "wordwrapjs": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-4.0.0.tgz",
@@ -1833,11 +2399,178 @@
                 "typical": "^5.0.0"
             }
         },
+        "workerpool": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.0.2.tgz",
+            "integrity": "sha512-DSNyvOpFKrNusaaUwk+ej6cBj1bmhLcBfj80elGk+ZIo5JSkq+unB1dLKEOcNfJDZgjGICfhQ0Q5TbP0PvF4+Q==",
+            "dev": true
+        },
+        "wrap-ansi": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+            "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+            "dev": true,
+            "requires": {
+                "ansi-styles": "^3.2.0",
+                "string-width": "^3.0.0",
+                "strip-ansi": "^5.0.0"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+                    "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+                    "dev": true
+                },
+                "string-width": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+                    "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+                    "dev": true,
+                    "requires": {
+                        "emoji-regex": "^7.0.1",
+                        "is-fullwidth-code-point": "^2.0.0",
+                        "strip-ansi": "^5.1.0"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+                    "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^4.1.0"
+                    }
+                }
+            }
+        },
         "wrappy": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
             "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
             "dev": true
+        },
+        "y18n": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.1.tgz",
+            "integrity": "sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ==",
+            "dev": true
+        },
+        "yargs": {
+            "version": "13.3.2",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
+            "integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
+            "dev": true,
+            "requires": {
+                "cliui": "^5.0.0",
+                "find-up": "^3.0.0",
+                "get-caller-file": "^2.0.1",
+                "require-directory": "^2.1.1",
+                "require-main-filename": "^2.0.0",
+                "set-blocking": "^2.0.0",
+                "string-width": "^3.0.0",
+                "which-module": "^2.0.0",
+                "y18n": "^4.0.0",
+                "yargs-parser": "^13.1.2"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+                    "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+                    "dev": true
+                },
+                "find-up": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+                    "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+                    "dev": true,
+                    "requires": {
+                        "locate-path": "^3.0.0"
+                    }
+                },
+                "locate-path": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+                    "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+                    "dev": true,
+                    "requires": {
+                        "p-locate": "^3.0.0",
+                        "path-exists": "^3.0.0"
+                    }
+                },
+                "p-locate": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+                    "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+                    "dev": true,
+                    "requires": {
+                        "p-limit": "^2.0.0"
+                    }
+                },
+                "path-exists": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+                    "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+                    "dev": true
+                },
+                "string-width": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+                    "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+                    "dev": true,
+                    "requires": {
+                        "emoji-regex": "^7.0.1",
+                        "is-fullwidth-code-point": "^2.0.0",
+                        "strip-ansi": "^5.1.0"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+                    "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^4.1.0"
+                    }
+                }
+            }
+        },
+        "yargs-parser": {
+            "version": "13.1.2",
+            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
+            "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
+            "dev": true,
+            "requires": {
+                "camelcase": "^5.0.0",
+                "decamelize": "^1.2.0"
+            }
+        },
+        "yargs-unparser": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
+            "integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
+            "dev": true,
+            "requires": {
+                "camelcase": "^6.0.0",
+                "decamelize": "^4.0.0",
+                "flat": "^5.0.2",
+                "is-plain-obj": "^2.1.0"
+            },
+            "dependencies": {
+                "camelcase": {
+                    "version": "6.2.0",
+                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.2.0.tgz",
+                    "integrity": "sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==",
+                    "dev": true
+                },
+                "decamelize": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
+                    "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
+                    "dev": true
+                }
+            }
         },
         "yauzl": {
             "version": "2.10.0",

--- a/code/package.json
+++ b/code/package.json
@@ -12,6 +12,8 @@
         "compile": "webpack --mode production",
         "webpack": "webpack --mode development",
         "webpack-dev": "webpack --mode development --watch",
+        "test": "tsc -p ./ && node ./dist/test/runTests.js",
+        "clean": "rm -r dist",
         "deploy": "vsce publish",
         "package": "vsce package",
         "vscode:prepublish": "webpack --mode production"
@@ -22,11 +24,15 @@
         "vscode-languageclient": "^6.1.3"
     },
     "devDependencies": {
+        "@types/glob": "^7.1.3",
+        "@types/mocha": "^8.2.0",
         "@types/node": "^14.14.7",
         "@types/vscode": "^1.43.0",
+        "mocha": "^8.2.1",
         "ts-loader": "^8.0.11",
         "typescript": "^4.0.5",
         "vsce": "^1.81.1",
+        "vscode-test": "^1.4.1",
         "webpack": "^5.8.0",
         "webpack-cli": "^4.2.0"
     },

--- a/code/package.json
+++ b/code/package.json
@@ -86,6 +86,18 @@
                 }
             }
         ],
+        "keybindings": [
+            {
+                "command": "esbonio.insert.inlineLink",
+                "key": "alt+l",
+                "when": "editorTextFocus"
+            },
+            {
+                "command": "esbonio.insert.link",
+                "key": "alt+shift+l",
+                "when": "editorTextFocus"
+            }
+        ],
         "languages": [
             {
                 "id": "rst",

--- a/code/package.json
+++ b/code/package.json
@@ -10,9 +10,10 @@
     "version": "0.2.1",
     "scripts": {
         "compile": "webpack --mode production",
+        "compile-test": "npm run clean && tsc -p ./",
         "webpack": "webpack --mode development",
         "webpack-dev": "webpack --mode development --watch",
-        "test": "tsc -p ./ && node ./dist/test/runTests.js",
+        "test": "npm run compile-test && node ./dist/test/runTests.js",
         "clean": "rm -r dist",
         "deploy": "vsce publish",
         "package": "vsce package",

--- a/code/package.json
+++ b/code/package.json
@@ -39,6 +39,16 @@
     "contributes": {
         "commands": [
             {
+                "command": "esbonio.insert.link",
+                "title": "Insert Link",
+                "category": "Esbonio"
+            },
+            {
+                "command": "esbonio.insert.inlineLink",
+                "title": "Insert Inline Link",
+                "category": "Esbonio"
+            },
+            {
                 "command": "esbonio.languageServer.install",
                 "title": "Install Language Server",
                 "category": "Esbonio"

--- a/code/src/commands.ts
+++ b/code/src/commands.ts
@@ -176,6 +176,10 @@ export class EditorCommands {
   async insertInlineLink(editor: vscode.TextEditor) {
 
     let link = await this.getLinkInfo(editor)
+    if (!link.url || !link.label) {
+      return
+    }
+
     let selection = editor.selection
 
     let inlineLink = `\`${link.label} <${link.url}>\`_`

--- a/code/src/test/runTests.ts
+++ b/code/src/test/runTests.ts
@@ -1,0 +1,17 @@
+import * as path from "path";
+import { runTests } from "vscode-test";
+
+async function main() {
+  try {
+    const extensionDevelopmentPath = path.resolve(__dirname, "../../../")
+    const extensionTestsPath = path.resolve(__dirname, "./suite/index")
+
+    await runTests({ extensionDevelopmentPath, extensionTestsPath })
+  } catch (err) {
+    console.error(err)
+    console.error("Failed to run the tests")
+    process.exit(1)
+  }
+}
+
+main()

--- a/code/src/test/suite/commands.test.ts
+++ b/code/src/test/suite/commands.test.ts
@@ -1,0 +1,41 @@
+import * as assert from "assert";
+import { resolve } from "path";
+import * as vscode from "vscode";
+import { EditorCommands, UserInput } from "../../commands";
+
+/**
+ * Class that mocks out the user input part of the vscode API.
+ */
+class MockInput implements UserInput {
+
+  constructor(public responses: Map<string, string>) { }
+
+  inputBox(label: string, placeholder: string): Thenable<string> {
+    if (this.responses.has(label)) {
+      return Promise.resolve(this.responses.get(label))
+    }
+
+    return Promise.resolve(undefined)
+  }
+}
+
+suite('Insert Inline Link', () => {
+
+  test('Without selected text', async () => {
+    let responses = new Map()
+    responses.set("Link Text", "here")
+    responses.set("Link URL", "https://github.com")
+
+    let editorCommands = new EditorCommands(new MockInput(responses))
+
+    const document = await vscode.workspace.openTextDocument({ language: 'rst' })
+    const editor = await vscode.window.showTextDocument(document)
+    await editor.edit(edit => {
+      edit.insert(new vscode.Position(0, 0), "You can find more info ")
+    })
+
+    await editorCommands.insertInlineLink(editor)
+    let doc = editor.document.getText()
+    assert.strictEqual(doc, "You can find more info `here <https://github.com>`_")
+  })
+})

--- a/code/src/test/suite/commands.test.ts
+++ b/code/src/test/suite/commands.test.ts
@@ -1,5 +1,6 @@
 import * as assert from "assert";
 import * as vscode from "vscode";
+import { after, before, beforeEach } from "mocha";
 import { EditorCommands, UserInput } from "../../commands";
 
 /**
@@ -31,10 +32,147 @@ async function editorWithText(text: string): Promise<vscode.TextEditor> {
   return editor
 }
 
-suite('Insert Inline Link', () => {
+suite('EditorCommands', () => {
 
-  test('Without selection', async () => {
-    let editor = await editorWithText("You can find more info ")
+  let editor: vscode.TextEditor
+
+  before(async () => {
+    const document = await vscode.workspace.openTextDocument({ language: 'rst' })
+    editor = await vscode.window.showTextDocument(document)
+  })
+
+  beforeEach(async () => {
+    await editor.edit(edit => {
+      edit.delete(new vscode.Range(new vscode.Position(0, 0), new vscode.Position(editor.document.lineCount, 0)))
+    })
+  })
+
+  after(async () => {
+    await vscode.commands.executeCommand('workbench.action.closeAllEditors')
+  })
+
+  test('insertLink - Without selection', async () => {
+    await editor.edit(edit => {
+      edit.insert(new vscode.Position(0, 0), "You can find more info ")
+    })
+
+    let responses = new Map()
+    responses.set("Link Text", "here")
+    responses.set("Link URL", "https://github.com")
+
+    let editorCommands = new EditorCommands(new MockInput(responses))
+    await editorCommands.insertLink(editor)
+
+    let doc = editor.document.getText()
+    assert.strictEqual(doc, "You can find more info `here`_\n\n.. _here: https://github.com\n")
+  })
+
+  test('insertLink - Without selection, cancelled url', async () => {
+    await editor.edit(edit => {
+      edit.insert(new vscode.Position(0, 0), "You can find more info ")
+    })
+
+    let responses = new Map()
+    let editorCommands = new EditorCommands(new MockInput(responses))
+    await editorCommands.insertLink(editor)
+
+    let doc = editor.document.getText()
+    assert.strictEqual(doc, "You can find more info ")
+  })
+
+  test('insertLink - Without selection, cancelled label', async () => {
+    await editor.edit(edit => {
+      edit.insert(new vscode.Position(0, 0), "You can find more info ")
+    })
+
+    let responses = new Map()
+    responses.set("Link URL", "https://github.com")
+
+    let editorCommands = new EditorCommands(new MockInput(responses))
+    await editorCommands.insertLink(editor)
+
+    let doc = editor.document.getText()
+    assert.strictEqual(doc, "You can find more info ")
+  })
+
+  test('insertLink - With newline', async () => {
+    await editor.edit(edit => {
+      edit.insert(new vscode.Position(0, 0), "You can find more info here\n")
+    })
+
+    // Select the text we want the command to use as the label.
+    editor.selection = new vscode.Selection(new vscode.Position(0, 23), new vscode.Position(0, 28))
+
+    let responses = new Map()
+    responses.set("Link URL", "https://github.com")
+
+    let editorCommands = new EditorCommands(new MockInput(responses))
+    await editorCommands.insertLink(editor)
+
+    let doc = editor.document.getText()
+    assert.strictEqual(doc, "You can find more info `here`_\n\n.. _here: https://github.com\n")
+  })
+
+  test('insertLink - With selection', async () => {
+    await editor.edit(edit => {
+      edit.insert(new vscode.Position(0, 0), "You can find more info here")
+    })
+
+    // Select the text we want the command to use as the label.
+    editor.selection = new vscode.Selection(new vscode.Position(0, 23), new vscode.Position(0, 28))
+
+    let responses = new Map()
+    responses.set("Link URL", "https://github.com")
+
+    let editorCommands = new EditorCommands(new MockInput(responses))
+    await editorCommands.insertLink(editor)
+
+    let doc = editor.document.getText()
+    assert.strictEqual(doc, "You can find more info `here`_\n\n.. _here: https://github.com\n")
+  })
+
+  test('insertLink - With selection, cancelled url', async () => {
+    await editor.edit(edit => {
+      edit.insert(new vscode.Position(0, 0), "You can find more info here")
+    })
+
+    // Select the text we want the command to use as the label.
+    editor.selection = new vscode.Selection(new vscode.Position(0, 23), new vscode.Position(0, 28))
+
+    let responses = new Map()
+    let editorCommands = new EditorCommands(new MockInput(responses))
+    await editorCommands.insertLink(editor)
+
+    let doc = editor.document.getText()
+    assert.strictEqual(doc, "You can find more info here")
+  })
+
+  test('insertLink - Multiple', async () => {
+    await editor.edit(edit => {
+      edit.insert(new vscode.Position(0, 0), "You can find more info here or upstream\n")
+    })
+
+    // Select the text we want the command to use as the label.
+    editor.selection = new vscode.Selection(new vscode.Position(0, 23), new vscode.Position(0, 27))
+
+    let responses = new Map()
+    responses.set("Link URL", "https://github.com")
+
+    let editorCommands = new EditorCommands(new MockInput(responses))
+    await editorCommands.insertLink(editor)
+
+    responses.set("Link URL", "https://pypi.org")
+    editor.selection = new vscode.Selection(new vscode.Position(0, 34), new vscode.Position(0, 43))
+    await editorCommands.insertLink(editor)
+
+    let doc = editor.document.getText()
+    assert.strictEqual(doc, "You can find more info `here`_ or `upstream`_\n\n.. _here: https://github.com\n.. _upstream: https://pypi.org\n")
+  })
+
+  test('insertInlineLink - Without selection', async () => {
+    await editor.edit(edit => {
+      edit.insert(new vscode.Position(0, 0), "You can find more info ")
+    })
 
     let responses = new Map()
     responses.set("Link Text", "here")
@@ -47,10 +185,12 @@ suite('Insert Inline Link', () => {
     assert.strictEqual(doc, "You can find more info `here <https://github.com>`_")
   })
 
-  test('Without selection, cancelled url', async () => {
-    let editor = await editorWithText("You can find more info ")
-    let responses = new Map()
+  test('insertInlineLink - Without selection, cancelled url', async () => {
+    await editor.edit(edit => {
+      edit.insert(new vscode.Position(0, 0), "You can find more info ")
+    })
 
+    let responses = new Map()
     let editorCommands = new EditorCommands(new MockInput(responses))
     await editorCommands.insertInlineLink(editor)
 
@@ -58,8 +198,10 @@ suite('Insert Inline Link', () => {
     assert.strictEqual(doc, "You can find more info ")
   })
 
-  test('Without selection, cancelled label', async () => {
-    let editor = await editorWithText("You can find more info ")
+  test('insertInlineLink - Without selection, cancelled label', async () => {
+    await editor.edit(edit => {
+      edit.insert(new vscode.Position(0, 0), "You can find more info ")
+    })
 
     let responses = new Map()
     responses.set("Link URL", "https://github.com")
@@ -71,8 +213,10 @@ suite('Insert Inline Link', () => {
     assert.strictEqual(doc, "You can find more info ")
   })
 
-  test('With selection', async () => {
-    let editor = await editorWithText("You can find more info here")
+  test('insertInlineLink - With selection', async () => {
+    await editor.edit(edit => {
+      edit.insert(new vscode.Position(0, 0), "You can find more info here")
+    })
 
     // Select the text we want the command to use as the label.
     editor.selection = new vscode.Selection(new vscode.Position(0, 23), new vscode.Position(0, 28))
@@ -87,8 +231,10 @@ suite('Insert Inline Link', () => {
     assert.strictEqual(doc, "You can find more info `here <https://github.com>`_")
   })
 
-  test('With selection, cancelled url', async () => {
-    let editor = await editorWithText("You can find more info here")
+  test('insertInlineLink - With selection, cancelled url', async () => {
+    await editor.edit(edit => {
+      edit.insert(new vscode.Position(0, 0), "You can find more info here")
+    })
 
     // Select the text we want the command to use as the label.
     editor.selection = new vscode.Selection(new vscode.Position(0, 23), new vscode.Position(0, 28))

--- a/code/src/test/suite/commands.test.ts
+++ b/code/src/test/suite/commands.test.ts
@@ -1,5 +1,4 @@
 import * as assert from "assert";
-import { resolve } from "path";
 import * as vscode from "vscode";
 import { EditorCommands, UserInput } from "../../commands";
 
@@ -19,23 +18,87 @@ class MockInput implements UserInput {
   }
 }
 
+/**
+ * Open a new document with the given text.
+ */
+async function editorWithText(text: string): Promise<vscode.TextEditor> {
+  const document = await vscode.workspace.openTextDocument({ language: 'rst' })
+  const editor = await vscode.window.showTextDocument(document)
+  await editor.edit(edit => {
+    edit.insert(new vscode.Position(0, 0), text)
+  })
+
+  return editor
+}
+
 suite('Insert Inline Link', () => {
 
-  test('Without selected text', async () => {
+  test('Without selection', async () => {
+    let editor = await editorWithText("You can find more info ")
+
     let responses = new Map()
     responses.set("Link Text", "here")
     responses.set("Link URL", "https://github.com")
 
     let editorCommands = new EditorCommands(new MockInput(responses))
-
-    const document = await vscode.workspace.openTextDocument({ language: 'rst' })
-    const editor = await vscode.window.showTextDocument(document)
-    await editor.edit(edit => {
-      edit.insert(new vscode.Position(0, 0), "You can find more info ")
-    })
-
     await editorCommands.insertInlineLink(editor)
+
     let doc = editor.document.getText()
     assert.strictEqual(doc, "You can find more info `here <https://github.com>`_")
+  })
+
+  test('Without selection, cancelled url', async () => {
+    let editor = await editorWithText("You can find more info ")
+    let responses = new Map()
+
+    let editorCommands = new EditorCommands(new MockInput(responses))
+    await editorCommands.insertInlineLink(editor)
+
+    let doc = editor.document.getText()
+    assert.strictEqual(doc, "You can find more info ")
+  })
+
+  test('Without selection, cancelled label', async () => {
+    let editor = await editorWithText("You can find more info ")
+
+    let responses = new Map()
+    responses.set("Link URL", "https://github.com")
+
+    let editorCommands = new EditorCommands(new MockInput(responses))
+    await editorCommands.insertInlineLink(editor)
+
+    let doc = editor.document.getText()
+    assert.strictEqual(doc, "You can find more info ")
+  })
+
+  test('With selection', async () => {
+    let editor = await editorWithText("You can find more info here")
+
+    // Select the text we want the command to use as the label.
+    editor.selection = new vscode.Selection(new vscode.Position(0, 23), new vscode.Position(0, 28))
+
+    let responses = new Map()
+    responses.set("Link URL", "https://github.com")
+
+    let editorCommands = new EditorCommands(new MockInput(responses))
+    await editorCommands.insertInlineLink(editor)
+
+    let doc = editor.document.getText()
+    assert.strictEqual(doc, "You can find more info `here <https://github.com>`_")
+  })
+
+  test('With selection, cancelled url', async () => {
+    let editor = await editorWithText("You can find more info here")
+
+    // Select the text we want the command to use as the label.
+    editor.selection = new vscode.Selection(new vscode.Position(0, 23), new vscode.Position(0, 28))
+
+    let responses = new Map()
+
+    let editorCommands = new EditorCommands(new MockInput(responses))
+    await editorCommands.insertInlineLink(editor)
+
+    let doc = editor.document.getText()
+    assert.strictEqual(doc, "You can find more info here")
   })
 })

--- a/code/src/test/suite/index.ts
+++ b/code/src/test/suite/index.ts
@@ -1,0 +1,36 @@
+import * as path from "path";
+import * as Mocha from "mocha";
+import * as glob from "glob";
+
+
+export function run(): Promise<void> {
+
+  const mocha = new Mocha({
+    ui: 'tdd',
+    color: true
+  })
+
+  const testsRoot = path.resolve(__dirname, '..')
+
+  return new Promise((resolve, reject) => {
+    glob('**/**.test.js', { cwd: testsRoot }, (err, files) => {
+      if (err) {
+        return reject(err)
+      }
+
+      files.forEach(f => mocha.addFile(path.resolve(testsRoot, f)))
+
+      try {
+        mocha.run(failures => {
+          if (failures > 0) {
+            reject(new Error(`${failures} tests failed.`))
+          } else {
+            resolve()
+          }
+        })
+      } catch (err) {
+        reject(err)
+      }
+    })
+  })
+}


### PR DESCRIPTION
- Adds an `Insert Inline Link` command that can be invoked using either the command palette or the shortcut `Alt+L`, it will insert the link using the inline syntax ``` `label <https://url.com>`_ ```
- Adds an `Insert Link` command that can be invoked using either the command palette or the shortcut `Alt+Shift+L`, it will insert the link using the "named reference" syntax
  ```
  Find out more `here`_

  .. _here: https://url.com
  ```
- When invoked both commands will prompt the user for the url to be inserted, if there is text selected when invoked these commands will use it as the label. Otherwise they will prompt for that also.

Closes #37 