### PR TITLE
Improvements to the installation flow

### DIFF
--- a/code/changes/92.feature.rst
+++ b/code/changes/92.feature.rst
@@ -1,0 +1,4 @@
+Add new ``esbonio.server.installBehavior`` option that gives greater control
+over how Language Server installation is handled. ``automatic`` will install the
+server in new environments without prompting, ``prompt`` will ask for
+confirmation first and ``nothing`` disables installation entirely.`

--- a/code/changes/97.fix.rst
+++ b/code/changes/97.fix.rst
@@ -1,0 +1,2 @@
+The extension now checks that the configured Python verison is compatible with
+the Language Server.

--- a/code/package.json
+++ b/code/package.json
@@ -111,6 +111,22 @@
                     "default": false,
                     "description": "Hide Sphinx build output from the Language Server log."
                 },
+                "esbonio.server.installBehavior": {
+                    "scope": "application",
+                    "type": "string",
+                    "default": "prompt",
+                    "enum": [
+                        "nothing",
+                        "prompt",
+                        "automatic"
+                    ],
+                    "enumDescriptions": [
+                        "Don't attempt to install the Language Server if it's missing",
+                        "Ask for confirmation before installing the Language Server",
+                        "Never ask for confirmation, the Language Server will be installed automatically in new environments"
+                    ],
+                    "description": "When the Language Server is missing from an environment, how should the extension handle it"
+                },
                 "esbonio.server.updateBehavior": {
                     "scope": "application",
                     "type": "string",


### PR DESCRIPTION
- Add new `esbonio.server.installBehavior` option that gives greater control over how Language Server installation is handled. `automatic` will install the server in new environments without prompting, `prompt` will ask for confirmation first and `nothing` disables installation entirely. Closes #92 
- The extension now checks that the configured Python's verison is compatible with the Language Server. Closes #97 
