### PR TITLE
Fix initial reporting of diagnostics

### DIFF
--- a/lib/esbonio/CHANGES.rst
+++ b/lib/esbonio/CHANGES.rst
@@ -15,7 +15,7 @@ Fixes
 
 - Errors encountered when initialising Sphinx are now caught and the language
   client is notified of an issue. (`#33 <https://github.com/swyddfa/esbonio/issues/33>`_)
-- **Language Server** Fix issue where some malformed ``CompletionItem``s were
+- **Language Server** Fix issue where some malformed ``CompletionItem`` objects were
   preventing completion suggestions from being shown. (`#54 <https://github.com/swyddfa/esbonio/issues/54>`_)
 - **Language Server** Windows paths are now handled correctly (`#60 <https://github.com/swyddfa/esbonio/issues/60>`_)
 - **Language Server** Server no longer chooses ``conf.py`` files that

--- a/lib/esbonio/changes/68.fix.rst
+++ b/lib/esbonio/changes/68.fix.rst
@@ -1,0 +1,1 @@
+**Language Server** Diagnostics are now reported on first startup

--- a/lib/esbonio/esbonio/lsp/__init__.py
+++ b/lib/esbonio/esbonio/lsp/__init__.py
@@ -3,7 +3,7 @@ import logging
 
 from typing import List
 
-from pygls.features import COMPLETION, INITIALIZE, TEXT_DOCUMENT_DID_SAVE
+from pygls.features import COMPLETION, INITIALIZE, INITIALIZED, TEXT_DOCUMENT_DID_SAVE
 from pygls.server import LanguageServer
 from pygls.types import (
     CompletionList,
@@ -35,6 +35,10 @@ class RstLanguageServer(LanguageServer):
         self.on_init_hooks = []
         """A list of functions to run on initialization"""
 
+        self.on_initialized_hooks = []
+        """A list of functions to run after receiving the initialized notification from the
+        client"""
+
         self.on_save_hooks = []
         """A list of hooks to run on document save."""
 
@@ -46,6 +50,9 @@ class RstLanguageServer(LanguageServer):
 
         if hasattr(feature, "initialize"):
             self.on_init_hooks.append(feature.initialize)
+
+        if hasattr(feature, "initialized"):
+            self.on_initialized_hooks.append(feature.initialized)
 
         if hasattr(feature, "save"):
             self.on_save_hooks.append(feature.save)
@@ -100,6 +107,12 @@ def create_language_server(modules: List[str]) -> RstLanguageServer:
             init_hook()
 
         rst.logger.info("LSP Server Initialized")
+
+    @server.feature(INITIALIZED)
+    def on_initialized(rst: RstLanguageServer, params):
+
+        for initialized_hook in rst.on_initialized_hooks:
+            initialized_hook()
 
     @server.feature(COMPLETION, trigger_characters=[".", ":", "`", "<"])
     def on_completion(rst: RstLanguageServer, params: CompletionParams):

--- a/lib/esbonio/esbonio/lsp/sphinx.py
+++ b/lib/esbonio/esbonio/lsp/sphinx.py
@@ -74,10 +74,21 @@ class SphinxManagement:
 
     def initialize(self):
         self.create_app()
-        self.refresh_app()
+
+        if self.rst.app is not None:
+            self.rst.app.builder.read()
+
+    def initialized(self):
+        self.report_diagnostics()
 
     def save(self, params: DidSaveTextDocumentParams):
-        self.refresh_app()
+
+        if self.rst.app is None:
+            return
+
+        self.reset_diagnostics()
+        self.rst.app.builder.read()
+        self.report_diagnostics()
 
     def create_app(self):
         """Initialize a Sphinx application instance for the current workspace."""
@@ -122,12 +133,8 @@ class SphinxManagement:
                 msg_type=MessageType.Error,
             )
 
-    def refresh_app(self):
-        if self.rst.app is None:
-            return
-
-        self.reset_diagnostics()
-        self.rst.app.builder.read()
+    def report_diagnostics(self):
+        """Publish the current set of diagnostics to the client."""
 
         for doc, diagnostics in self.diagnostics.items():
 

--- a/lib/esbonio/tests/lsp/test_sphinx.py
+++ b/lib/esbonio/tests/lsp/test_sphinx.py
@@ -172,7 +172,7 @@ def test_report_diagnostics():
     }
 
     manager.reset_diagnostics = mock.Mock()
-    manager.refresh_app()
+    manager.save(None)
 
     expected = [
         mock.call("file:///c:\\Users\\username\\Project\\file.rst", (1, 2, 3)),


### PR DESCRIPTION
The issue was that the diagnostics were being reported before the
server had responded to the `initialize` request - which is against
the protocol.

Instead the server now listens for the `initialized` notification from
the client and exposes a hook to features where on first startup code
can be run once initialization has finished

Closes #68 