### PR TITLE
Fix crash when clients don't send an `esbonio.sphinx` config object

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -24,7 +24,7 @@
         "**/.coverage": true,
         "**/.vscode-test": true
     },
-    "python.pythonPath": ".env/bin/python",
+    "python.pythonPath": "${workspaceRoot}/.env/bin/python",
     "python.formatting.provider": "black",
     //"esbonio.trace.server": "verbose"
 }

--- a/docs/_static/sample-configs/emacs/.gitignore
+++ b/docs/_static/sample-configs/emacs/.gitignore
@@ -1,0 +1,3 @@
+elpa
+*~
+custom.el

--- a/lib/esbonio/changes/171.fix.rst
+++ b/lib/esbonio/changes/171.fix.rst
@@ -1,0 +1,2 @@
+The language server no longer crashes if clients don't send the ``esbonio.sphinx``
+configuration object

--- a/lib/esbonio/esbonio/lsp/__init__.py
+++ b/lib/esbonio/esbonio/lsp/__init__.py
@@ -201,10 +201,12 @@ def create_language_server(
         config_params = ConfigurationParams(
             items=[ConfigurationItem(section="esbonio.sphinx")]
         )
-        config = await rst.get_configuration_async(config_params)
 
-        rst.logger.debug("SphinxConfig: %s", config[0])
-        rst.run_hooks("initialized", SphinxConfig.from_dict(config[0]))
+        config_items = await rst.get_configuration_async(config_params)
+        sphinx_config = SphinxConfig.from_dict(config_items[0] or dict())
+
+        rst.logger.debug("SphinxConfig: %s", dump(sphinx_config))
+        rst.run_hooks("initialized", sphinx_config)
 
         rst.logger.info("LSP server initialized")
 


### PR DESCRIPTION
Closes #171