### PR TITLE
Fix handling of inline javascript

### DIFF
--- a/code/changes/214.fix.rst
+++ b/code/changes/214.fix.rst
@@ -1,0 +1,2 @@
+Fix handling of ``<script>`` tags without a ``src`` attribute when generating the
+HTML preview of a page.

--- a/code/changes/217.misc.rst
+++ b/code/changes/217.misc.rst
@@ -1,0 +1,1 @@
+This extension does not support untrusted workspaces.

--- a/code/package-lock.json
+++ b/code/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "esbonio",
-    "version": "0.6.2",
+    "version": "0.7.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -770,9 +770,9 @@
             }
         },
         "css-what": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/css-what/-/css-what-5.0.0.tgz",
-            "integrity": "sha512-qxyKHQvgKwzwDWC/rGbT821eJalfupxYW2qbSJSAtdSTimsr/MlaGONoNLllaUPZWf8QnbcKM/kPVYUQuEKAFA==",
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/css-what/-/css-what-5.0.1.tgz",
+            "integrity": "sha512-FYDTSHb/7KXsWICVsxdmiExPjCfRC4qRFBdVwv7Ax9hMnvMmEjP9RfxTEZ3qPZGmADDn2vAKSo9UcN1jKVYscg==",
             "dev": true
         },
         "cssom": {
@@ -3289,9 +3289,9 @@
             "dev": true
         },
         "ws": {
-            "version": "7.4.5",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.5.tgz",
-            "integrity": "sha512-xzyu3hFvomRfXKH8vOFMU3OguG6oOvhXMo3xsGy3xWExqaM2dxBbVxuD99O7m3ZUFMvvscsZDqxfgMaRr/Nr1g=="
+            "version": "7.5.0",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.0.tgz",
+            "integrity": "sha512-6ezXvzOZupqKj4jUqbQ9tXuJNo+BR2gU8fFRk3XCP3e0G6WT414u5ELe6Y0vtp7kmSJ3F7YWObSNr1ESsgi4vw=="
         },
         "xml-name-validator": {
             "version": "3.0.0",

--- a/code/package.json
+++ b/code/package.json
@@ -44,7 +44,16 @@
         "webpack-cli": "^4.7.0"
     },
     "engines": {
-        "vscode": "^1.52.0"
+        "vscode": "^1.57.0"
+    },
+    "capabilities": {
+        "virtualWorkspaces": {
+            "supported": false
+        },
+        "untrustedWorkspaces": {
+            "supported": false,
+            "description": "Building and inspecting Sphinx projects has the potential to execute arbitrary code."
+        }
     },
     "icon": "icon.png",
     "activationEvents": [

--- a/code/src/preview/view.ts
+++ b/code/src/preview/view.ts
@@ -149,8 +149,8 @@ export class PreviewManager {
     styles.forEach(stylesheet => this.rewriteHrefUrl(stylesheet, baseDir))
 
     // Rewrite script urls
-    let headScripts = head.querySelectorAll('script')
-    let bodyScripts = body.querySelectorAll('script')
+    let headScripts = head.querySelectorAll('script [src]')
+    let bodyScripts = body.querySelectorAll('script [src]')
     headScripts.forEach(script => this.rewriteSrcUrl(script, baseDir))
     bodyScripts.forEach(script => this.rewriteSrcUrl(script, baseDir))
 


### PR DESCRIPTION
- `<script>` tags that do not contain a `src` attribute no longer cause the preview generation to crash (Closes #214)
- This extension does not support untrusted workspaces (Closes #217)