### PR TITLE
Better handling of existing text with completions

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -49,7 +49,7 @@
             ],
             "preLaunchTask": "${defaultBuildTask}",
             "env": {
-                // "VSCODE_LSP_DEBUG": "true"
+                "VSCODE_LSP_DEBUG": "true"
             }
         },
         {

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -8,9 +8,11 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-# import os
-# import sys
-# sys.path.insert(0, os.path.abspath('.'))
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath("../lib/esbonio"))
+
 from sphinx.application import Sphinx
 
 import esbonio.lsp

--- a/docs/contributing/lsp/roles.rst
+++ b/docs/contributing/lsp/roles.rst
@@ -2,3 +2,8 @@ Roles
 =====
 
 .. automodule:: esbonio.lsp.roles
+
+Test Cases
+----------
+
+.. automodule:: tests.test_roles

--- a/lib/esbonio/changes/223.fix.rst
+++ b/lib/esbonio/changes/223.fix.rst
@@ -1,0 +1,1 @@
+``CompletionItems`` should no longer corrupt existing text when selected.

--- a/lib/esbonio/esbonio/lsp/completion/domains.py
+++ b/lib/esbonio/esbonio/lsp/completion/domains.py
@@ -85,10 +85,10 @@ class Domain(TargetCompletion):
         groups = context.match.groupdict()
         name = groups["name"]
         domain = groups["domain"] or None
-        target = groups["target"]
+        label = groups["label"]
 
