### PR TITLE
Improve configuration options in the VSCode extension

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -262,7 +262,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
         os: [ubuntu-20.04]
     steps:
     - uses: actions/checkout@v2

--- a/code/changes/239.enhancement.rst
+++ b/code/changes/239.enhancement.rst
@@ -1,0 +1,1 @@
+Add ``esbonio.server.enabled`` option which gives the user the ability to disable the language sever if they wish.

--- a/code/changes/258.enhancement.rst
+++ b/code/changes/258.enhancement.rst
@@ -1,0 +1,1 @@
+Add ``esbonio.sphinx.buildDir`` option which allows the user to specify where Sphinx's build files get written to.

--- a/code/package.json
+++ b/code/package.json
@@ -191,6 +191,13 @@
                     ],
                     "description": "How often should the extension check for updates to the Language Server"
                 },
+                "esbonio.sphinx.buildDir": {
+                    "scope": "window",
+                    "type": "string",
+                    "default": null,
+                    "description": "The directory in which to store Sphinx's build output.\n\nBy default the Language Server will store any build files in a storage area provided by VSCode, this option allows you to override this to be a directory of your choosing e.g. your local _build/ directory.",
+                    "markdownDescription": "The directory in which to store Sphinx's build output.\n\nBy default the Language Server will store any build files in a storage area provided by VSCode, this option allows you to override this to be a directory of your choosing e.g. your local `_build/` directory."
+                },
                 "esbonio.sphinx.confDir": {
                     "scope": "window",
                     "type": "string",

--- a/code/package.json
+++ b/code/package.json
@@ -103,6 +103,12 @@
             "type": "object",
             "title": "Esbonio",
             "properties": {
+                "esbonio.server.enabled": {
+                    "scope": "window",
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Enable/Disable the language server"
+                },
                 "esbonio.server.logLevel": {
                     "scope": "application",
                     "type": "string",
@@ -127,7 +133,7 @@
                     "scope": "window",
                     "type": "string",
                     "default": "",
-                    "markdownDescription": "The path to the Python interpreter to use when running the Langague Server.\n\nBy default this extension will try to use the interpreter configured via the `#python.pythonPath#` option in the Python Extension. If you do not use the Python Extension or you wish to use a different environment, then this option can be used to override the default behavior."
+                    "description": "The path to the Python interpreter to use when running the Langague Server.\n\nBy default this extension will try to use the interpreter configured via the Python Extension. If you do not use the Python Extension or you wish to use a different environment, then this option can be used to override the default behavior."
                 },
                 "esbonio.server.hideSphinxOutput": {
                     "scope": "application",
@@ -195,7 +201,8 @@
                     "scope": "window",
                     "type": "string",
                     "default": null,
-                    "markdownDescription": "The directory containing your rst source files. By default the Language Server will assume this is the same as `#esbonio.sphinx.srcDir#` but this opton can override this if necessary."
+                    "description": "The directory containing your rst source files. By default the Language Server will assume this is the same as `esbonio.sphinx.confDir` but this opton can override this if necessary.",
+                    "markdownDescription": "The directory containing your rst source files. By default the Language Server will assume this is the same as `#esbonio.sphinx.confDir#` but this opton can override this if necessary."
                 }
             }
         },

