### PR TITLE
Catch consistency errors.

### DIFF
--- a/lib/esbonio/changes/57.feature.rst
+++ b/lib/esbonio/changes/57.feature.rst
@@ -1,0 +1,1 @@
+The language server now reports invalid references as diagnostics

--- a/lib/esbonio/changes/94.fix.rst
+++ b/lib/esbonio/changes/94.fix.rst
@@ -1,0 +1,1 @@
+Consistency errors are now included in reported diagnostics.


### PR DESCRIPTION
By running the full build, we are now able to catch errors like
invalid references and benefit from Sphinx's caching logic.

Also by updating the `PROBLEM_PATTERN` regex, we can catch errors
that do not have an associated line number.

`DiagnosticList` is a way to ensure we don't get repeat reports of
the same issue, but might become an issue depending on project scale.

Closes #94 
Closes #57 