-        if ":" in target:
-            return self.complete_intersphinx_targets(name, domain, target)
+        if ":" in label:
+            return self.complete_intersphinx_targets(name, domain, label)
 
         items = [
             object_to_completion_item(o)
@@ -102,10 +102,10 @@ class Domain(TargetCompletion):
         return items
 
     def complete_intersphinx_targets(
-        self, name, domain, target
+        self, name: str, domain: str, label: str
     ) -> List[CompletionItem]:
         items = []
-        project, *_ = target.split(":")
+        project, *_ = label.split(":")
         intersphinx_targets = self.rst.get_intersphinx_targets(project, name, domain)
 
         for type_, targets in intersphinx_targets.items():

--- a/lib/esbonio/esbonio/lsp/completion/domains.py
+++ b/lib/esbonio/esbonio/lsp/completion/domains.py
@@ -22,7 +22,7 @@ TARGET_KINDS = {
 
 
 def intersphinx_target_to_completion_item(
-    label: str, target: tuple, type_: str
+    project: str, label: str, target: tuple, type_: str
 ) -> CompletionItem:
 
     # _. _. url, _
@@ -38,7 +38,7 @@ def intersphinx_target_to_completion_item(
         label=label,
         detail=f"{display_name} - {source}{version}",
         kind=TARGET_KINDS.get(completion_kind, CompletionItemKind.Reference),
-        insert_text=label,
+        insert_text=f"{project}:{label}",
     )
 
 
@@ -110,7 +110,7 @@ class Domain(TargetCompletion):
 
         for type_, targets in intersphinx_targets.items():
             items += [
-                intersphinx_target_to_completion_item(label, target, type_)
+                intersphinx_target_to_completion_item(project, label, target, type_)
                 for label, target in targets.items()
             ]
 

--- a/lib/esbonio/esbonio/lsp/completion/filepaths.py
+++ b/lib/esbonio/esbonio/lsp/completion/filepaths.py
@@ -103,8 +103,8 @@ class Filepath(ArgumentCompletion, TargetCompletion):
 
         groups = context.match.groupdict()
 
-        if "target" in groups:
-            partial_path = groups["target"]
+        if "role" in groups:
+            partial_path = groups["label"]
         else:
             partial_path = groups["argument"]
 

--- a/lib/esbonio/esbonio/lsp/completion/filepaths.py
+++ b/lib/esbonio/esbonio/lsp/completion/filepaths.py
@@ -1,12 +1,13 @@
 """Completion provider for filepaths."""
 import pathlib
-import re
 from typing import List
 
 import pygls.uris as uri
 from pygls.lsp.types import CompletionItem
 from pygls.lsp.types import CompletionItemKind
-from pygls.workspace import Document
+from pygls.lsp.types import Position
+from pygls.lsp.types import Range
+from pygls.lsp.types import TextEdit
 
 from esbonio.lsp.directives import ArgumentCompletion
 from esbonio.lsp.feature import CompletionContext
@@ -14,14 +15,69 @@ from esbonio.lsp.roles import TargetCompletion
 from esbonio.lsp.sphinx import SphinxLanguageServer
 
 
-def path_to_completion_item(path: pathlib.Path) -> CompletionItem:
+def path_to_completion_item(
+    context: CompletionContext, path: pathlib.Path
+) -> CompletionItem:
+    """Create the ``CompletionItem`` for the given path.
 
+    In the case where there are multiple filepath components, this function needs to
+    provide an appropriate ``TextEdit`` so that the most recent entry in the path can
+    be easily edited - without clobbering the existing path.
+
+    Also bear in mind that this function must play nice with both role target and
+    directive argument completions.
+    """
+
+    new_text = f"{path.name}"
     kind = CompletionItemKind.Folder if path.is_dir() else CompletionItemKind.File
+
+    # If we can't find the '/' we may as well not bother with a `TextEdit` and let the
+    # `Roles` feature provide the default handling.
+    start = find_start_char(context)
+    if start == -1:
+        insert_text = new_text
+        filter_text = None
+        text_edit = None
+    else:
+
+        start += 1
+        _, end = context.match.span()
+        prefix = context.match.group(0)[start:]
+
+        insert_text = None
+        filter_text = (
+            f"{prefix}{new_text}"  # Needed so VSCode will actually show the results.
+        )
+
+        text_edit = TextEdit(
+            range=Range(
+                start=Position(line=context.position.line, character=start),
+                end=Position(line=context.position.line, character=end),
+            ),
+            new_text=new_text,
+        )
+
     return CompletionItem(
-        label=str(path.name),
+        label=new_text,
         kind=kind,
-        insert_text=f"{path.name}",
+        insert_text=insert_text,
+        filter_text=filter_text,
+        text_edit=text_edit,
     )
+
+
+def find_start_char(context: CompletionContext) -> int:
+    matched_text = context.match.group(0)
+    idx = matched_text.find("/")
+
+    while True:
+        next_idx = matched_text.find("/", idx + 1)
+        if next_idx == -1:
+            break
+
+        idx = next_idx
+
+    return idx
 
 
 class Filepath(ArgumentCompletion, TargetCompletion):
@@ -35,19 +91,17 @@ class Filepath(ArgumentCompletion, TargetCompletion):
 
         name = context.match.groupdict()["name"]
         if name in {"image", "figure", "include", "literalinclude"}:
-            return self.complete_filepaths(context.doc, context.match)
+            return self.complete_filepaths(context)
 
     def complete_targets(self, context: CompletionContext) -> List[CompletionItem]:
 
         name = context.match.groupdict()["name"]
         if name in {"download"}:
-            return self.complete_filepaths(context.doc, context.match)
+            return self.complete_filepaths(context)
 
-    def complete_filepaths(
-        self, doc: Document, match: "re.Match"
-    ) -> List[CompletionItem]:
+    def complete_filepaths(self, context: CompletionContext) -> List[CompletionItem]:
 
-        groups = match.groupdict()
+        groups = context.match.groupdict()
 
         if "target" in groups:
             partial_path = groups["target"]
@@ -63,7 +117,7 @@ class Filepath(ArgumentCompletion, TargetCompletion):
             partial_path = partial_path[1:]
         else:
             # Otherwise they're relative to the current file.
-            filepath = uri.to_fs_path(doc.uri)
+            filepath = uri.to_fs_path(context.doc.uri)
             candidate_dir = pathlib.Path(filepath).parent
 
         candidate_dir /= pathlib.Path(partial_path)
@@ -71,4 +125,4 @@ class Filepath(ArgumentCompletion, TargetCompletion):
         if partial_path and not partial_path.endswith("/"):
             candidate_dir = candidate_dir.parent
 
-        return [path_to_completion_item(p) for p in candidate_dir.glob("*")]
+        return [path_to_completion_item(context, p) for p in candidate_dir.glob("*")]

--- a/lib/esbonio/esbonio/lsp/definition/domains.py
+++ b/lib/esbonio/esbonio/lsp/definition/domains.py
@@ -27,26 +27,26 @@ class Domain(TargetDefinition):
         self, doc: Document, match: "re.Match", name: str, domain: Optional[str]
     ) -> List[Location]:
 
-        target = match.groupdict()["target"]
+        label = match.groupdict()["label"]
 
         if name == "ref":
-            return self.ref_definition(target)
+            return self.ref_definition(label)
 
         if name == "doc":
-            return self.doc_definition(doc, target)
+            return self.doc_definition(doc, label)
 
         return super().find_definitions(doc, match, name, domain=domain)
 
-    def doc_definition(self, doc: Document, target: str) -> List[Location]:
+    def doc_definition(self, doc: Document, label: str) -> List[Location]:
         """Goto definition implementation for ``:doc:`` targets"""
 
         srcdir = self.rst.app.srcdir
         currentdir = pathlib.Path(Uri.to_fs_path(doc.uri)).parent
 
-        if target.startswith("/"):
-            path = str(pathlib.Path(srcdir, target[1:] + ".rst"))
+        if label.startswith("/"):
+            path = str(pathlib.Path(srcdir, label[1:] + ".rst"))
         else:
-            path = str(pathlib.Path(currentdir, target + ".rst"))
+            path = str(pathlib.Path(currentdir, label + ".rst"))
 
         return [
             Location(
@@ -58,13 +58,13 @@ class Domain(TargetDefinition):
             )
         ]
 
-    def ref_definition(self, target: str) -> List[Location]:
+    def ref_definition(self, label: str) -> List[Location]:
         """Goto definition implementation for ``:ref:`` targets"""
 
         std = self.rst.get_domain("std")
         types = set(self.rst.get_role_target_types("ref"))
 
-        docname = self.find_docname_for_target(target, std, types)
+        docname = self.find_docname_for_label(label, std, types)
         if docname is None:
             return []
 
@@ -80,7 +80,7 @@ class Domain(TargetDefinition):
             if "refid" not in node:
                 continue
 
-            if target == node["refid"].replace("-", "_"):
+            if label == node["refid"].replace("-", "_"):
                 uri = Uri.from_fs_path(node.source)
                 line = node.line
                 break
@@ -98,20 +98,20 @@ class Domain(TargetDefinition):
             )
         ]
 
