### PR TITLE
Align to `initializationOptions`

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -26,5 +26,11 @@
     },
     "python.pythonPath": "${workspaceRoot}/.env/bin/python",
     "python.formatting.provider": "black",
+    "python.testing.pytestArgs": [
+        "lib/esbonio/tests"
+    ],
+    "python.testing.unittestEnabled": false,
+    "python.testing.nosetestsEnabled": false,
+    "python.testing.pytestEnabled": true,
     //"esbonio.trace.server": "verbose"
 }

--- a/code/changes/185.misc.rst
+++ b/code/changes/185.misc.rst
@@ -1,0 +1,4 @@
+The cli arguments ``--cache-dir``, ``--log-filter``, ``--log-level`` and
+``--hide-sphinx-output`` have been replaced with the configuration
+parameters ``esbonio.sphinx.buildDir``, ``esbonio.server.logFilter``,
+``esbonio.logLevel`` and ``esbonio.server.hideSphinxOutput`` respectively

--- a/code/changes/192.misc.rst
+++ b/code/changes/192.misc.rst
@@ -1,0 +1,3 @@
+The language server's startup sequence has been reworked. Language clients are now
+required to provide configuration parameters under the ``initializationOptions`` field
+in the ``initialize`` request.

--- a/code/package.json
+++ b/code/package.json
@@ -164,13 +164,13 @@
                 "esbonio.sphinx.confDir": {
                     "scope": "window",
                     "type": "string",
-                    "default": "",
+                    "default": null,
                     "description": "The Language Server should be able to automatically find the folder containing your project's 'conf.py' file. However this setting can be used to force the Language Server to use a particular directory if required."
                 },
                 "esbonio.sphinx.srcDir": {
                     "scope": "window",
                     "type": "string",
-                    "default": "",
+                    "default": null,
                     "markdownDescription": "The directory containing your rst source files. By default the Language Server will assume this is the same as `#esbonio.sphinx.srcDir#` but this opton can override this if necessary."
                 }
             }

