### PR TITLE
Initial goto definition support

### DIFF
--- a/docs/lsp/editors/index.rst
+++ b/docs/lsp/editors/index.rst
@@ -19,7 +19,7 @@ Common Setup
 ------------
 
 The language server works by creating an instance of Sphinx's application object and
-inspecting it in order to provide completion suggestions etc.  In order for this
+inspecting it in order to provide completion suggestions etc. In order for this
 application instance to have the correct configuration, the language server needs to be
 installed into and used from the same Python environment that you use when building your
 documentation.

--- a/docs/lsp/features.rst
+++ b/docs/lsp/features.rst
@@ -7,7 +7,7 @@ Server
 Completion
 ----------
 
-The Language Server can offer auto complete suggestions in a variety of contexts
+The language server can offer auto complete suggestions in a variety of contexts
 
 .. figure:: ../../resources/images/completion-demo.gif
    :align: center
@@ -22,3 +22,12 @@ building and publish them as diagnostic messages
    :align: center
 
    Example diagnostic messages from Sphinx
+
+Goto Definition
+---------------
+
+The language server can look up the definition of certain role targets.
+Currently this is limited to just the ``:ref:`` and ``:doc:`` roles.
+
+.. figure:: ../../resources/images/definition-demo.gif
+   :align: center

--- a/lib/esbonio/changes/209.feature.rst
+++ b/lib/esbonio/changes/209.feature.rst
@@ -1,0 +1,2 @@
+Add initial goto definition support.
+Currently only support definitions for ``:ref:`` and ``:doc:`` role targets.