-    def find_docname_for_target(
-        self, target: str, domain: Domain, types: Optional[Set[str]] = None
+    def find_docname_for_label(
+        self, label: str, domain: Domain, types: Optional[Set[str]] = None
     ) -> Optional[str]:
-        """Given the target name and domain it belongs to, return the docname its
+        """Given the label name and domain it belongs to, return the docname its
         definition resides in.
 
         Parameters
         ----------
-        target:
-           The target to search for
+        label:
+           The label to search for
         domain:
            The domain to search within
         types:
-           A collection of object types that the target chould have.
+           A collection of object types that the label chould have.
         """
 
         docname = None
@@ -124,7 +124,7 @@ class Domain(TargetDefinition):
             if types and type_ not in types:
                 continue
 
-            if name == target:
+            if name == label:
                 docname = doc
                 break
 

--- a/lib/esbonio/esbonio/lsp/directives.py
+++ b/lib/esbonio/esbonio/lsp/directives.py
@@ -18,33 +18,30 @@ from esbonio.lsp import RstLanguageServer
 
 DIRECTIVE = re.compile(
     r"""
-    (?P<indent>\s*)             # directives can be indented
-    (?P<directive>\.\.          # start with a comment
-    [ ]                         # separated by a space
-    (?P<domain>[\w]+:)?         # with an optional domain namespace
-    (?P<name>[\w-]+))           # with a name
-    ::
-    ([\s]+(?P<argument>.*$))?   # some directives may take an argument
+    (\s*)                           # directives can be indented
+    (?P<directive>
+      \.\.                          # directives start with a comment
+      [ ]?                          # followed by a space
+      ((?P<domain>[\w]+):(?!:))?    # directives may include a domain
+      (?P<name>[\w-]+)?             # directives have a name
+      (::)?                         # directives end with '::'
+    )
+    ([\s]+(?P<argument>.*$))?       # directives may take an argument
     """,
     re.VERBOSE,
 )
-"""A regular expression that matches a complete, valid directive declaration. Not
-including any options or content."""
+"""A regular expression to detect and parse partial and complete directives.
 
+This does **not** include any options or content that may be included underneath
+the initial declaration. The language server breaks a directive down into a number
+of parts::
 
-PARTIAL_DIRECTIVE = re.compile(
-    r"""
-    (?P<indent>^\s*)          # directives can be indented
-    \.\.                      # start with a commment
-    (?P<prefix>[ ]?)          # may have a space
-    (?P<domain>[\w]+:)?       # with an optional domain namespace
-    (?P<name>[\w-]+)?         # with an optional name
-    $
-    """,
-    re.VERBOSE,
-)
-"""A regular expression that matches a partial directive declaraiton. Used when
-generating auto complete suggestions."""
+                   vvvvvv argument
+   .. c:function:: malloc
+   ^^^^^^^^^^^^^^^ directive
+        ^^^^^^^^ name
+      ^ domain (optional)
+"""
 
 
 PARTIAL_DIRECTIVE_OPTION = re.compile(
@@ -88,7 +85,7 @@ class Directives(LanguageFeature):
     def add_argument_provider(self, provider: ArgumentCompletion) -> None:
         self._argument_providers.append(provider)
 
-    completion_triggers = [DIRECTIVE, PARTIAL_DIRECTIVE, PARTIAL_DIRECTIVE_OPTION]
+    completion_triggers = [DIRECTIVE, PARTIAL_DIRECTIVE_OPTION]
 
     def complete(self, context: CompletionContext) -> List[CompletionItem]:
 
@@ -98,16 +95,21 @@ class Directives(LanguageFeature):
 
         groups = context.match.groupdict()
 
-        if "argument" in groups:
+        # Are we completing a directive's options?
+        if "directive" not in groups:
+            return self.complete_options(context)
+
+        # Are we completing the directive's argument?
+        directive_end = context.match.span()[0] + len(groups["directive"])
+        complete_directive = groups["directive"].endswith("::")
+
+        if complete_directive and directive_end < context.position.character:
             return self.complete_arguments(context)
 
-        if "domain" in groups:
-            return self.complete_directives(context)
-
-        return self.complete_options(context)
+        return self.complete_directives(context)
 
     def complete_arguments(self, context: CompletionContext) -> List[CompletionItem]:
-
+        self.logger.debug("Completing arguments")
         arguments = []
 
         for provide in self._argument_providers:
@@ -116,25 +118,52 @@ class Directives(LanguageFeature):
         return arguments
 
     def complete_directives(self, context: CompletionContext) -> List[CompletionItem]:
+        self.logger.debug("Completing directives")
 
-        domain = context.match.groupdict()["domain"] or ""
         items = []
+        match = context.match
+        groups = match.groupdict()
+
+        domain = ""
+        if groups["domain"]:
+            domain = f'{groups["domain"]}:'
+
+        # Calculate the range of text the CompletionItems should edit.
+        # If there is an existing argument to the directive, we should leave it untouched
+        # otherwise, edit the whole line to insert any required arguments.
+        start = match.span()[0] + match.group(0).find(".")
+        include_argument = True
+        end = match.span()[1]
+
+        if groups["argument"]:
+            include_argument = False
+            end = match.span()[0] + match.group(0).find("::") + 2
+
+        range_ = Range(
+            start=Position(line=context.position.line, character=start),
+            end=Position(line=context.position.line, character=end),
+        )
 
         for name, directive in self.rst.get_directives().items():
 
             if not name.startswith(domain):
                 continue
 
-            item = self.directive_to_completion_item(name, directive, context)
+            item = self.directive_to_completion_item(
+                name, directive, context, include_argument=include_argument
+            )
+            item.text_edit = TextEdit(range=range_, new_text=item.insert_text)
+            item.insert_text = None
+
+            self.logger.debug(item)
             items.append(item)
 
         return items
 
     def complete_options(self, context: CompletionContext) -> List[CompletionItem]:
-
+        self.logger.debug("Completing options")
         groups = context.match.groupdict()
 
-        self.logger.info("Suggesting options")
         self.logger.debug("Match groups: %s", groups)
 
         indent = groups["indent"]
@@ -163,52 +192,13 @@ class Directives(LanguageFeature):
         return self.options_to_completion_items(options)
 
     def directive_to_completion_item(
-        self, name: str, directive: Directive, context: CompletionContext
+        self,
+        name: str,
+        directive: Directive,
+        context: CompletionContext,
+        include_argument: bool = True,
     ) -> CompletionItem:
         """Convert an rst directive to its CompletionItem representation.
-
-        Previously, it was fine to pre-convert directives into their completion item
-        representation during the :meth:`discover` phase. However a number of factors
-        combined to force this to be something we have to compute specifically for each
-        completion site.
-
-        It all stems from directives that live under a namespaced domain e.g.
-        ``.. c:macro::``. First in order to get trigger character completions for
-        directives, we need to allow users to start typing the directive name
-        immediately after the second dot and have the CompletionItem insert the leading
-        space. Which is exactly what we used to do, setting
-        ``insert_text=" directive::"`` and we were done.
-
-        However with domain support, we introduced the possibility of a ``:`` character
-        in the name of a directive. You can imagine a scenario where a user types in a
-        domain namespace, say ``py:`` in order to filter down the list of options to
-        directives that belong to that namespace. With ``:`` being a trigger character
-        for role completions and the like, this would cause editors like VSCode to issue
-        a new completion request ignoring the old one.
-
-        That isn't necessarily the end of the world, but with CompletionItems assuming
-        that they were following the ``..`` characters, the ``insert_text`` was no
-        longer correct leading to broken completions like ``..py: py:function::``.
-
-        In order to handle the two scenarios, conceptually the easiest approach is to
-        switch to using a ``text_edit`` and replace the entire line with the correct
-        text. Unfortunately in practice this was rather fiddly.
-
-        Upon first setting the ``text_edit`` field VSCode suddenly stopped presenting
-        any options! After much debugging, head scratching and searching, I eventually
-        found a `couple <https://github.com/microsoft/vscode/issues/38982>`_ of
-        `issues <https://github.com/microsoft/vscode/issues/41208>`_ that hinted as to
-        what was happening.
-
-        I **think** what happens is that since the ``range`` of the text edit extends
-        back to the start of the line VSCode considers the entire line to be the filter
-        for the CompletionItems so it's looking to select items that start with ``..``
-        - which is none of them!
-
-        To work around this, we additionaly need to set the ``filter_text`` field so
-        that VSCode computes matches against that instead of the label. Then in order
-        for the items to be shown the value of that field needs to be ``..my:directive``
-        so it corresponds with what the user has actually written.
 
         Parameters
         ----------
@@ -219,13 +209,13 @@ class Directives(LanguageFeature):
            The class definition that implements the Directive's behavior
         context:
            The completion context
+        include_argument:
+           A flag that indicates if a placholder for any directive arguments should
+           be included
         """
-        position = context.position
-        groups = context.match.groupdict()
-        prefix = groups["prefix"]
-        indent = groups["indent"]
-
+        args = ""
         documentation = inspect.getdoc(directive)
+        insert_format = InsertTextFormat.PlainText
 
         # Ignore directives that do not provide their own documentation.
         if any(
@@ -237,25 +227,23 @@ class Directives(LanguageFeature):
             documentation = None
 
         # TODO: Give better names to arguments based on what they represent.
-        args = " ".join(
-            "${{{0}:arg{0}}}".format(i)
-            for i in range(1, directive.required_arguments + 1)
-        )
+        if include_argument:
+            insert_format = InsertTextFormat.Snippet
+            args = " " + " ".join(
+                "${{{0}:arg{0}}}".format(i)
+                for i in range(1, directive.required_arguments + 1)
+            )
+
+        insert_text = f".. {name}::{args}"
 
         return CompletionItem(
             label=name,
             kind=CompletionItemKind.Class,
             detail="directive",
             documentation=documentation,
-            filter_text=f"..{prefix}{name}",
-            insert_text_format=InsertTextFormat.Snippet,
-            text_edit=TextEdit(
-                range=Range(
-                    start=Position(line=position.line, character=0),
-                    end=Position(line=position.line, character=position.character - 1),
-                ),
-                new_text=f"{indent}.. {name}:: {args}",
-            ),
+            filter_text=insert_text,
+            insert_text=insert_text,
+            insert_text_format=insert_format,
         )
 
     def options_to_completion_items(self, options) -> List[CompletionItem]:

--- a/lib/esbonio/esbonio/lsp/feature.py
+++ b/lib/esbonio/esbonio/lsp/feature.py
@@ -35,6 +35,12 @@ class CompletionContext:
         self.position = position
         """The position at which the completion request was made."""
 
+    def __repr__(self):
+        p = f"{self.position.line}:{self.position.character}"
+        return (
+            f"CompletionContext<{self.doc.uri}:{p} ({self.location}) -- {self.match}>"
+        )
+
 
 class LanguageFeature:
     """Base class for language features."""

--- a/lib/esbonio/esbonio/lsp/sphinx.py
+++ b/lib/esbonio/esbonio/lsp/sphinx.py
@@ -98,11 +98,17 @@ class SphinxLogHandler(LspHandler):
     def __init__(self, app, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
+        self.app = app
         self.translator = WarningLogRecordTranslator(app)
         self.only_once = OnceFilter()
         self.diagnostics: Dict[str, List[Diagnostic]] = {}
 
     def get_location(self, location: str) -> Tuple[str, Optional[int]]:
+
+        if not location:
+            conf = pathlib.Path(self.app.confdir, "conf.py")
+            return (str(conf), None)
+
         path, *parts = location.split(":")
         lineno = None
 

--- a/lib/esbonio/esbonio/lsp/testing.py
+++ b/lib/esbonio/esbonio/lsp/testing.py
@@ -115,6 +115,10 @@ class ClientServer:
         self.server_thread.start()
         self.client_thread.start()
 
+        # Give the client and server some time to initialize
+        while self.server.lsp.transport is None or self.client.lsp.transport is None:
+            await asyncio.sleep(0.1)
+
         response = await self.client.lsp.send_request_async(
             INITIALIZE,
             InitializeParams(

--- a/lib/esbonio/esbonio/lsp/testing.py
+++ b/lib/esbonio/esbonio/lsp/testing.py
@@ -267,9 +267,7 @@ def intersphinx_target_patterns(name: str, project: str) -> List[str]:
 
 
 async def completion_request(
-    test: ClientServer,
-    test_uri: str,
-    text: str,
+    test: ClientServer, test_uri: str, text: str, character: Optional[int] = None
 ) -> CompletionList:
     """Make a completion request to a language server.
 
@@ -304,6 +302,9 @@ async def completion_request(
        The uri the completion request should be made within.
     text
        The text that provides the context for the completion request.
+    character:
+       The character index at which to make the completion request from.
+       If ``None``, it will default to the end of the inserted text.
     """
 
     if "\f" in text:
@@ -329,9 +330,9 @@ async def completion_request(
 
     lines = contents.split("\n")
     line = len(lines) - 1
-    character = len(lines[-1])
+    insertion_point = len(lines[-1])
 
-    logger.debug("Insertion pos: (%d, %d)", line, character)
+    logger.debug("Insertion pos: (%d, %d)", line, insertion_point)
 
     test.client.lsp.notify(
         TEXT_DOCUMENT_DID_CHANGE,
@@ -340,8 +341,8 @@ async def completion_request(
             content_changes=[
                 TextDocumentContentChangeEvent(
                     range=Range(
-                        start=Position(line=line, character=character),
-                        end=Position(line=line, character=character + len(text)),
+                        start=Position(line=line, character=insertion_point),
+                        end=Position(line=line, character=insertion_point + len(text)),
                     ),
                     text=text,
                 )
@@ -349,11 +350,12 @@ async def completion_request(
         ),
     )
 
+    character = character or insertion_point + len(text)
     response = await test.client.lsp.send_request_async(
         COMPLETION,
         CompletionParams(
             text_document=TextDocumentIdentifier(uri=test_uri),
-            position=Position(line=line, character=character + len(text)),
+            position=Position(line=line, character=character),
         ),
     )
 

--- a/lib/esbonio/pyproject.toml
+++ b/lib/esbonio/pyproject.toml
@@ -60,6 +60,7 @@ deps =
     pytest
     pytest-asyncio
     pytest-cov
+    pytest-timeout
 commands =
     pytest --tb=short --cov=esbonio.lsp {posargs}
 

--- a/lib/esbonio/pyproject.toml
+++ b/lib/esbonio/pyproject.toml
@@ -2,6 +2,12 @@
 requires = ["setuptools >= 35.0.2", "wheel >= 0.29.0"]
 build-backend = "setuptools.build_meta"
 
+[tool.pytest.ini_options]
+filterwarnings = [
+     "ignore:'contextfunction' is renamed to 'pass_context',*:DeprecationWarning",
+     "ignore:'environmentfilter' is renamed to 'pass_environment',*:DeprecationWarning"
+]
+
 [tool.towncrier]
 filename = "CHANGES.rst"
 directory = "changes/"

--- a/lib/esbonio/setup.cfg
+++ b/lib/esbonio/setup.cfg
@@ -41,7 +41,7 @@ console_scripts =
     esbonio = esbonio.cli:main
 
 [options.extras_require]
-dev = black ; flake8 ; pre-commit ; pytest ; pytest-asyncio ; pytest-cov ; tox
+dev = black ; flake8 ; pre-commit ; pytest ; pytest-asyncio ; pytest-cov ; pytest-timeout ; tox
 lsp =
 
 [flake8]

--- a/lib/esbonio/setup.cfg
+++ b/lib/esbonio/setup.cfg
@@ -46,4 +46,4 @@ lsp =
 
 [flake8]
 max-line-length = 88
-ignore = E501,W503
+ignore = E501,W503,E402

--- a/lib/esbonio/tests/test_directives.py
+++ b/lib/esbonio/tests/test_directives.py
@@ -157,6 +157,12 @@ C_FUNC_OPTS = {"noindex"} if sphinx_version(eq=2) else {"noindexentry"}
     "project,text,expected,unexpected",
     [
         ("sphinx-default", ".. image:: f.png\n\f   :", IMAGE_OPTS, {"ref", "func"}),
+        (
+            "sphinx-default",
+            ".. image:: f.png\n   :align:\n\f   :",
+            IMAGE_OPTS,
+            {"ref", "func"},
+        ),
         ("sphinx-default", ".. function:: foo\n\f   :", PY_FUNC_OPTS, {"ref", "func"}),
         (
             "sphinx-default",

--- a/lib/esbonio/tests/test_roles.py
+++ b/lib/esbonio/tests/test_roles.py
@@ -274,7 +274,6 @@ async def test_completion_suppression(client_server, extension, setup):
     test = await client_server("sphinx-default")
     test_uri = test.server.workspace.root_uri + f"/test.{extension}"
 
-    print(extension, setup)
     text, expected, character = setup
 
     results = await completion_request(test, test_uri, text, character=character)

--- a/lib/esbonio/tests/test_roles.py
+++ b/lib/esbonio/tests/test_roles.py
@@ -188,7 +188,7 @@ async def test_role_insert_range(
 
     - ``"sphinx-default"`` corresponds to the Sphinx project to execute the test case
       within.
-    - ``"some :ref"`` corresponds to the text to insert to the test file.
+    - ``"some :ref"`` corresponds to the text to insert into the test file.
     - ``7`` is the character index to trigger the completion request at.
     - ``Range(...)`` the expected range the resulting ``CompletionItems`` should modify
 
@@ -944,7 +944,8 @@ def test_role_regex(string, expected):
 
     As a general rule, it's better to write tests at the LSP protocol level as that
     decouples the test cases from the implementation. However, roles and the
-    corresponding regular expression are complex enough to warrant test case on its own.
+    corresponding regular expression are complex enough to warrant a test case on its
+    own.
 
     As with most test cases, this one is parameterized with the following arguments::
 

--- a/lib/esbonio/tests/test_sphinx.py
+++ b/lib/esbonio/tests/test_sphinx.py
@@ -54,6 +54,7 @@ async def cs():
 
 
 @py.test.mark.asyncio
+@py.test.mark.timeout(10)
 @py.test.mark.parametrize(
     "root,options,expected",
     [
@@ -287,6 +288,7 @@ async def test_initialization_missing_conf(cs, testdata):
 
 
 @py.test.mark.asyncio
+@py.test.mark.timeout(10)
 @py.test.mark.parametrize(
     "good,bad,expected",
     [


### PR DESCRIPTION
Phew! That seemed like a lot of effort for what should've been a "small" bugfix, anyway to summarize

`CompletionItems` throughout the language server should now use the `text_edit` field to specify any text that should be overridden and ensure that items are inserted cleanly into the document. Closes #223 

A number of additional fixes and cleanups have been included along the way.
