### PR TITLE
Finer control of language server startup

### DIFF
--- a/code/changes/118.feature.rst
+++ b/code/changes/118.feature.rst
@@ -1,0 +1,2 @@
+Expose ``esbonio.server.logFilter`` option that can be used to limit the
+components of the language server which produce output.

--- a/code/changes/119.misc.rst
+++ b/code/changes/119.misc.rst
@@ -1,0 +1,2 @@
+The extension now makes use of the ``--cache-dir`` cli option in the language
+server to set Sphinx's build output to use a known location.

--- a/code/changes/120.feature.rst
+++ b/code/changes/120.feature.rst
@@ -1,0 +1,2 @@
+Expose ``esbonio.server.hideSphinxOutput`` option which allows for Sphinx's
+build output to be omitted from the log.

--- a/code/changes/86.misc.rst
+++ b/code/changes/86.misc.rst
@@ -1,0 +1,2 @@
+The language server's logging level is set to match the logging level defined in
+the extension.

--- a/code/package.json
+++ b/code/package.json
@@ -79,7 +79,7 @@
             "type": "object",
             "title": "Esbonio",
             "properties": {
-                "esbonio.log.level": {
+                "esbonio.server.logLevel": {
                     "scope": "application",
                     "type": "string",
                     "default": "error",
@@ -90,11 +90,26 @@
                     ],
                     "description": "The level of log message to show in the log"
                 },
+                "esbonio.server.logFilter": {
+                    "scope": "application",
+                    "type": "array",
+                    "default": null,
+                    "items": {
+                        "type": "string"
+                    },
+                    "description": "A list of logger names to limit output from"
+                },
                 "esbonio.server.pythonPath": {
                     "scope": "window",
                     "type": "string",
                     "default": "",
                     "markdownDescription": "The path to the Python interpreter to use when running the Langague Server.\n\nBy default this extension will try to use the interpreter configured via the `#python.pythonPath#` option in the Python Extension. If you do not use the Python Extension or you wish to use a different environment, then this option can be used to override the default behavior."
+                },
+                "esbonio.server.hideSphinxOutput": {
+                    "scope": "application",
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Hide Sphinx build output from the Language Server log."
                 },
                 "esbonio.server.updateBehavior": {
                     "scope": "application",

--- a/code/src/log.ts
+++ b/code/src/log.ts
@@ -56,7 +56,7 @@ export function getOutputLogger() {
   if (!channelLogger) {
     let logLevel: LogLevel
 
-    let level = vscode.workspace.getConfiguration('esbonio').get<string>('log.level')
+    let level = vscode.workspace.getConfiguration('esbonio').get<string>('server.logLevel')
     switch (level) {
       case 'debug':
         logLevel = LogLevel.DEBUG


### PR DESCRIPTION
- Expose ``esbonio.server.logFilter`` option that can be used to limit the components of the language server which produce output.  Closes #118 
- Expose ``esbonio.server.hideSphinxOutput`` option which allows for Sphinx's build output to be omitted from the log. Closes #120 
- The extension now makes use of the ``--cache-dir`` cli option in the language server to set Sphinx's build output to use a known location. Closes #119 
- The language server's logging level is set to match the logging level defined in the extension. Closes #86 