### PR TITLE
Better role target completions

### DIFF
--- a/lib/esbonio/changes/54.fix.rst
+++ b/lib/esbonio/changes/54.fix.rst
@@ -1,0 +1,2 @@
+**Language Server** Fix issue where some malformed ``CompletionItem``s were
+preventing completion suggestions from being shown.

--- a/lib/esbonio/esbonio/lsp/__init__.py
+++ b/lib/esbonio/esbonio/lsp/__init__.py
@@ -15,7 +15,7 @@ def _(rst: RstLanguageServer, params: InitializeParams):
     return initialized(rst, params)
 
 
-@server.feature(COMPLETION, trigger_characters=[".", ":", "`"])
+@server.feature(COMPLETION, trigger_characters=[".", ":", "`", "<"])
 def _(rst: RstLanguageServer, params: CompletionParams):
     return completions(rst, params)
 

--- a/lib/esbonio/esbonio/lsp/completion.py
+++ b/lib/esbonio/esbonio/lsp/completion.py
@@ -56,11 +56,10 @@ def completions(rst: RstLanguageServer, params: CompletionParams):
     doc = rst.workspace.get_document(uri)
     line = get_line_til_position(doc, pos)
 
-    target_match = ROLE_TARGET.match(line)
-
     if DIRECTIVE.match(line):
         return CompletionList(False, list(rst.directives.values()))
 
+    target_match = ROLE_TARGET.match(line)
     if target_match:
         return CompletionList(False, suggest_targets(rst, target_match))
 

--- a/lib/esbonio/esbonio/lsp/initialize.py
+++ b/lib/esbonio/esbonio/lsp/initialize.py
@@ -215,7 +215,7 @@ def completion_from_target(name, display, type_) -> CompletionItem:
     """Convert a target into a completion item we can return to the client"""
 
     kind = TARGET_KINDS.get(type_, CompletionItemKind.Reference)
-    return CompletionItem(name, kind=kind, detail=display, insert_text=name)
+    return CompletionItem(name, kind=kind, detail=str(display), insert_text=name)
 
 
 def completion_from_role(name, role) -> CompletionItem:

--- a/lib/esbonio/esbonio/lsp/initialize.py
+++ b/lib/esbonio/esbonio/lsp/initialize.py
@@ -224,8 +224,7 @@ def completion_from_role(name, role) -> CompletionItem:
         name,
         kind=CompletionItemKind.Function,
         detail="role",
-        insert_text="{}:`$0`".format(name),
-        insert_text_format=InsertTextFormat.Snippet,
+        insert_text="{}:".format(name),
     )
 
 


### PR DESCRIPTION
Fix issue where some malformed completion items would prevent the suggestions from being displayed.
Tweak the completion text for roles so that it's easier to trigger suggestions for role targets