### PR TITLE
Improved error reporting

### DIFF
--- a/code/src/lsp/client.ts
+++ b/code/src/lsp/client.ts
@@ -272,6 +272,9 @@ export class EsbonioClient {
 
     this.client.onNotification("esbonio/buildComplete", (result: BuildCompleteResult) => {
       this.logger.debug(`Build complete ${JSON.stringify(result, null, 2)}`)
+      if (result.error) {
+        this.client.outputChannel.show()
+      }
       this.buildCompleteCallbacks.forEach(fn => {
         fn(result)
       })

--- a/lib/esbonio/esbonio/lsp/sphinx/__init__.py
+++ b/lib/esbonio/esbonio/lsp/sphinx/__init__.py
@@ -267,10 +267,6 @@ class SphinxLanguageServer(RstLanguageServer):
             )
         except Exception:
             self.logger.error(traceback.format_exc())
-            self.show_message(
-                message="Unable to initialize Sphinx, see output window for details.",
-                msg_type=MessageType.Error,
-            )
             self.send_notification(
                 "esbonio/buildComplete",
                 {"config": self.configuration, "error": True, "warnings": 0},
@@ -330,7 +326,6 @@ class SphinxLanguageServer(RstLanguageServer):
             error = True
 
             self.logger.error(traceback.format_exc())
-            self.show_message(message=message, msg_type=MessageType.Error)
 
         for doc, diagnostics in self.sphinx_log.diagnostics.items():
             self.logger.debug("Found %d problems for %s", len(diagnostics), doc)

--- a/lib/esbonio/esbonio/lsp/sphinx/__init__.py
+++ b/lib/esbonio/esbonio/lsp/sphinx/__init__.py
@@ -265,8 +265,22 @@ class SphinxLanguageServer(RstLanguageServer):
                     "warnings": 0,
                 },
             )
-        except Exception:
+        except Exception as e:
             self.logger.error(traceback.format_exc())
+            conf = pathlib.Path(self.app.confdir, "conf.py")
+            line = 0
+            message=type(e).__name__ if e.args.count== 0 else e.args[0]
+            diagnostic = Diagnostic(
+                range=Range(
+                    start=Position(line=line, character=0),
+                    end=Position(line=line, character=0),
+                ),
+                message=message,
+                severity=DiagnosticSeverity.Error,
+            )
+            self.set_diagnostics("sphinx", str(conf), [diagnostic])
+
+            self.sync_diagnostics()
             self.send_notification(
                 "esbonio/buildComplete",
                 {"config": self.configuration, "error": True, "warnings": 0},


### PR DESCRIPTION
Scenario: When a Sphinx project is being edited, the build fails and succeeds often (especially when conf.py is being changed).

Problem: The current version raises too many error notifications. Besides, "see output window for details" is ambiguous, as some users might not know it is "Esbonio Language Server" channel under OUTPUT panel that they should open and read.

Solution: Removed the error notifications. Instead, automatically open the channel when errors occur.