### PR TITLE
Start testing our TM Grammar rules

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,6 +95,7 @@ jobs:
         npm install
 
         mkdir dist
+        npm run test-grammar
         xvfb-run -a npm test
       name: Test Extension
 

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -45,6 +45,40 @@
             "options": {
                 "cwd": "${workspaceRoot}/docs"
             }
+        },
+        {
+            "label": "Grammar Tests",
+            "type": "shell",
+            "command": "npx vscode-tmgrammar-test -c -s source.rst -g rst.tmLanguage.json -t \"**/*.rst\"",
+            "group": "test",
+            "presentation": {
+                "echo": true,
+                "reveal": "always",
+                "focus": false,
+                "panel": "shared",
+                "showReuseMessage": false,
+                "clear": false
+            },
+            "options": {
+                "cwd": "${workspaceRoot}/code/syntaxes"
+            },
+            "problemMatcher": {
+                "fileLocation": [
+                    "relative",
+                    "${workspaceRoot}/code/syntaxes"
+                ],
+                "pattern": [
+                    {
+                        "regexp": "^(ERROR)\\s([^:]+):(\\d+):(\\d+):(\\d+)\\s(.*)$",
+                        "severity": 1,
+                        "file": 2,
+                        "line": 3,
+                        "column": 4,
+                        "endColumn": 5,
+                        "message": 6
+                    }
+                ]
+            }
         }
     ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -49,7 +49,7 @@
         {
             "label": "Grammar Tests",
             "type": "shell",
-            "command": "npx vscode-tmgrammar-test -c -s source.rst -g rst.tmLanguage.json -t \"**/*.rst\"",
+            "command": "npx vscode-tmgrammar-test -c -s source.rst -g rst.tmLanguage.json -g tests/python.tmLanguage.json -t \"**/*.rst\"",
             "group": "test",
             "presentation": {
                 "echo": true,

--- a/code/changes/42.fix.rst
+++ b/code/changes/42.fix.rst
@@ -1,0 +1,2 @@
+Support syntax highligting for more header styles. Support highligting python code
+under directives from Sphinx's ``sphinx.ext.doctest`` extension

--- a/code/package-lock.json
+++ b/code/package-lock.json
@@ -1558,6 +1558,12 @@
             "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
             "dev": true
         },
+        "nan": {
+            "version": "2.14.2",
+            "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
+            "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
+            "dev": true
+        },
         "nanoid": {
             "version": "3.1.12",
             "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.12.tgz",
@@ -1616,6 +1622,15 @@
             "dev": true,
             "requires": {
                 "mimic-fn": "^2.1.0"
+            }
+        },
+        "oniguruma": {
+            "version": "7.2.1",
+            "resolved": "https://registry.npmjs.org/oniguruma/-/oniguruma-7.2.1.tgz",
+            "integrity": "sha512-WPS/e1uzhswPtJSe+Zls/kAj27+lEqZjCmRSjnYk/Z4L2Mu+lJC2JWtkZhPJe4kZeTQfz7ClcLyXlI4J68MG2w==",
+            "dev": true,
+            "requires": {
+                "nan": "^2.14.0"
             }
         },
         "os": {
@@ -2263,6 +2278,36 @@
                 "http-proxy-agent": "^2.1.0",
                 "https-proxy-agent": "^2.2.4",
                 "rimraf": "^2.6.3"
+            }
+        },
+        "vscode-textmate": {
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-4.4.0.tgz",
+            "integrity": "sha512-dFpm2eK0HwEjeFSD1DDh3j0q47bDSVuZt20RiJWxGqjtm73Wu2jip3C2KaZI3dQx/fSeeXCr/uEN4LNaNj7Ytw==",
+            "dev": true,
+            "requires": {
+                "oniguruma": "^7.2.0"
+            }
+        },
+        "vscode-tmgrammar-test": {
+            "version": "0.0.10",
+            "resolved": "https://registry.npmjs.org/vscode-tmgrammar-test/-/vscode-tmgrammar-test-0.0.10.tgz",
+            "integrity": "sha512-sYNjo+BXWzDfYZ8uY9tTWofMwKUyffUGmUcF0lJtRkuL1/tGn3trzlhTWZJDh6j5QowDkrZ3w0AE21qo4dzXUg==",
+            "dev": true,
+            "requires": {
+                "chalk": "^2.4.2",
+                "commander": "^2.20.3",
+                "diff": "^4.0.2",
+                "glob": "^7.1.6",
+                "vscode-textmate": "^4.1.1"
+            },
+            "dependencies": {
+                "commander": {
+                    "version": "2.20.3",
+                    "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+                    "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+                    "dev": true
+                }
             }
         },
         "watchpack": {

--- a/code/package.json
+++ b/code/package.json
@@ -14,6 +14,7 @@
         "webpack": "webpack --mode development",
         "webpack-dev": "webpack --mode development --watch",
         "test": "npm run compile-test && node ./dist/test/runTests.js",
+        "test-grammar": "vscode-tmgrammar-test -s source.rst -g syntaxes/rst.tmLanguage.json -t \"syntaxes/**/*.rst\"",
         "clean": "rm -r dist",
         "deploy": "vsce publish",
         "package": "vsce package",
@@ -34,6 +35,7 @@
         "typescript": "^4.0.5",
         "vsce": "^1.81.1",
         "vscode-test": "^1.4.1",
+        "vscode-tmgrammar-test": "0.0.10",
         "webpack": "^5.8.0",
         "webpack-cli": "^4.2.0"
     },