--- a/code/src/lsp/client.ts
+++ b/code/src/lsp/client.ts
@@ -13,6 +13,76 @@ import { ServerManager } from "./server";
 const DEBUG = process.env.VSCODE_LSP_DEBUG === "true"
 
 /**
+ * Represents the current sphinx configuration / configuration options
+ * that should be passed to sphinx on creation.
+ */
+export interface SphinxConfig {
+
+  /**
+   * Sphinx's version number.
+   */
+  version?: string
+
+  /**
+   * The directory containing the project's 'conf.py' file.
+   */
+  confDir?: string
+
+  /**
+   * The source dir containing the *.rst files for the project.
+   */
+  srcDir?: string
+
+  /**
+   * The directory where Sphinx's build output should be stored.
+   */
+  buildDir?: string
+
+  /**
+   * The name of the builder to use.
+   */
+  builderName?: string
+
+}
+
+/**
+ * Represents configuration options that should be passed to the server.
+ */
+export interface ServerConfig {
+
+  /**
+   * Used to set the logging level of the server.
+   */
+  logLevel: string
+
+  /**
+   * A list of logger names to suppress output from.
+   */
+  logFilter?: string[]
+
+  /**
+   * A flag to indicate if Sphinx build output should be omitted from the log.
+   */
+  hideSphinxOutput: boolean
+}
+
+/**
+ * The initialization options we pass to the server on startup.
+ */
+export interface InitOptions {
+
+  /**
+   * Language server specific options
+   */
+  server: ServerConfig
+
+  /**
+   * Sphinx specific options
+   */
+  sphinx: SphinxConfig
+}
+
+/**
  * While the ServerManager is responsible for installation and updates of the
  * Python package containing the server. The ClientManager is responsible for
  * creating the LanguageClient instance that utilmately starts the server
@@ -98,27 +168,10 @@ export class ClientManager {
       return undefined
     }
 
-    let config = vscode.workspace.getConfiguration('esbonio')
     let command = await this.python.getCmd()
-
-    let cache = this.context.storageUri.path
-
     command.push(
       "-m", "esbonio",
-      "--cache-dir", join(cache, 'sphinx'),
-      "--log-level", config.get<string>('server.logLevel')
     )
-
-    if (config.get<boolean>('server.hideSphinxOutput')) {
-      command.push("--hide-sphinx-output")
-    }
-
-    let logFilters = config.get<string[]>('server.logFilter')
-    if (logFilters) {
-      logFilters.forEach(filterName => {
-        command.push("--log-filter", filterName)
-      })
-    }
 
     this.logger.debug(`Server start command: ${command.join(" ")}`)
 
@@ -159,12 +212,32 @@ export class ClientManager {
    * transport.
    */
   private getLanguageClientOptions(): LanguageClientOptions {
-    return {
+
+    let cache = this.context.storageUri.path
+    let config = vscode.workspace.getConfiguration("esbonio")
+
+    let initOptions: InitOptions = {
+      sphinx: {
+        srcDir: config.get<string>("sphinx.srcDir"),
+        confDir: config.get<string>('sphinx.confDir'),
+        buildDir: join(cache, 'sphinx')
+      },
+      server: {
+        logLevel: config.get<string>('server.logLevel'),
+        logFilter: config.get<string[]>('server.logFilter'),
+        hideSphinxOutput: config.get<boolean>('server.hideSphinxOutput')
+      }
+    }
+
+    let clientOptions: LanguageClientOptions = {
       documentSelector: [
         { scheme: 'file', language: 'rst' },
         { scheme: 'file', language: 'python' }
-      ]
+      ],
+      initializationOptions: initOptions
     }
+    this.logger.debug(`LanguageClientOptions: ${JSON.stringify(clientOptions)}`)
+    return clientOptions
   }
 
   /**

--- a/lib/esbonio/changes/185.misc.rst
+++ b/lib/esbonio/changes/185.misc.rst
@@ -1,0 +1,4 @@
+The cli arguments ``--cache-dir``, ``--log-filter``, ``--log-level`` and
+``--hide-sphinx-output`` have been replaced with the configuration
+parameters ``esbonio.sphinx.buildDir``, ``esbonio.server.logFilter``,
+``esbonio.logLevel`` and ``esbonio.server.hideSphinxOutput`` respectively

--- a/lib/esbonio/changes/192.misc.rst
+++ b/lib/esbonio/changes/192.misc.rst
@@ -1,0 +1,3 @@
+The language server's startup sequence has been reworked. Language clients are now
+required to provide configuration parameters under the ``initializationOptions`` field
+in the ``initialize`` request.

--- a/lib/esbonio/esbonio/__main__.py
+++ b/lib/esbonio/esbonio/__main__.py
@@ -7,57 +7,11 @@ import esbonio.lsp as lsp
 from esbonio.lsp import RstLanguageServer, __version__
 from esbonio.lsp.logger import LspHandler
 
-LOG_LEVELS = {
-    "debug": logging.DEBUG,
-    "error": logging.ERROR,
-    "info": logging.INFO,
-}
-
-
-class LogFilter:
-    """A log filter that accepts message from any of the listed logger names."""
-
-    def __init__(self, names):
-        self.names = names
-
-    def filter(self, record):
-        return any(record.name == name for name in self.names)
-
-
-def configure_logging(args, server: RstLanguageServer):
-
-    level = LOG_LEVELS[args.log_level]
-
-    lsp_logger = logging.getLogger("esbonio.lsp")
-    lsp_logger.setLevel(level)
-
-    lsp_handler = LspHandler(server)
-    lsp_handler.setLevel(level)
-
-    if args.log_filter is not None:
-        lsp_handler.addFilter(LogFilter(args.log_filter))
-
-    formatter = logging.Formatter("[%(name)s] %(message)s")
-    lsp_handler.setFormatter(formatter)
-    lsp_logger.addHandler(lsp_handler)
-
-    if not args.hide_sphinx_output:
-        sphinx_logger = logging.getLogger("esbonio.sphinx")
-        sphinx_logger.setLevel(logging.INFO)
-
-        sphinx_handler = LspHandler(server)
-        sphinx_handler.setLevel(logging.INFO)
-
-        formatter = logging.Formatter("%(message)s")
-        sphinx_handler.setFormatter(formatter)
-        sphinx_logger.addHandler(sphinx_handler)
-
 
 def start_server(args):
     """Start the language server."""
 
-    server = lsp.create_language_server(lsp.BUILTIN_MODULES, cache_dir=args.cache_dir)
-    configure_logging(args, server)
+    server = lsp.create_language_server(lsp.BUILTIN_MODULES)
 
     if args.port:
         server.start_tcp("localhost", args.port)
@@ -66,33 +20,6 @@ def start_server(args):
 
 
 cli = argparse.ArgumentParser(prog="esbonio", description="The Esbonio language server")
-
-cli.add_argument(
-    "--cache-dir",
-    default=None,
-    type=str,
-    help="the directory where cached data should be stored, e.g. Sphinx build output ",
-)
-
-cli.add_argument(
-    "--hide-sphinx-output",
-    action="store_true",
-    help="hide sphinx build output from the log",
-)
-
-cli.add_argument(
-    "--log-filter",
-    action="append",
-    help="only include log messages from loggers with the given name,"
-    + "can be set multiple times.",
-)
-
-cli.add_argument(
-    "--log-level",
-    choices=["error", "info", "debug"],
-    default="error",
-    help="set the level of log message to show from the language server",
-)
 
 cli.add_argument(
     "-p",

--- a/lib/esbonio/esbonio/lsp/__init__.py
+++ b/lib/esbonio/esbonio/lsp/__init__.py
@@ -255,6 +255,7 @@ def create_language_server(modules: List[str]) -> RstLanguageServer:
     @server.feature(INITIALIZED)
     def on_initialized(rst: RstLanguageServer, params: InitializedParams):
         rst.logger.debug("%s: %s", INITIALIZED, dump(params))
+        rst.run_hooks("initialized")
 
     @server.feature(
         COMPLETION, CompletionOptions(trigger_characters=[".", ":", "`", "<", "/"])

--- a/lib/esbonio/esbonio/lsp/directives.py
+++ b/lib/esbonio/esbonio/lsp/directives.py
@@ -67,7 +67,7 @@ auto complete suggestions."""
 class Directives(lsp.LanguageFeature):
     """Directive support for the language server."""
 
-    def initialized(self, config: lsp.SphinxConfig):
+    def initialize(self, options: lsp.InitializationOptions):
         self.discover()
 
     def discover(self):

--- a/lib/esbonio/esbonio/lsp/intersphinx.py
+++ b/lib/esbonio/esbonio/lsp/intersphinx.py
@@ -72,7 +72,7 @@ Used when generating auto complete suggestions.
 class InterSphinx(lsp.LanguageFeature):
     """Intersphinx support for the language server."""
 
-    def initialized(self, config: lsp.SphinxConfig):
+    def initialize(self, options: lsp.InitializationOptions):
 
         self.targets = {}
         self.target_types = {}

--- a/lib/esbonio/esbonio/lsp/logger.py
+++ b/lib/esbonio/esbonio/lsp/logger.py
@@ -5,6 +5,22 @@ import logging
 
 from pygls.server import LanguageServer
 
+LOG_LEVELS = {
+    "debug": logging.DEBUG,
+    "error": logging.ERROR,
+    "info": logging.INFO,
+}
+
+
+class LogFilter:
+    """A log filter that accepts message from any of the listed logger names."""
+
+    def __init__(self, names):
+        self.names = names
+
+    def filter(self, record):
+        return any(record.name == name for name in self.names)
+
 
 class LspHandler(logging.Handler):
     """A logging handler that will send log records to an LSP client."""

--- a/lib/esbonio/esbonio/lsp/roles.py
+++ b/lib/esbonio/esbonio/lsp/roles.py
@@ -107,7 +107,7 @@ COMPLETION_TARGETS = {
 class Roles(lsp.LanguageFeature):
     """Role support for the language server."""
 
-    def initialized(self, config: lsp.SphinxConfig):
+    def initialize(self, options: lsp.InitializationOptions):
         self.discover_roles()
         self.discover_targets()
 

--- a/lib/esbonio/esbonio/lsp/sphinx.py
+++ b/lib/esbonio/esbonio/lsp/sphinx.py
@@ -18,6 +18,7 @@ from pygls.lsp.types import (
     Position,
     Range,
 )
+from sphinx import __version__ as __sphinx_version__
 from sphinx.application import Sphinx
 from sphinx.domains import Domain
 from sphinx.util import console
@@ -245,6 +246,22 @@ class SphinxManagement(lsp.LanguageFeature):
         self.logger.debug("SphinxConfig %s", self.config.dict())
         self.create_app(self.config)
         self.build_app()
+
+    def initialized(self):
+
+        if not self.rst.app:
+            return
+
+        app = self.rst.app
+        params = lsp.SphinxConfig(
+            version=__sphinx_version__,
+            confDir=app.confdir,
+            srcDir=app.srcdir,
+            buildDir=app.outdir,
+            builderName=app.builder.name,
+        )
+        self.rst.logger.debug("Final Sphinx Config: %s", params.dict(by_alias=True))
+        self.rst.send_notification("esbonio/sphinxConfiguration", params)
 
     def save(self, params: DidSaveTextDocumentParams):
 

--- a/lib/esbonio/tests/lsp/test_directives.py
+++ b/lib/esbonio/tests/lsp/test_directives.py
@@ -126,7 +126,7 @@ def test_directive_completions(sphinx, project, text, expected, unexpected):
     rst.logger = logging.getLogger("rst")
 
     feature = Directives(rst)
-    feature.initialized(None)
+    feature.initialize(None)
 
     completion_test(feature, text, expected=expected, unexpected=unexpected)
 
@@ -217,6 +217,6 @@ def test_directive_option_completions(sphinx, project, text, expected, unexpecte
     rst.logger = logging.getLogger("rst")
 
     feature = Directives(rst)
-    feature.initialized(None)
+    feature.initialize(None)
 
     completion_test(feature, text, expected=expected, unexpected=unexpected)

--- a/lib/esbonio/tests/lsp/test_intersphinx.py
+++ b/lib/esbonio/tests/lsp/test_intersphinx.py
@@ -33,7 +33,7 @@ def intersphinx(sphinx):
         rst.logger = logging.getLogger("rst")
 
         feature = InterSphinx(rst)
-        feature.initialized(None)
+        feature.initialize(None)
         instances[project] = feature
 
         return feature

--- a/lib/esbonio/tests/lsp/test_roles.py
+++ b/lib/esbonio/tests/lsp/test_roles.py
@@ -71,7 +71,7 @@ def test_role_completions(sphinx, project, text, expected, unexpected):
     rst.logger = logging.getLogger("rst")
 
     feature = Roles(rst)
-    feature.initialized(None)
+    feature.initialize(None)
 
     completion_test(feature, text, expected=expected, unexpected=unexpected)
 
@@ -252,7 +252,7 @@ def test_role_target_completions(sphinx, text, setup):
     rst.logger = logging.getLogger("rst")
 
     feature = Roles(rst)
-    feature.initialized(None)
+    feature.initialize(None)
 
     completion_test(feature, text, expected=expected, unexpected=unexpected)
 

--- a/lib/esbonio/tests/lsp/test_sphinx.py
+++ b/lib/esbonio/tests/lsp/test_sphinx.py
@@ -221,13 +221,15 @@ class TestCreateApp:
         rst.workspace.root_uri = f"file://{sphinx_default}"
 
         manager = SphinxManagement(rst)
-        manager.create_app(SphinxConfig.default())
+        manager.create_app(SphinxConfig())
 
         assert rst.app is not None
         assert rst.app.confdir == str(sphinx_default)
         assert rst.app.srcdir == str(sphinx_default)
         assert ".cache/esbonio" in rst.app.outdir
-        assert rst.app.doctreedir == os.path.join(rst.app.outdir, "doctrees")
+        assert rst.app.doctreedir == os.path.realpath(
+            os.path.join(rst.app.outdir, "..", "doctrees")
+        )
 
     def test_missing_conf(self, rst):
         """Ensure that if we cannot find a project's conf.py we notify the user."""
@@ -236,7 +238,7 @@ class TestCreateApp:
             rst.workspace.root_uri = f"file://{confdir}"
 
             manager = SphinxManagement(rst)
-            manager.create_app(SphinxConfig.default())
+            manager.create_app(SphinxConfig())
 
             assert rst.app is None
 
@@ -250,7 +252,7 @@ class TestCreateApp:
         data_dir = (sphinx_extensions / "..").resolve()
         rst.workspace.root_uri = f"file://{data_dir}"
 
-        config = SphinxConfig(conf_dir=str(sphinx_extensions))
+        config = SphinxConfig(confDir=str(sphinx_extensions))
 
         manager = SphinxManagement(rst)
         manager.create_app(config)
@@ -265,7 +267,7 @@ class TestCreateApp:
         data_dir = (sphinx_extensions / "..").resolve()
         rst.workspace.root_uri = f"file://{data_dir}"
 
-        config = SphinxConfig(conf_dir="${workspaceRoot}/sphinx-extensions")
+        config = SphinxConfig(confDir="${workspaceRoot}/sphinx-extensions")
 
         manager = SphinxManagement(rst)
         manager.create_app(config)
@@ -280,7 +282,7 @@ class TestCreateApp:
         rst.workspace.root_uri = f"file://{sphinx_srcdir}"
 
         srcdir = (sphinx_srcdir / "../sphinx-default").resolve()
-        config = SphinxConfig(src_dir=str(srcdir))
+        config = SphinxConfig(srcDir=str(srcdir))
 
         manager = SphinxManagement(rst)
         manager.create_app(config)
@@ -298,7 +300,7 @@ class TestCreateApp:
 
         srcdir = "${workspaceRoot}/sphinx-default"
         confdir = "${workspaceRoot}/sphinx-srcdir"
-        config = SphinxConfig(src_dir=srcdir, conf_dir=confdir)
+        config = SphinxConfig(srcDir=srcdir, confDir=confdir)
 
         manager = SphinxManagement(rst)
         manager.create_app(config)
@@ -315,7 +317,7 @@ class TestCreateApp:
         rst.workspace.root_uri = f"file://{sphinx_srcdir}"
 
         srcdir = "${confDir}/../sphinx-default"
-        config = SphinxConfig(src_dir=srcdir)
+        config = SphinxConfig(srcDir=srcdir)
 
         manager = SphinxManagement(rst)
         manager.create_app(config)
@@ -327,20 +329,19 @@ class TestCreateApp:
     def test_set_cache_dir(self, rst, testdata):
         """Ensure that we can override the cache dir if necessary"""
 
-        with tempfile.TemporaryDirectory() as cache_dir:
+        with tempfile.TemporaryDirectory() as build_dir:
             sphinx_default = testdata("sphinx-default", path_only=True)
 
             rst.workspace.root_uri = f"file://{sphinx_default}"
-            rst.cache_dir = cache_dir
 
             manager = SphinxManagement(rst)
-            manager.create_app(SphinxConfig.default())
+            manager.create_app(SphinxConfig(buildDir=build_dir))
 
             assert rst.app is not None
             assert rst.app.confdir == str(sphinx_default)
             assert rst.app.srcdir == str(sphinx_default)
-            assert rst.app.outdir == cache_dir
-            assert rst.app.doctreedir == os.path.join(rst.app.outdir, "doctrees")
+            assert rst.app.outdir == os.path.join(build_dir, "html")
+            assert rst.app.doctreedir == os.path.join(build_dir, "doctrees")
 
     def test_sphinx_exception(self, rst, testdata):
         """Ensure that we correctly handle the case where creating a Sphinx app throws
@@ -350,7 +351,7 @@ class TestCreateApp:
         rst.workspace.root_uri = f"file://{sphinx_error}"
 
         manager = SphinxManagement(rst)
-        manager.create_app(SphinxConfig.default())
+        manager.create_app(SphinxConfig())
 
         assert rst.app is None
 


### PR DESCRIPTION
Originally we deferred most of the startup code to the `initialzed`
notification handler and used the `workspace/configuration` request to
obtain the values we needed to create a Sphinx application. However,
the `initialize` request has a field `initializationOptions` where the
client can pass values to the server on initialization.

This pull request moves our startup code back into the `initialize` request
handler and looks for the relevant values as fields within
`initializationOptions`.

Additionally, the following cli arguments have been replaced with
configuration parameters in `initializationOptions`

- `--cache-dir` is now `esbonio.sphinx.buildDir`
- `--log-level` is now `esbonio.server.logLevel`
- `--log-filter` is now `esbonio.server.logFilter`
- `--hide-sphinx-output` is now `esbonio.server.hideSphinxOutput`

Closes #185 
Closes #192 