### PR TITLE
Fix document symbols on windows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -162,7 +162,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
         os: [ubuntu-20.04]
     steps:
     - uses: actions/checkout@v2

--- a/lib/esbonio/esbonio/lsp/sphinx.py
+++ b/lib/esbonio/esbonio/lsp/sphinx.py
@@ -372,21 +372,14 @@ class SphinxLanguageServer(RstLanguageServer):
             return None
 
         if uri is not None:
-            srcdir = self.app.srcdir
             fspath = Uri.to_fs_path(uri)
+            docname = self.app.env.path2doc(fspath)
 
-            if not fspath.startswith(srcdir):
-                return None
-
-            docpath = pathlib.Path(fspath.replace(srcdir, ""))
-            docname = str(docpath.with_suffix(""))
-
-            if docname.startswith("/"):
-                docname = docname[1:]
-
-        self.logger.debug("Getting doctree for '%s'", docname)
+        if docname is None:
+            return None
 
         try:
+            self.logger.debug("Getting doctree for '%s'", docname)
             return self.app.env.get_and_resolve_doctree(docname, self.app.builder)
         except FileNotFoundError:
             self.logger.debug(traceback.format_exc())

--- a/lib/esbonio/pyproject.toml
+++ b/lib/esbonio/pyproject.toml
@@ -55,6 +55,7 @@ envlist = py{36,37,38,39}-sphinx{2,3,4}
 [testenv]
 deps =
     sphinx2: sphinx>=2,<3
+    sphinx2: docutils<0.18
     sphinx3: sphinx>=3,<4
     sphinx4: sphinx>=4,<5
     pytest

--- a/lib/esbonio/setup.cfg
+++ b/lib/esbonio/setup.cfg
@@ -22,6 +22,7 @@ classifiers =
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     Topic :: Documentation
     Topic :: Documentation :: Sphinx
 platforms = any


### PR DESCRIPTION
- Fix a bug on windows where the server was unable to translate a filepath into its corresponding docname
- Add support for Python 3.10