### PR TITLE
lsp: Give target completion providers the role domain and name

### DIFF
--- a/lib/esbonio/esbonio/lsp/completion/domains.py
+++ b/lib/esbonio/esbonio/lsp/completion/domains.py
@@ -80,20 +80,12 @@ class Domain(TargetCompletion):
         self.rst = rst
         self.logger = rst.logger.getChild(self.__class__.__name__)
 
-    def complete_targets(self, context: CompletionContext) -> List[CompletionItem]:
+    def complete_targets(
+        self, context: CompletionContext, domain: str, name: str
+    ) -> List[CompletionItem]:
 
         groups = context.match.groupdict()
         label = groups["label"]
-
-        # Handle the default role case.
-        if "role" not in groups:
-            domain, name = self.rst.get_default_role()
-
-            if not name:
-                return []
-        else:
-            name = groups["name"]
-            domain = groups["domain"] or None
 
         if ":" in label:
             return self.complete_intersphinx_targets(name, domain, label)

--- a/lib/esbonio/esbonio/lsp/completion/filepaths.py
+++ b/lib/esbonio/esbonio/lsp/completion/filepaths.py
@@ -93,14 +93,9 @@ class Filepath(ArgumentCompletion, TargetCompletion):
         if name in {"image", "figure", "include", "literalinclude"}:
             return self.complete_filepaths(context)
 
-    def complete_targets(self, context: CompletionContext) -> List[CompletionItem]:
-
-        groups = context.match.groupdict()
-
-        if "role" not in groups:
-            _, name = self.rst.get_default_role()
-        else:
-            name = groups["name"]
+    def complete_targets(
+        self, context: CompletionContext, domain: str, name: str
+    ) -> List[CompletionItem]:
 
         if name in {"download"}:
             return self.complete_filepaths(context)


### PR DESCRIPTION
Rather than force each `TargetCompletion` provider to handle the
`default_role` setting, the `Roles` language feature now handles that
logic and passes down the `domain` and `name` to each of the providers