### PR TITLE
Allow Language Clients to override default conf.py discovery mechanism

### DIFF
--- a/code/changes/63.feature.rst
+++ b/code/changes/63.feature.rst
@@ -1,0 +1,3 @@
+Add new ``esbonio.sphinx.confDir`` option that allows for a project's config
+directory to be explictly set should the automatic discovery in the Language
+Server fail.

--- a/code/package.json
+++ b/code/package.json
@@ -160,6 +160,12 @@
                         "Check for updates daily"
                     ],
                     "description": "How often should the extension check for updates to the Language Server"
+                },
+                "esbonio.sphinx.confDir": {
+                    "scope": "window",
+                    "type": "string",
+                    "default": "",
+                    "description": "The Language Server should be able to automatically find the folder containing your project's 'conf.py' file. However this setting can be used to force the Language Server to use a particular directory if required."
                 }
             }
         },

--- a/lib/esbonio/changes/62.feature.rst
+++ b/lib/esbonio/changes/62.feature.rst
@@ -1,0 +1,2 @@
+Language clients can now override the default ``conf.py`` discovery mechanism
+by providing a ``esbonio.sphinx.confDir`` config option.

--- a/lib/esbonio/esbonio/lsp/directives.py
+++ b/lib/esbonio/esbonio/lsp/directives.py
@@ -16,7 +16,7 @@ from pygls.lsp.types import (
 )
 from pygls.workspace import Document
 
-from esbonio.lsp import RstLanguageServer, LanguageFeature
+import esbonio.lsp as lsp
 from esbonio.lsp.sphinx import get_domains
 
 
@@ -64,10 +64,10 @@ PARTIAL_DIRECTIVE_OPTION = re.compile(
 auto complete suggestions."""
 
 
-class Directives(LanguageFeature):
+class Directives(lsp.LanguageFeature):
     """Directive support for the language server."""
 
-    def initialize(self):
+    def initialized(self, config: lsp.SphinxConfig):
         self.discover()
 
     def discover(self):
@@ -317,7 +317,7 @@ class Directives(LanguageFeature):
         ]
 
 
-def setup(rst: RstLanguageServer):
+def setup(rst: lsp.RstLanguageServer):
 
     directive_completion = Directives(rst)
     rst.add_feature(directive_completion)

--- a/lib/esbonio/esbonio/lsp/intersphinx.py
+++ b/lib/esbonio/esbonio/lsp/intersphinx.py
@@ -9,7 +9,7 @@ from pygls.lsp.types import (
 )
 from pygls.workspace import Document
 
-from esbonio.lsp import RstLanguageServer, LanguageFeature
+import esbonio.lsp as lsp
 from esbonio.lsp.roles import (
     COMPLETION_TARGETS,
     DEFAULT_TARGET,
@@ -69,10 +69,10 @@ Used when generating auto complete suggestions.
 """
 
 
-class InterSphinx(LanguageFeature):
+class InterSphinx(lsp.LanguageFeature):
     """Intersphinx support for the language server."""
 
-    def initialize(self):
+    def initialized(self, config: lsp.SphinxConfig):
 
         self.targets = {}
         self.target_types = {}
@@ -235,6 +235,6 @@ class InterSphinx(LanguageFeature):
         )
 
 
-def setup(rst: RstLanguageServer):
+def setup(rst: lsp.RstLanguageServer):
     intersphinx = InterSphinx(rst)
     rst.add_feature(intersphinx)

--- a/lib/esbonio/esbonio/lsp/roles.py
+++ b/lib/esbonio/esbonio/lsp/roles.py
@@ -15,7 +15,7 @@ from pygls.lsp.types import (
 )
 from pygls.workspace import Document
 
-from esbonio.lsp import RstLanguageServer, LanguageFeature, dump
+import esbonio.lsp as lsp
 from esbonio.lsp.directives import DIRECTIVE
 from esbonio.lsp.sphinx import get_domains
 
@@ -104,10 +104,10 @@ COMPLETION_TARGETS = {
 }
 
 
-class Roles(LanguageFeature):
+class Roles(lsp.LanguageFeature):
     """Role support for the language server."""
 
-    def initialize(self):
+    def initialized(self, config: lsp.SphinxConfig):
         self.discover_roles()
         self.discover_targets()
 
@@ -322,7 +322,7 @@ class Roles(LanguageFeature):
             ),
         )
 
-        self.logger.debug("Item %s", dump(item))
+        self.logger.debug("Item %s", lsp.dump(item))
         return item
 
     def target_object_to_completion_item(
@@ -345,6 +345,6 @@ class Roles(LanguageFeature):
         )
 
 
-def setup(rst: RstLanguageServer):
+def setup(rst: lsp.RstLanguageServer):
     role_completion = Roles(rst)
     rst.add_feature(role_completion)

--- a/lib/esbonio/setup.cfg
+++ b/lib/esbonio/setup.cfg
@@ -6,6 +6,11 @@ long_description = file:README.md
 long_description_content_type = text/markdown
 author = Alex Carney
 author_email = alcarneyme@gmail.com
+url = https://swyddfa.github.io/esbonio/
+project_urls =
+    Bug Tracker = https://github.com/swyddfa/esbonio/issues
+    Documentation = https://swyddfa.github.io/esbonio/
+    Source Code = https://github.com/swyddfa/esbonio
 license = MIT
 classifiers =
     Development Status :: 3 - Alpha

--- a/lib/esbonio/tests/lsp/test_directives.py
+++ b/lib/esbonio/tests/lsp/test_directives.py
@@ -126,7 +126,7 @@ def test_directive_completions(sphinx, project, text, expected, unexpected):
     rst.logger = logging.getLogger("rst")
 
     feature = Directives(rst)
-    feature.initialize()
+    feature.initialized(None)
 
     completion_test(feature, text, expected=expected, unexpected=unexpected)
 
@@ -217,6 +217,6 @@ def test_directive_option_completions(sphinx, project, text, expected, unexpecte
     rst.logger = logging.getLogger("rst")
 
     feature = Directives(rst)
-    feature.initialize()
+    feature.initialized(None)
 
     completion_test(feature, text, expected=expected, unexpected=unexpected)

--- a/lib/esbonio/tests/lsp/test_intersphinx.py
+++ b/lib/esbonio/tests/lsp/test_intersphinx.py
@@ -33,7 +33,7 @@ def intersphinx(sphinx):
         rst.logger = logging.getLogger("rst")
 
         feature = InterSphinx(rst)
-        feature.initialize()
+        feature.initialized(None)
         instances[project] = feature
 
         return feature

--- a/lib/esbonio/tests/lsp/test_roles.py
+++ b/lib/esbonio/tests/lsp/test_roles.py
@@ -71,7 +71,7 @@ def test_role_completions(sphinx, project, text, expected, unexpected):
     rst.logger = logging.getLogger("rst")
 
     feature = Roles(rst)
-    feature.initialize()
+    feature.initialized(None)
 
     completion_test(feature, text, expected=expected, unexpected=unexpected)
 
@@ -252,7 +252,7 @@ def test_role_target_completions(sphinx, text, setup):
     rst.logger = logging.getLogger("rst")
 
     feature = Roles(rst)
-    feature.initialize()
+    feature.initialized(None)
 
     completion_test(feature, text, expected=expected, unexpected=unexpected)
 


### PR DESCRIPTION
Clients can now provide the `esbonio.sphinx.confDir` option to bypass
the default `conf.py` discovery code and use a given absolute path. Or a
path may be given like `${workspaceRoot}/some/dir`, in which case the
path will be expanded relative to the workspace root as specified by the
language client during `initialize`

Closes #62 
Closes #63 