### PR TITLE
Fix JsonRpcMethodNotFound exceptions when running in VSCode

### DIFF
--- a/lib/esbonio/changes/91.fix.rst
+++ b/lib/esbonio/changes/91.fix.rst
@@ -1,0 +1,2 @@
+``$/setTraceNotification`` notifications from VSCode no longer cause exceptions to be thrown
+in the Language Server.

--- a/lib/esbonio/esbonio/lsp/__init__.py
+++ b/lib/esbonio/esbonio/lsp/__init__.py
@@ -177,4 +177,9 @@ def create_language_server(modules: List[str]) -> RstLanguageServer:
         else:
             rst.run_hooks("save", params)
 
+    @server.feature("$/setTraceNotification")
+    def vscode_set_trace(rst: RstLanguageServer, params):
+        """Dummy implementation, stops JsonRpcMethodNotFound exceptions."""
+        rst.logger.debug("VSCode set trace: %s", params)
+
     return server


### PR DESCRIPTION
Closes #91 