### PR TITLE
Quality of life improvements

### DIFF
--- a/code/changes/122.feature.rst
+++ b/code/changes/122.feature.rst
@@ -1,0 +1,2 @@
+The extension will now automatically restart the Language Server when the
+extension's configuration is updated

--- a/code/changes/123.fix.rst
+++ b/code/changes/123.fix.rst
@@ -1,0 +1,1 @@
+The extension now enforces a minimum Language Server version

--- a/code/changes/133.misc.rst
+++ b/code/changes/133.misc.rst
@@ -1,0 +1,3 @@
+If ``esbonio.server.logLevel`` is set to ``debug`` the extension assumes the
+user is working on the Language Server and will automatically open the log panel
+on restarts.


### PR DESCRIPTION
- The extension now enforces a minimum Language Server version, will give the option of upgrading the server if an old version is detected. Closes #123 
- The extension will now automatically restart the Language Server when the extension's configuration is updated. Closes #122 
- If `esbonio.server.logLevel` is set to `debug` the extension assumes the user is working on the Language Server and will automatically open the log panel on restarts.