### PR TITLE
lsp: Fix format of completion suggestions for `:option:` targets

### DIFF
--- a/lib/esbonio/changes/212.fix.rst
+++ b/lib/esbonio/changes/212.fix.rst
@@ -1,0 +1,1 @@
+Completion suggestions for ``:option:`` targets now insert text in the correct format (``<progname> <option>``)

--- a/lib/esbonio/tests/data/sphinx-default/index.rst
+++ b/lib/esbonio/tests/data/sphinx-default/index.rst
@@ -19,7 +19,7 @@ Welcome to Defaults's documentation!
 Setup
 =====
 
-In order to run the program you need a few environment variables set.
+The program supports specifying configuration values through environment variables.
 
 .. envvar:: ANGLE_UNIT
 
@@ -31,3 +31,19 @@ In order to run the program you need a few environment variables set.
    Use this to set the level of precision used when manipulating floating point numbers.
    Its value is an integer which represents the number of decimal places to use, default
    value is ``2``
+
+Alternatively they can be set through command line options
+
+.. program:: pythag
+
+.. option:: -e, --exact
+
+   Output results exactly (as a rational number)
+
+.. option:: -u <unit>, --unit <unit>
+
+   Specify the angle units to use can be one of ``degrees``, ``radians`` or ``gradians``.
+
+.. option:: -p <prescision>, --precision <precision>
+
+   The number of decimal places to use. This option is ignored when using :option:`pythag --exact`

--- a/lib/esbonio/tests/test_roles.py
+++ b/lib/esbonio/tests/test_roles.py
@@ -478,10 +478,59 @@ async def test_role_target_definitions(
                 ),
             ],
         ),
+        *itertools.product(
+            role_target_patterns("option"),
+            [
+                (
+                    "sphinx-default",
+                    {
+                        "pythag -e",
+                        "pythag --exact",
+                        "pythag -u",
+                        "pythag --unit",
+                        "pythag -p",
+                        "pythag --precision",
+                    },
+                    None,
+                )
+            ],
+        ),
     ],
 )
 async def test_role_target_completions(client_server, text, setup):
-    """Ensure that we can offer correct role target suggestions."""
+    """Ensure that we can offer correct role target suggestions.
+
+    This test case is focused on the list of completion items we return for a
+    given completion request. This ensures we correctly handle differing sphinx
+    configurations and extensions while discovering the available roles.
+
+    Cases are parameterized and the inputs are expected to have the following format::
+
+       (":ref:`", ("sphinx-project", {'expected'}, {'unexpected'}))
+
+    where:
+
+    - ``"sphinx-project"`` corresponds to the name of one of the example Sphinx projects
+      in the ``tests/data/`` folder.
+    - ``{'expected'}`` is the set of completion item labels you expect to see returned
+      from the completion request. Can be ``None`` which will assert that no completions
+      are returned.
+    - ``{'unexpected'}`` is the set of completion item labels you **do not** expect to
+      see returned from the completion request.
+
+    A common pattern where a number of different values for ``text`` should produce the
+    same set of results within a given setup, is to make use of
+    :func:`python:itertools.product` to generate all combinations of setups.
+
+    Parameters
+    ----------
+    client_server:
+       The client_server fixture used to drive the test.
+    text:
+       The text providing the context of the completion request.
+    setup:
+       The tuple providing the rest of the setup for the test.
+    """
 
     project, expected, unexpected = setup
 


### PR DESCRIPTION
Closes #212 