### PR TITLE
Preserve role target modifiers

### DIFF
--- a/lib/esbonio/changes/211.fix.rst
+++ b/lib/esbonio/changes/211.fix.rst
@@ -1,0 +1,1 @@
+Role target ``CompletionItems`` now preserve additional cross reference modifiers like ``!`` and ``~``

--- a/lib/esbonio/esbonio/lsp/__init__.py
+++ b/lib/esbonio/esbonio/lsp/__init__.py
@@ -77,7 +77,6 @@ def create_language_server(
 
     @server.feature(INITIALIZE)
     def on_initialize(rst: server_cls, params: InitializeParams):
-        rst.logger.debug("%s: %s", INITIALIZE, dump(params))
         rst.initialize(params)
 
         for feature in rst._features.values():
@@ -85,7 +84,6 @@ def create_language_server(
 
     @server.feature(INITIALIZED)
     def on_initialized(rst: server_cls, params: InitializedParams):
-        rst.logger.debug("%s: %s", INITIALIZED, dump(params))
         rst.initialized(params)
 
         for feature in rst._features.values():
@@ -93,15 +91,14 @@ def create_language_server(
 
     @server.feature(TEXT_DOCUMENT_DID_OPEN)
     def on_open(rst: server_cls, params: DidOpenTextDocumentParams):
-        rst.logger.debug("%s: %s", TEXT_DOCUMENT_DID_OPEN, dump(params))
+        pass
 
     @server.feature(TEXT_DOCUMENT_DID_CHANGE)
     def on_change(rst: server_cls, params: DidChangeTextDocumentParams):
-        rst.logger.debug("%s: %s", TEXT_DOCUMENT_DID_CHANGE, dump(params))
+        pass
 
     @server.feature(TEXT_DOCUMENT_DID_SAVE)
     def on_save(rst: server_cls, params: DidSaveTextDocumentParams):
-        rst.logger.debug("%s: %s", TEXT_DOCUMENT_DID_SAVE, dump(params))
         rst.save(params)
 
         for feature in rst._features.values():
@@ -111,8 +108,6 @@ def create_language_server(
         COMPLETION, CompletionOptions(trigger_characters=[".", ":", "`", "<", "/"])
     )
     def on_completion(rst: server_cls, params: CompletionParams):
-        rst.logger.debug("%s: %s", COMPLETION, dump(params))
-
         uri = params.text_document.uri
         pos = params.position
 
@@ -142,8 +137,6 @@ def create_language_server(
 
     @server.feature(DEFINITION)
     def on_definition(rst: server_cls, params: DefinitionParams):
-        rst.logger.debug("%s: %s", DEFINITION, dump(params))
-
         uri = params.text_document.uri
         pos = params.position
 
@@ -166,7 +159,6 @@ def create_language_server(
 
     @server.feature(DOCUMENT_SYMBOL)
     def on_document_symbol(rst: server_cls, params: DocumentSymbolParams):
-        rst.logger.debug("%s: %s", DOCUMENT_SYMBOL, params)
 
         doctree = rst.get_doctree(uri=params.text_document.uri)
         if doctree is None:

--- a/lib/esbonio/esbonio/lsp/testing.py
+++ b/lib/esbonio/esbonio/lsp/testing.py
@@ -209,8 +209,10 @@ def role_patterns(partial: str = "") -> List[str]:
         for s in [
             "{}",
             "({}",
+            "- {}",
             "   {}",
             "   ({}",
+            "   - {}",
             "some text {}",
             "some text ({}",
             "   some text {}",
@@ -219,7 +221,9 @@ def role_patterns(partial: str = "") -> List[str]:
     ]
 
 
-def role_target_patterns(name: str, partial: str = "") -> List[str]:
+def role_target_patterns(
+    name: str, partial: str = "", include_modifiers: bool = True
+) -> List[str]:
     """Return a number of example role target patterns.
 
     These correspond to test cases where role target suggestions should be generated.
@@ -230,20 +234,31 @@ def role_target_patterns(name: str, partial: str = "") -> List[str]:
        The name of the role to generate suggestions for.
     partial:
        The partial target that the user as already entered.
+    include_modifiers:
+       A flag to indicate if additional modifiers like ``!`` and ``~`` should be
+       included in the generated patterns.
     """
-    return [
-        s.format(name, partial)
-        for s in [
-            ":{}:`{}",
-            "(:{}:`{}",
-            ":{}:`More Info <{}",
-            "(:{}:`More Info <{}",
-            "   :{}:`{}",
-            "   (:{}:`{}",
-            "   :{}:`Some Label <{}",
-            "   (:{}:`Some Label <{}",
-        ]
+
+    patterns = [
+        ":{}:`{}",
+        "(:{}:`{}",
+        "- :{}:`{}",
+        ":{}:`More Info <{}",
+        "(:{}:`More Info <{}",
+        "   :{}:`{}",
+        "   (:{}:`{}",
+        "   - :{}:`{}",
+        "   :{}:`Some Label <{}",
+        "   (:{}:`Some Label <{}",
     ]
+
+    test_cases = [p.format(name, partial) for p in patterns]
+
+    if include_modifiers:
+        test_cases += [p.format(name, "!" + partial) for p in patterns]
+        test_cases += [p.format(name, "~" + partial) for p in patterns]
+
+    return test_cases
 
 
 def intersphinx_target_patterns(name: str, project: str) -> List[str]:

--- a/lib/esbonio/tests/test_filepaths.py
+++ b/lib/esbonio/tests/test_filepaths.py
@@ -23,7 +23,7 @@ THEOREM_FILES = {"index.rst", "pythagoras.rst"}
 def filepath_trigger_cases(path: str = ""):
     """Expand a path into all roles and directives we wish to test it with."""
     return [
-        *role_target_patterns("download", path),
+        *role_target_patterns("download", path, include_modifiers=False),
         *directive_argument_patterns("image", path),
         *directive_argument_patterns("figure", path),
         *directive_argument_patterns("include", path),


### PR DESCRIPTION
Sphinx adds a few [modifiers](https://www.sphinx-doc.org/en/master/usage/restructuredtext/roles.html#cross-referencing-syntax) that can be applied to cross-references. This PR ensures that any `CompletionItems` returned from the language server preserve them if they are present.

Closes #211 