### PR TITLE
Pin pygls version

### DIFF
--- a/lib/esbonio/changes/147.fix.rst
+++ b/lib/esbonio/changes/147.fix.rst
@@ -1,0 +1,1 @@
+Pin ``pygls<0.10.0`` to ensure installs pick up a compatible version

--- a/lib/esbonio/setup.cfg
+++ b/lib/esbonio/setup.cfg
@@ -31,7 +31,7 @@ exclude = tests
 
 [options.extras_require]
 dev = black ; flake8 ; pytest ; pytest-cov ; mock
-lsp = appdirs ; pygls
+lsp = appdirs ; pygls<0.10.0
 
 [flake8]
 max-line-length = 88

--- a/scripts/should-build.sh
+++ b/scripts/should-build.sh
@@ -4,7 +4,7 @@
 # File patterns to check for each component, if there's a match a build will be
 # triggered
 DOCS="^docs"
-PYTHON="^lib/esbonio/.*\.py"
+PYTHON="^lib/esbonio/"
 VSCODE="^code"
 
 # Determine which files have changed


### PR DESCRIPTION
Pygls 0.10.x contains breaking changes so we should pin the version until #144 is resolved

Fixes #147 