--- a/code/package.json
+++ b/code/package.json
@@ -14,7 +14,7 @@
         "webpack": "webpack --mode development",
         "webpack-dev": "webpack --mode development --watch",
         "test": "npm run compile-test && node ./dist/test/runTests.js",
-        "test-grammar": "vscode-tmgrammar-test -s source.rst -g syntaxes/rst.tmLanguage.json -t \"syntaxes/**/*.rst\"",
+        "test-grammar": "vscode-tmgrammar-test -s source.rst -g syntaxes/rst.tmLanguage.json -g syntaxes/tests/python.tmLanguage.json -t \"syntaxes/**/*.rst\"",
         "clean": "rm -r dist",
         "deploy": "vsce publish",
         "package": "vsce package",

--- a/code/src/test/suite/commands.test.ts
+++ b/code/src/test/suite/commands.test.ts
@@ -19,19 +19,6 @@ class MockInput implements UserInput {
   }
 }
 
-/**
- * Open a new document with the given text.
- */
-async function editorWithText(text: string): Promise<vscode.TextEditor> {
-  const document = await vscode.workspace.openTextDocument({ language: 'rst' })
-  const editor = await vscode.window.showTextDocument(document)
-  await editor.edit(edit => {
-    edit.insert(new vscode.Position(0, 0), text)
-  })
-
-  return editor
-}
-
 suite('EditorCommands', () => {
 
   let editor: vscode.TextEditor

--- a/code/syntaxes/rst.tmLanguage.json
+++ b/code/syntaxes/rst.tmLanguage.json
@@ -73,7 +73,25 @@
                     "include": "#python-code-block"
                 },
                 {
+                    "include": "#doctest-directive"
+                },
+                {
                     "include": "#generic-directive"
+                }
+            ]
+        },
+        "doctest-directive": {
+            "begin": "(\\s*)\\.\\.\\s+(doctest|testcode|testsetup|testcleanup)::",
+            "beginCaptures": {
+                "2": {
+                    "name": "entity.name.type"
+                }
+            },
+            "end": "^(?!\\1\\s+)(?!\\s*$)",
+            "name": "doctest.directive",
+            "patterns": [
+                {
+                    "include": "#python-code"
                 }
             ]
         },

