### PR TITLE
Fix diagnostic path encoding for Windows paths

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -304,14 +304,14 @@ jobs:
       run: |
         cd lib/esbonio
         python -m tox -e pkg
-      if: matrix.python-version == '3.8'
+      if: always() && matrix.python-version == '3.8'
 
     - name: 'Upload Artifact'
       uses: actions/upload-artifact@v1.0.0
       with:
         name: 'dist'
         path: lib/esbonio/dist
-      if: matrix.python-version == '3.8'
+      if: always() && matrix.python-version == '3.8'
 
     - name: Publish
       id: assets

--- a/lib/esbonio/CHANGES.rst
+++ b/lib/esbonio/CHANGES.rst
@@ -1,4 +1,4 @@
-v0.6.0 - 2021-05-07v0.6.0 - 2021-05-07
+v0.6.0 - 2021-05-07
 -------------------
 
 Features
@@ -19,6 +19,8 @@ Fixes
 
 - The Language Server no longer throws an exception while handling errors raised
   during initialization of a Sphinx application. (`#139 <https://github.com/swyddfa/esbonio/issues/139>`_)
+- The Language Server now correctly offers completions for ``autoxxx`` directive options
+  (`#100 <https://github.com/swyddfa/esbonio/issues/100>`_)
 
 
 Misc

--- a/lib/esbonio/changes/100.bug.rst
+++ b/lib/esbonio/changes/100.bug.rst
@@ -1,1 +1,0 @@
-The Language Server now correctly offers completions for ``autoxxx`` directive options

--- a/lib/esbonio/changes/166.fix.rst
+++ b/lib/esbonio/changes/166.fix.rst
@@ -1,0 +1,1 @@
+Fix the uri representation of Windows paths when reporting diagnostics

--- a/lib/esbonio/esbonio/lsp/sphinx.py
+++ b/lib/esbonio/esbonio/lsp/sphinx.py
@@ -6,7 +6,7 @@ import pathlib
 import re
 
 from typing import Iterator, Optional, Tuple
-from urllib.parse import urlparse, unquote
+from urllib.parse import quote
 
 import appdirs
 
@@ -289,9 +289,10 @@ class SphinxManagement(lsp.LanguageFeature):
         for doc, diagnostics in self.diagnostics.items():
 
             if not doc.startswith("/"):
-                doc = "/" + doc
+                doc = "/" + doc.replace("\\", "/")
 
-            uri = f"file://{doc}"
+            uri = f"file://{quote(doc)}"
+            self.logger.debug("Publishing diagnostics for document: %s", uri)
             self.rst.publish_diagnostics(uri, diagnostics.data)
 
     def reset_diagnostics(self, filepath: str):
@@ -322,9 +323,8 @@ class SphinxManagement(lsp.LanguageFeature):
                 line_number = int(match.group("line"))
             except (TypeError, ValueError) as exc:
                 self.logger.debug(
-                    "Unable to parse line number: '%s'", match.group("line")
+                    "Unable to parse line number: '%s' - %s", match.group("line"), exc
                 )
-                self.logger.debug(exc)
 
                 line_number = 1
 

--- a/lib/esbonio/tests/lsp/test_sphinx.py
+++ b/lib/esbonio/tests/lsp/test_sphinx.py
@@ -188,7 +188,7 @@ def test_report_diagnostics():
 
     expected = [
         mock.call(
-            "file:///c:\\Users\\username\\Project\\file.rst", DiagnosticList([1, 2, 3])
+            "file:///c%3A/Users/username/Project/file.rst", DiagnosticList([1, 2, 3])
         ),
         mock.call("file:///home/username/Project/file.rst", DiagnosticList([4, 5, 6])),
     ]


### PR DESCRIPTION
- Fixes #166. 
- Tweak the CI workflow to publish build artifacts containing a packaged version of the language server even if the tests fail.
- Fix formatting issues in the changelog from the previous release