--- a/code/src/extension.ts
+++ b/code/src/extension.ts
@@ -25,7 +25,10 @@ export async function activate(context: vscode.ExtensionContext) {
 
     let preview = new PreviewManager(logger, context, esbonio)
 
-    await esbonio.start()
+    let config = vscode.workspace.getConfiguration("esbonio.server")
+    if (config.get("enabled")) {
+        await esbonio.start()
+    }
 }
 
 export function deactivate(): Thenable<void> | undefined {

--- a/code/src/lsp/client.ts
+++ b/code/src/lsp/client.ts
@@ -271,11 +271,16 @@ export class EsbonioClient {
     let cache = this.context.storageUri.path
     let config = vscode.workspace.getConfiguration("esbonio")
 
+    let buildDir = config.get<string>('sphinx.buildDir')
+    if (!buildDir) {
+      buildDir = join(cache, 'sphinx')
+    }
+
     let initOptions: InitOptions = {
       sphinx: {
         srcDir: config.get<string>("sphinx.srcDir"),
         confDir: config.get<string>('sphinx.confDir'),
-        buildDir: join(cache, 'sphinx')
+        buildDir: buildDir
       },
       server: {
         logLevel: config.get<string>('server.logLevel'),

--- a/code/src/lsp/client.ts
+++ b/code/src/lsp/client.ts
@@ -119,19 +119,22 @@ export class EsbonioClient {
   }
 
   async stop() {
-    if (!this.client) {
-      return
+    this.statusBar.hide()
+
+    if (this.client) {
+      await this.client.stop()
     }
 
-    return await this.client.stop()
+    return
   }
 
   /**
    * Start the language client.
    */
   async start(): Promise<void> {
-    this.statusBar.text = "$(sync~spin) Starting..."
     this.statusBar.show()
+    this.statusBar.text = "$(sync~spin) Starting..."
+
     if (DEBUG) {
       this.client = await this.getTcpClient()
     } else {
@@ -172,13 +175,12 @@ export class EsbonioClient {
    * Restart the language server.
    */
   async restartServer() {
-    this.logger.info("Stopping Language Server")
-
-    if (this.client) {
-      await this.client.stop()
+    let config = vscode.workspace.getConfiguration("esbonio.server")
+    if (config.get("enabled")) {
+      this.logger.info("Stopping Language Server")
+      await this.stop()
+      await this.start()
     }
-
-    await this.start()
   }
 
   /**
@@ -301,6 +303,11 @@ export class EsbonioClient {
     this.logger.debug(`ConfigurationChangeEvent`)
 
     let config = vscode.workspace.getConfiguration("esbonio")
+    if (!config.get("server.enabled")) {
+      await this.stop()
+      return
+    }
+
 
     let conditions = [
       event.affectsConfiguration("esbonio"),

--- a/docs/lsp/editors/index.rst
+++ b/docs/lsp/editors/index.rst
@@ -72,9 +72,14 @@ available in any language client.
    - ``${confDir}/../src/`` - A path relative to your project's ``confDir``
 
 ``sphinx.buildDir`` (string)
-   By default the language server will choose an appropriate location to cache the build
-   output from Sphinx. This option can be used to force the language server to use a location
-   of your choosing.
+   By default the language server will choose a cache directory (as determined by
+   `appdirs <https://pypi.org/project/appdirs>`_) to put Sphinx's build output.
+   This option can be used to force the language server to use a location
+   of your choosing, currently accepted values include:
+
+   - ``/path/to/src/`` - An absolute path
+   - ``${workspaceRoot}/docs/src`` - A path relative to the root of your workspace
+   - ``${confDir}/../src/`` - A path relative to your project's ``confDir``
 
 ``server.logLevel`` (string)
    This can be used to set the level of log messages emitted by the server. This can be set

--- a/docs/lsp/editors/vscode.rst
+++ b/docs/lsp/editors/vscode.rst
@@ -17,6 +17,9 @@ Configuration
 The VSCode extension exposes the language server's :ref:`editor_integration_config`
 under an ``esbonio.*`` prefix. It also exposes the following additional options.
 
+``esbonio.server.enabled`` (boolean)
+   A flag that can be used to completely disable the language server, if required.
+
 ``esbonio.server.pythonPath`` (string)
    If the official `Python Extension`_ is available the extension will use the same
    Python environment as you have configured for your workspace. However, if you wish

--- a/lib/esbonio/changes/259.feature.rst
+++ b/lib/esbonio/changes/259.feature.rst
@@ -1,0 +1,1 @@
+The ``esbonio.sphinx.buildDir`` option now supports ``${workspaceRoot}`` and ``${confDir}`` variable expansions

--- a/lib/esbonio/pyproject.toml
+++ b/lib/esbonio/pyproject.toml
@@ -50,7 +50,7 @@ legacy_tox_ini = """
 [tox]
 isolated_build = True
 skip_missing_interpreters = true
-envlist = py{36,37,38,39}-sphinx{2,3,4}
+envlist = py{36,37,38,39}-sphinx{2,3,4}, py310-sphinx{2,4}
 
 [testenv]
 deps =


### PR DESCRIPTION
- New `esbonio.server.enabled` flag which allows the user to disable the language server if they wish. (Closes #239 )
- New `esbonio.sphinx.buildDir` option which allows the user to override where the language server places build outputs (Closes #258)
- The language server now expands `${workspaceRoot}` and `${confDir}` variables in the `sphinx.buildDir` option (Closes #259)