### PR TITLE
Miscellaneous fixes and improvements

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,12 +8,20 @@
             "default": "code/",
             "options": [
                 {
-                    "label": "code/",
+                    "label": "code",
                     "value": "code"
+                },
+                {
+                    "label": "docs",
+                    "value": "docs"
                 },
                 {
                     "label": "sphinx-default",
                     "value": "lib/esbonio/tests/data/sphinx-default"
+                },
+                {
+                    "label": "sphinx-error",
+                    "value": "lib/esbonio/tests/data/sphinx-error"
                 },
                 {
                     "label": "sphinx-extensions",

--- a/lib/esbonio/changes/169.fix.rst
+++ b/lib/esbonio/changes/169.fix.rst
@@ -1,0 +1,2 @@
+The language server now attempts to recreate the Sphinx application if the user
+updates a broken ``conf.py``.

--- a/lib/esbonio/changes/179.fix.rst
+++ b/lib/esbonio/changes/179.fix.rst
@@ -1,0 +1,1 @@
+Sphinx build time exceptions are now caught and reported

--- a/lib/esbonio/changes/180.fix.rst
+++ b/lib/esbonio/changes/180.fix.rst
@@ -1,0 +1,1 @@
+Fix ``Method not found: $/setTrace`` exceptions when running against VSCode

--- a/lib/esbonio/esbonio/lsp/__init__.py
+++ b/lib/esbonio/esbonio/lsp/__init__.py
@@ -240,19 +240,7 @@ def create_language_server(
     @server.feature(TEXT_DOCUMENT_DID_SAVE)
     def on_save(rst: RstLanguageServer, params: DidSaveTextDocumentParams):
         rst.logger.debug("%s: %s", TEXT_DOCUMENT_DID_SAVE, params)
-
-        conf_py = None
-        uri = urlparse(params.text_document.uri)
-        filepath = pathlib.Path(unquote(uri.path))
-
-        if rst.app:
-            conf_py = pathlib.Path(rst.app.confdir, "conf.py")
-
-        # Re-initialize everything if the app's config has changed.
-        if filepath == conf_py:
-            rst.run_hooks("init")
-        else:
-            rst.run_hooks("save", params)
+        rst.run_hooks("save", params)
 
     @server.feature("$/setTraceNotification")
     def vscode_set_trace(rst: RstLanguageServer, params):

--- a/lib/esbonio/esbonio/lsp/__init__.py
+++ b/lib/esbonio/esbonio/lsp/__init__.py
@@ -242,6 +242,11 @@ def create_language_server(
         rst.logger.debug("%s: %s", TEXT_DOCUMENT_DID_SAVE, params)
         rst.run_hooks("save", params)
 
+    @server.feature("$/setTrace")
+    def on_set_trace(rst: RstLanguageServer, params):
+        """Dummy implementation, stops JsonRpcMethodNotFound exceptions."""
+        rst.logger.debug("$/setTrace: %s", params)
+
     @server.feature("$/setTraceNotification")
     def vscode_set_trace(rst: RstLanguageServer, params):
         """Dummy implementation, stops JsonRpcMethodNotFound exceptions."""

--- a/lib/esbonio/esbonio/lsp/sphinx.py
+++ b/lib/esbonio/esbonio/lsp/sphinx.py
@@ -209,38 +209,62 @@ class SphinxManagement(lsp.LanguageFeature):
         self.diagnostics = {}
         """A place to keep track of diagnostics we can publish to the client."""
 
+        self.config: Optional[lsp.SphinxConfig] = None
+        """The client's ``esbonio.sphinx.*`` configuration."""
+
+        self._conf_dir = None
+        """The directory containing Sphinx's ``conf.py``.
+
+        The source of truth for this value should be the Sphinx application itself,
+        **you should not depend on this value**.
+
+        The only use case for this field is when a user's config is broken and there
+        currently isn't a valid application object, we use this field to determine when
+        a user has edited their ``conf.py`` and we should try to restart the server.
+        """
+
         self.sphinx_log = logging.getLogger("esbonio.sphinx")
         """The logger that should be used by a Sphinx application"""
 
     def initialized(self, config: lsp.SphinxConfig):
-        self.create_app(config)
 
-        if self.rst.app is not None:
-            self.rst.app.build()
-
-        self.logger.debug("%s", config)
-        self.report_diagnostics()
+        self.config = config
+        self.logger.debug("%s", self.config)
+        self.create_app(self.config)
+        self.build_app()
 
     def save(self, params: DidSaveTextDocumentParams):
 
-        if self.rst.app is None:
-            return
-
         filepath = lsp.filepath_from_uri(params.text_document.uri)
 
-        self.reset_diagnostics(str(filepath))
-        self.rst.app.build()
-        self.report_diagnostics()
+        # There may not be an application instance - the user's config could
+        # be broken...
+        if not self.rst.app:
+
+            # ...did thry try to fix it?
+            if self._conf_dir and filepath == (self._conf_dir / "conf.py"):
+                self.create_app(self.config)
+
+        # The user has updated their conf.py, we need to recreate the application.
+        elif filepath == pathlib.Path(self.rst.app.confdir) / "conf.py":
+            self.create_app(self.config)
+
+        else:
+            self.reset_diagnostics(str(filepath))
+
+        self.build_app()
 
     def create_app(self, config: lsp.SphinxConfig):
         """Initialize a Sphinx application instance for the current workspace."""
         self.rst.logger.debug("Workspace root %s", self.rst.workspace.root_uri)
 
+        self.diagnostics = {}
         conf_dir = find_conf_dir(self.rst.workspace.root_uri, config)
 
         if conf_dir is None:
             self.rst.show_message(
-                'Unable to find your project\'s "conf.py", features wil be limited',
+                'Unable to find your project\'s "conf.py", features that depend on '
+                + "Sphinx will be unavailable",
                 msg_type=MessageType.Warning,
             )
             return
@@ -276,12 +300,31 @@ class SphinxManagement(lsp.LanguageFeature):
             )
         except Exception as exc:
             message = "Unable to initialize Sphinx, see output window for details."
+            self._conf_dir = conf_dir
 
             self.sphinx_log.error(exc)
             self.rst.show_message(
                 message=message,
                 msg_type=MessageType.Error,
             )
+
+    def build_app(self):
+
+        if not self.rst.app:
+            return
+
+        try:
+            self.rst.app.build()
+        except Exception as exc:
+            message = "Unable to build documentation, see output window for details."
+
+            self.sphinx_log.error(exc)
+            self.rst.show_message(
+                message=message,
+                msg_type=MessageType.Error,
+            )
+
+        self.report_diagnostics()
 
     def report_diagnostics(self):
         """Publish the current set of diagnostics to the client."""

--- a/lib/esbonio/tests/lsp/test_sphinx.py
+++ b/lib/esbonio/tests/lsp/test_sphinx.py
@@ -172,6 +172,7 @@ def test_report_diagnostics():
     publish_diagnostics = mock.Mock()
 
     rst = mock.Mock()
+    rst.app.confdir = "/some/folder"
     rst.publish_diagnostics = publish_diagnostics
 
     manager = SphinxManagement(rst)


### PR DESCRIPTION
- When the user's `conf.py` is broken the language server will now attempt to create a Sphinx application when it is updated (Closes #169)
- Exceptions are no longer generated by `$/setTrace` notifications (Closes #180)
- Exceptions raised by Sphinx builds are now caught and reported (Closes #179)