### PR TITLE
Align vscode to changes in the language server

### DIFF
--- a/code/src/constants.ts
+++ b/code/src/constants.ts
@@ -3,7 +3,7 @@ export const PYTHON_EXTENSION = "ms-python.python"
 
 export namespace Server {
   export const REQUIRED_PYTHON = "3.6.0"
-  export const REQUIRED_VERSION = "0.6.0"
+  export const REQUIRED_VERSION = "0.7.0"
 }
 
 export namespace Commands {

--- a/code/src/lsp/client.ts
+++ b/code/src/lsp/client.ts
@@ -130,7 +130,7 @@ export class EsbonioClient {
    * Start the language client.
    */
   async start(): Promise<void> {
-    this.statusBar.text = "$(sync~spin) Starting."
+    this.statusBar.text = "$(sync~spin) Starting..."
     this.statusBar.show()
     if (DEBUG) {
       this.client = await this.getTcpClient()
@@ -160,21 +160,11 @@ export class EsbonioClient {
       }
 
       await this.client.onReady()
-      this.client.onNotification("esbonio/sphinxConfiguration", params => {
-        this.sphinxConfig = params
-        this.statusBar.text = `$(check) Sphinx v${this.sphinxConfig.version}`
-      })
+      this.configureHandlers()
 
-      this.client.onNotification("esbonio/buildComplete", params => {
-        this.logger.debug("Build complete")
-        if (this.buildCompleteCallback) {
-          this.buildCompleteCallback()
-        }
-      })
-
-      return
     } catch (err) {
       this.statusBar.text = "$(error) Failed."
+      this.logger.error(err)
     }
   }
 
@@ -239,6 +229,35 @@ export class EsbonioClient {
       serverOptions,
       this.getLanguageClientOptions()
     )
+  }
+
+  private configureHandlers() {
+
+    this.client.onNotification("esbonio/buildStart", params => {
+      this.statusBar.text = "$(sync~spin) Building..."
+      this.logger.debug("Build start.")
+    })
+
+    this.client.onNotification("esbonio/buildComplete", params => {
+      this.logger.debug(`Build complete ${JSON.stringify(params)}`)
+      this.sphinxConfig = params.config.sphinx
+
+      let icon;
+
+      if (params.error) {
+        icon = "$(error)"
+      } else if (params.warnings > 0) {
+        icon = `$(warning) ${params.warnings}`
+      } else {
+        icon = "$(check)"
+      }
+
+      this.statusBar.text = `${icon} Sphinx[${this.sphinxConfig.builderName}] v${this.sphinxConfig.version}`
+
+      if (this.buildCompleteCallback) {
+        this.buildCompleteCallback()
+      }
+    })
   }
 
   /**

--- a/lib/esbonio/esbonio/lsp/sphinx.py
+++ b/lib/esbonio/esbonio/lsp/sphinx.py
@@ -209,11 +209,9 @@ class SphinxLanguageServer(RstLanguageServer):
         self.user_config = InitializationOptions(**params.initialization_options)
 
         self.app = self._initialize_sphinx()
-        self.build()
 
     def initialized(self, params: InitializedParams):
-        # Diagnostics cannot be reported during initialize, so report them now
-        self.sync_diagnostics()
+        self.build()
 
     def _initialize_sphinx(self):
 


### PR DESCRIPTION
This aligns to the changes made in the language server including
- The removal of the `esbonio/sphinxConfiguration` notification
- The addition of the `esbonio/buildStart` notification
- The inclusion of parameters to the `esbonio/buildComplete`
  notification.

This commit also makes the statusbar item more informative, where
- The sphinx builder name is reported
- Whether or not a sphinx build is in progress.
- The result of that build (ok, warnings + how many, error)