--- a/lib/esbonio/esbonio/lsp/__init__.py
+++ b/lib/esbonio/esbonio/lsp/__init__.py
@@ -139,9 +139,13 @@ def create_language_server(
 
         for feature in rst._features.values():
             for pattern in feature.definition_triggers:
-                match = pattern.search(line)
-                if match:
-                    definitions += feature.definition(match, doc, pos)
+                for match in pattern.finditer(line):
+                    if not match:
+                        continue
+
+                    start, stop = match.span()
+                    if start < pos.character and pos.character < stop:
+                        definitions += feature.definition(match, doc, pos)
 
         return definitions
 

--- a/lib/esbonio/esbonio/lsp/definition/__init__.py
+++ b/lib/esbonio/esbonio/lsp/definition/__init__.py
@@ -1,0 +1,17 @@
+import typing
+from typing import Optional
+
+from .domains import Domain
+from esbonio.lsp.rst import RstLanguageServer
+from esbonio.lsp.sphinx import SphinxLanguageServer
+
+if typing.TYPE_CHECKING:
+    from esbonio.lsp.roles import Roles
+
+
+def esbonio_setup(rst: RstLanguageServer):
+
+    roles = rst.get_feature("roles")  # type: Optional[Roles]
+
+    if roles and isinstance(rst, SphinxLanguageServer):
+        roles.add_definition_provider(Domain(rst))

--- a/lib/esbonio/esbonio/lsp/definition/domains.py
+++ b/lib/esbonio/esbonio/lsp/definition/domains.py
@@ -1,0 +1,103 @@
+import pathlib
+import re
+from typing import List
+from typing import Optional
+
+import pygls.uris as Uri
+from docutils.parsers.rst import nodes
+from pygls.lsp.types import Location
+from pygls.lsp.types import Position
+from pygls.lsp.types import Range
+from pygls.workspace import Document
+
+from esbonio.lsp.roles import TargetDefinition
+from esbonio.lsp.sphinx import SphinxLanguageServer
+
+
+class Domain(TargetDefinition):
+    """Looks up definitions of objects defined under Sphinx domains."""
+
+    def __init__(self, rst: SphinxLanguageServer):
+        self.rst = rst
+        self.logger = rst.logger.getChild(self.__class__.__name__)
+
+    def find_definitions(
+        self, doc: Document, match: "re.Match", name: str, domain: Optional[str]
+    ) -> List[Location]:
+
+        target = match.groupdict()["target"]
+
+        if name == "ref":
+            return self.ref_definition(target)
+
+        if name == "doc":
+            return self.doc_definition(doc, target)
+
+        return super().find_definitions(doc, match, name, domain=domain)
+
+    def doc_definition(self, doc: Document, target: str) -> List[Location]:
+        """Goto definition implementation for ``:doc:`` targets"""
+
+        srcdir = self.rst.app.srcdir
+        currentdir = pathlib.Path(Uri.to_fs_path(doc.uri)).parent
+
+        if target.startswith("/"):
+            path = str(pathlib.Path(srcdir, target[1:] + ".rst"))
+        else:
+            path = str(pathlib.Path(currentdir, target + ".rst"))
+
+        return [
+            Location(
+                uri=Uri.from_fs_path(path),
+                range=Range(
+                    start=Position(line=0, character=0),
+                    end=Position(line=1, character=0),
+                ),
+            )
+        ]
+
+    def ref_definition(self, target: str) -> List[Location]:
+        """Goto definition implementation for ``:ref:`` targets"""
+
+        std = self.rst.get_domain("std")
+        types = set(self.rst.get_role_target_types("ref"))
+
+        uri = None
+        line = None
+        docname = None
+
+        if not std:
+            return []
+
+        # _, title, _, _, anchor, priority
+        for name, _, type_, doc, _, _ in std.get_objects():
+            if type_ not in types:
+                continue
+
+            if name == target:
+                docname = doc
+                break
+
+        doctree = self.rst.get_doctree(docname)
+        for node in doctree.traverse(condition=nodes.target):
+
+            if "refid" not in node:
+                continue
+
+            if target == node["refid"].replace("-", "_"):
+                uri = Uri.from_fs_path(node.source)
+                line = node.line
+                break
+
+        if uri is None or line is None:
+            return []
+
+        return [
+            Location(
+                uri=uri,
+                range=Range(
+                    start=Position(line=line - 1, character=0),
+                    end=Position(line=line, character=0),
+                ),
+            )
+        ]

--- a/lib/esbonio/esbonio/lsp/feature.py
+++ b/lib/esbonio/esbonio/lsp/feature.py
@@ -1,3 +1,4 @@
+import re
 import typing
 from typing import List
 
@@ -5,11 +6,11 @@ from pygls.lsp.types import CompletionItem
 from pygls.lsp.types import DidSaveTextDocumentParams
 from pygls.lsp.types import InitializedParams
 from pygls.lsp.types import InitializeParams
+from pygls.lsp.types import Location
 from pygls.lsp.types import Position
 from pygls.workspace import Document
 
 if typing.TYPE_CHECKING:
-    import re
     from .rst import RstLanguageServer
 
 
@@ -29,17 +30,17 @@ class LanguageFeature:
     def save(self, params: DidSaveTextDocumentParams) -> None:
         """Called each time a document is saved."""
 
-    completion_triggers = []
-    """A list of regular expressions used to determine if the :meth`~LanguageFeature.complete`
-    method should be called on the current line."""
+    completion_triggers: List[re.Pattern] = []
+    """A list of regular expressions used to determine if the
+    :meth`~esbonio.lsp.feature.LanguageFeature.complete` method should be called on the
+    current line."""
 
     def complete(
         self, match: "re.Match", doc: Document, pos: Position
     ) -> List[CompletionItem]:
         """Called if any of the given ``completion_triggers`` match the current line.
 
-        This method should return a list of ``CompletionItem`` objects to return to the
-        client.
+        This method should return a list of ``CompletionItem`` objects.
 
         Parameters
         ----------
@@ -47,6 +48,28 @@ class LanguageFeature:
            The match object generated from the corresponding regular expression.
         doc:
            The document the completion has been requested within
+        pos:
+           The position of the request within the document.
+        """
+        return []
+
+    definition_triggers: List[re.Pattern] = []
+    """A list of regular expressions used to determine if the
+    :meth:`~esbonio.lsp.feature.LanguageFeature.definition` method should be called."""
+
+    def definition(
+        self, match: "re.Match", doc: Document, pos: Position
+    ) -> List[Location]:
+        """Called if any of the given ``definition_triggers`` match the current line.
+
+        This method should return a list of ``Location`` objects.
+
+        Parameters
+        ----------
+        match:
+           The match object generated from the corresponding regular expression.
+        doc:
+           The document the definition has been requested within
         pos:
            The position of the request within the document.
         """

--- a/lib/esbonio/esbonio/lsp/feature.py
+++ b/lib/esbonio/esbonio/lsp/feature.py
@@ -30,7 +30,7 @@ class LanguageFeature:
     def save(self, params: DidSaveTextDocumentParams) -> None:
         """Called each time a document is saved."""
 
-    completion_triggers: List[re.Pattern] = []
+    completion_triggers: List["re.Pattern"] = []
     """A list of regular expressions used to determine if the
     :meth`~esbonio.lsp.feature.LanguageFeature.complete` method should be called on the
     current line."""
@@ -53,7 +53,7 @@ class LanguageFeature:
         """
         return []
 
-    definition_triggers: List[re.Pattern] = []
+    definition_triggers: List["re.Pattern"] = []
     """A list of regular expressions used to determine if the
     :meth:`~esbonio.lsp.feature.LanguageFeature.definition` method should be called."""
 

--- a/lib/esbonio/esbonio/lsp/rst.py
+++ b/lib/esbonio/esbonio/lsp/rst.py
@@ -209,14 +209,18 @@ class RstLanguageServer(LanguageServer):
             self.logger.debug("Publishing %d diagnostics for: %s", len(diags), uri)
             self.publish_diagnostics(uri, diags.data)
 
-    def line_to_position(self, doc: Document, position: Position) -> str:
-        """Return the contents of the line up until the given position."""
+    def line_at_position(self, doc: Document, position: Position) -> str:
+        """Return the contents of the line corresponding to the given position."""
 
         try:
-            line = doc.lines[position.line]
+            return doc.lines[position.line]
         except IndexError:
             return ""
 
+    def line_to_position(self, doc: Document, position: Position) -> str:
+        """Return the contents of the line up until the given position."""
+
+        line = self.line_at_position(doc, position)
         return line[: position.character]
 
     def _configure_logging(self, config: ServerConfig):

--- a/lib/esbonio/esbonio/lsp/sphinx.py
+++ b/lib/esbonio/esbonio/lsp/sphinx.py
@@ -328,6 +328,30 @@ class SphinxLanguageServer(RstLanguageServer):
 
         return app
 
+    def get_doctree(
+        self, docname: Optional[str] = None, uri: Optional[str] = None
+    ) -> Optional[Any]:
+        """Return the doctree that corresponds with the specified document.
+
+        The ``docname`` of a document is its path relative to the project's ``srcdir``
+        minus the extension e.g. the docname of the file ``docs/lsp/features.rst``
+        would be ``lsp/features``.
+
+        Parameters
+        ----------
+        docname:
+           Returns the doctree that corresponds with the given docname
+        uri:
+           Returns the doctree that corresponds with the given uri. (Not yet
+           implemented)
+        """
+
+        if uri is not None:
+            raise NotImplementedError()
+
+        self.logger.debug("Getting doctree for '%s'", docname)
+        return self.app.env.get_and_resolve_doctree(docname, self.app.builder)
+
     def get_domain(self, name: str) -> Optional[Domain]:
         """Return the domain with the given name.
 
@@ -460,7 +484,10 @@ class SphinxLanguageServer(RstLanguageServer):
 
                     self._role_target_types[role_key] = target_types
 
-        return self._role_target_types.get(key, [])
+        types = self._role_target_types.get(key, [])
+        self.logger.debug("Role '%s' targets object types '%s'", key, types)
+
+        return types
 
     def get_role_targets(self, name: str, domain: str = "") -> List[tuple]:
         """Return a list of objects targeted by the given role.

--- a/lib/esbonio/esbonio/lsp/sphinx.py
+++ b/lib/esbonio/esbonio/lsp/sphinx.py
@@ -328,6 +328,23 @@ class SphinxLanguageServer(RstLanguageServer):
 
         return app
 
+    def get_domain(self, name: str) -> Optional[Domain]:
+        """Return the domain with the given name.
+
+        If a domain with the given name cannot be found, this method will return None.
+
+        Parameters
+        ----------
+        name:
+           The name of the domain
+        """
+
+        if self.app is None:
+            return None
+
+        domains = self.app.env.domains
+        return domains.get(name, None)
+
     def get_domains(self) -> Iterator[Tuple[str, Domain]]:
         """Get all the domains registered with an applications.
 

--- a/lib/esbonio/esbonio/lsp/sphinx.py
+++ b/lib/esbonio/esbonio/lsp/sphinx.py
@@ -350,7 +350,12 @@ class SphinxLanguageServer(RstLanguageServer):
             raise NotImplementedError()
 
         self.logger.debug("Getting doctree for '%s'", docname)
-        return self.app.env.get_and_resolve_doctree(docname, self.app.builder)
+
+        try:
+            return self.app.env.get_and_resolve_doctree(docname, self.app.builder)
+        except FileNotFoundError:
+            self.logger.debug(traceback.format_exc())
+            return None
 
     def get_domain(self, name: str) -> Optional[Domain]:
         """Return the domain with the given name.

--- a/lib/esbonio/tests/data/sphinx-default/definitions.rst
+++ b/lib/esbonio/tests/data/sphinx-default/definitions.rst
@@ -1,0 +1,14 @@
+Definition Tests
+================
+
+This file contains a number of test cases for us to test goto definition on.
+
+This line refers to the :ref:`welcome` page
+
+This line refers to the :ref:`search` page
+
+This line refers to both :ref:`welcome` and :ref:`pythagoras_theorem` pages
+
+This line refers to :ref:`this <welcome>` page
+
+Here is a reference to the :doc:`/changelog`

--- a/lib/esbonio/tests/data/sphinx-default/index.rst
+++ b/lib/esbonio/tests/data/sphinx-default/index.rst
@@ -13,6 +13,7 @@ Welcome to Defaults's documentation!
    :caption: Contents:
 
    theorems/index
+   definitions
    glossary
 
 Setup


### PR DESCRIPTION
In a similar way to completions, language features can provide a list of
`definition_triggers` which determine when the `definition` method
should be called.

The `Roles` language feature has been extended to trigger a definition
lookup on complete role definitions which then delegates to a list of
`TargetDefinition` providers which do the actual lookup.

This currently only provides goto definition support for `:doc:` and `:ref:` 
roles

Closes #209