--- a/code/syntaxes/rst.tmLanguage.json
+++ b/code/syntaxes/rst.tmLanguage.json
@@ -48,7 +48,7 @@
             ]
         },
         "section": {
-            "match": "^[=-]+",
+            "match": "^[=^'\"*+~-]+",
             "name": "keyword.control"
         },
         "comment": {

--- a/code/syntaxes/tests/code.rst
+++ b/code/syntaxes/tests/code.rst
@@ -1,0 +1,28 @@
+-- SYNTAX TEST "source.rst" "code"
+-- In this file we use '-' as the comment character as vscode-tmgrammar-test
+-- gets confused between comments and directives.
+
+.. code-block:: python
+
+   print("Hi there!")
+-- ^^^^^^^^^^^^^^^^^^ source.python
+
+.. doctest::
+
+   >>> print("Hi there")
+-- ^^^^^^^^^^^^^^^^^^^^^ source.python
+
+.. testcode::
+
+   print("Hi there")
+-- ^^^^^^^^^^^^^^^^^ source.python
+
+.. testsetup::
+
+   import matplotlib.pyplot as plt
+-- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.python
+
+.. testcleanup::
+
+   outputs.remove()
+-- ^^^^^^^^^^^^^^^^ source.python

--- a/code/syntaxes/tests/directives.rst
+++ b/code/syntaxes/tests/directives.rst
@@ -1,0 +1,10 @@
+-- SYNTAX TEST "source.rst" "directives"
+-- In this file we use '-' as the comment character as vscode-tmgrammar-test
+-- gets confused between comments and directives.
+
+.. include:: somefile.rst
+-- ^^^^^^^ entity.name.type
+
+.. toctree::
+   :glob:
+--  ^^^^ entity.name.type

--- a/code/syntaxes/tests/inline-elements.rst
+++ b/code/syntaxes/tests/inline-elements.rst
@@ -1,0 +1,25 @@
+.. SYNTAX TEST "source.rst" "inline elements"
+
+This line has **bold** text
+..            ^^^^^^^^ markup.bold
+
+This line has *italic* text
+..            ^^^^^^^^ markup.italic
+
+This line has ``inline`` code
+..            ^^^^^^^^^^ string
+
+This line contains a :ref:`reference_label`
+..                   ^^^^^^^^^^^^^^^^^^^^^^ meta.role.rst
+..                    ^^^ keyword.letter
+..                         ^^^^^^^^^^^^^^^ string
+
+This line contains a :ref:`reference <reference_label>`
+..                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.role.rst
+..                    ^^^ keyword.letter
+..                                   ^^^^^^^^^^^^^^^^^ entity.name.function
+
+This line has an `inline <https://github.com>`_ link
+..               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.link.rst
+..                ^^^^^^ string
+..                       ^^^^^^^^^^^^^^^^^^^^ entity.name.function

--- a/code/syntaxes/tests/python.tmLanguage.json
+++ b/code/syntaxes/tests/python.tmLanguage.json
@@ -1,0 +1,14 @@
+{
+    "scopeName": "source.python",
+    "patterns": [
+        {
+            "include": "#code"
+        }
+    ],
+    "repository": {
+        "code": {
+            "match": ".*",
+            "name": "invalid"
+        }
+    }
+}

--- a/code/syntaxes/tests/sections.rst
+++ b/code/syntaxes/tests/sections.rst
@@ -1,0 +1,33 @@
+.. SYNTAX TEST "source.rst" "sections"
+
+Section
+=======
+.. <------- keyword.control
+
+Section
+-------
+.. <------- keyword.control
+
+Section
+^^^^^^^
+.. <------- keyword.control
+
+Section
+'''''''
+.. <------- keyword.control
+
+Section
+"""""""
+.. <------- keyword.control
+
+Section
+~~~~~~~
+.. <------- keyword.control
+
+Section
+*******
+.. <------- keyword.control
+
+Section
++++++++
+.. <------- keyword.control


### PR DESCRIPTION
- Start testing our grammar definition using `vscode-tmgrammar-test`
- Add support for highlighting python code blocks under the `sphinx.ext.doctest` directives
- Add support for highlighting more section header types