### PR TITLE
vscode: Improve the development experience

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,7 +2,7 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "Esbonio VSCode",
+            "name": "VSCode Extension",
             "type": "extensionHost",
             "request": "launch",
             "runtimeExecutable": "${execPath}",
@@ -13,10 +13,13 @@
             "outFiles": [
                 "${workspaceRoot}/code/dist/**/*.js"
             ],
-            "preLaunchTask": "${defaultBuildTask}"
+            "preLaunchTask": "${defaultBuildTask}",
+            "env": {
+                "VSCODE_DEBUG": "true"
+            }
         },
         {
-            "name": "Esbonio VSCode Tests",
+            "name": "VSCode Tests",
             "type": "extensionHost",
             "request": "launch",
             "runtimeExecutable": "${execPath}",
@@ -28,6 +31,28 @@
                 "${workspaceFolder}/code/dist/test/**/*.js"
             ],
             "preLaunchTask": "Build Tests",
+        },
+        {
+            "name": "Language Server",
+            "type": "python",
+            "request": "launch",
+            "module": "esbonio",
+            "justMyCode": false,
+            "args": [
+                "--port",
+                "8421"
+            ],
+            "python": "${command:python.interpreterPath}",
+            "cwd": "${workspaceRoot}"
+        }
+    ],
+    "compounds": [
+        {
+            "name": "VSCode + Language Server",
+            "configurations": [
+                "Language Server",
+                "VSCode Extension"
+            ]
         }
     ]
 }

--- a/code/changes/170.misc.rst
+++ b/code/changes/170.misc.rst
@@ -1,0 +1,1 @@
+Improvements to the development experience


### PR DESCRIPTION
This commit introduces the ability for the extension to connect to a
language server instance over TCP. This way of connecting is tried when
the `VSCODE_DEBUG` environment variable is present and set to `true`.

The commit also updates the `.vscode/launch.json` file to set this
environment variable as well as introducing a new launch configuration
that starts the language server in TCP mode.

Finally the inclusion of a compound configuration allows both the
language server and VSCode extension to be debugged simultaneously!

This implementation was heavily inspired from the example json-extension
in the pygls repo.
https://github.com/openlawlibrary/pygls/tree/e1a5c751fe45d940350d8a755490889b75d52273/examples/json-extension