### PR TITLE
Have the language server manage previews 

### DIFF
--- a/code/changes/275.enhancement.rst
+++ b/code/changes/275.enhancement.rst
@@ -1,0 +1,1 @@
+Switched to an ``<iframe>`` based approach for previews, which should improve compatability with various Sphinx themes.

--- a/code/package-lock.json
+++ b/code/package-lock.json
@@ -1,21 +1,19 @@
 {
     "name": "esbonio",
-    "version": "0.7.2",
+    "version": "0.7.3",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "esbonio",
-            "version": "0.7.2",
+            "version": "0.7.3",
             "license": "MIT",
             "dependencies": {
-                "jsdom": "^16.7.0",
                 "semver": "^7.3.5",
                 "vscode-languageclient": "^7.0.0"
             },
             "devDependencies": {
                 "@types/glob": "^7.1.4",
-                "@types/jsdom": "^16.2.13",
                 "@types/mocha": "^8.2.3",
                 "@types/node": "^14.17.15",
                 "@types/semver": "^7.3.8",
@@ -45,6 +43,7 @@
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
             "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
+            "dev": true,
             "engines": {
                 "node": ">= 6"
             }
@@ -85,17 +84,6 @@
                 "@types/node": "*"
             }
         },
-        "node_modules/@types/jsdom": {
-            "version": "16.2.13",
-            "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-16.2.13.tgz",
-            "integrity": "sha512-8JQCjdeAidptSsOcRWk2iTm9wCcwn9l+kRG6k5bzUacrnm1ezV4forq0kWjUih/tumAeoG+OspOvQEbbRucBTw==",
-            "dev": true,
-            "dependencies": {
-                "@types/node": "*",
-                "@types/parse5": "*",
-                "@types/tough-cookie": "*"
-            }
-        },
         "node_modules/@types/json-schema": {
             "version": "7.0.9",
             "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
@@ -120,22 +108,10 @@
             "integrity": "sha512-D1sdW0EcSCmNdLKBGMYb38YsHUS6JcM7yQ6sLQ9KuZ35ck7LYCKE7kYFHOO59ayFOY3zobWVZxf4KXhYHcHYFA==",
             "dev": true
         },
-        "node_modules/@types/parse5": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/@types/parse5/-/parse5-6.0.1.tgz",
-            "integrity": "sha512-ARATsLdrGPUnaBvxLhUlnltcMgn7pQG312S8ccdYlnyijabrX9RN/KN/iGj9Am96CoW8e/K9628BA7Bv4XHdrA==",
-            "dev": true
-        },
         "node_modules/@types/semver": {
             "version": "7.3.8",
             "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.8.tgz",
             "integrity": "sha512-D/2EJvAlCEtYFEYmmlGwbGXuK886HzyCc3nZX/tkFTQdEU8jZDAgiv08P162yB17y4ZXZoq7yFAnW4GDBb9Now==",
-            "dev": true
-        },
-        "node_modules/@types/tough-cookie": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.1.tgz",
-            "integrity": "sha512-Y0K95ThC3esLEYD6ZuqNek29lNX2EM1qxV8y2FTLUB0ff5wWrk7az+mLrnNFUnaXcgKye22+sFBRXOgpPILZNg==",
             "dev": true
         },
         "node_modules/@types/vscode": {
@@ -344,35 +320,11 @@
             "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
             "dev": true
         },
-        "node_modules/abab": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.5.tgz",
-            "integrity": "sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q=="
-        },
         "node_modules/acorn": {
             "version": "8.5.0",
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.5.0.tgz",
             "integrity": "sha512-yXbYeFy+jUuYd3/CDcg2NkIYE991XYX/bje7LmjJigUciaeO1JR4XxXgCIV1/Zc/dRuFEyw1L0pbA+qynJkW5Q==",
-            "bin": {
-                "acorn": "bin/acorn"
-            },
-            "engines": {
-                "node": ">=0.4.0"
-            }
-        },
-        "node_modules/acorn-globals": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-6.0.0.tgz",
-            "integrity": "sha512-ZQl7LOWaF5ePqqcX4hLuv/bLXYQNfNWw2c0/yX/TsPRKamzHcTGQnlCjHT3TsmkOUVEPS3crCxiPfdzE/Trlhg==",
-            "dependencies": {
-                "acorn": "^7.1.1",
-                "acorn-walk": "^7.1.1"
-            }
-        },
-        "node_modules/acorn-globals/node_modules/acorn": {
-            "version": "7.4.1",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
-            "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+            "dev": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -389,18 +341,11 @@
                 "acorn": "^8"
             }
         },
-        "node_modules/acorn-walk": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.2.0.tgz",
-            "integrity": "sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==",
-            "engines": {
-                "node": ">=0.4.0"
-            }
-        },
         "node_modules/agent-base": {
             "version": "6.0.2",
             "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
             "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+            "dev": true,
             "dependencies": {
                 "debug": "4"
             },
@@ -497,11 +442,6 @@
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
             "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
             "dev": true
-        },
-        "node_modules/asynckit": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-            "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
         },
         "node_modules/azure-devops-node-api": {
             "version": "11.0.1",
@@ -635,11 +575,6 @@
             "engines": {
                 "node": ">=8"
             }
-        },
-        "node_modules/browser-process-hrtime": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz",
-            "integrity": "sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow=="
         },
         "node_modules/browser-stdout": {
             "version": "1.3.1",
@@ -966,17 +901,6 @@
             "integrity": "sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==",
             "dev": true
         },
-        "node_modules/combined-stream": {
-            "version": "1.0.8",
-            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-            "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-            "dependencies": {
-                "delayed-stream": "~1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.8"
-            }
-        },
         "node_modules/commander": {
             "version": "6.2.1",
             "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
@@ -1045,44 +969,11 @@
                 "url": "https://github.com/sponsors/fb55"
             }
         },
-        "node_modules/cssom": {
-            "version": "0.4.4",
-            "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.4.4.tgz",
-            "integrity": "sha512-p3pvU7r1MyyqbTk+WbNJIgJjG2VmTIaB10rI93LzVPrmDJKkzKYMtxxyAvQXR/NS6otuzveI7+7BBq3SjBS2mw=="
-        },
-        "node_modules/cssstyle": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-2.3.0.tgz",
-            "integrity": "sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==",
-            "dependencies": {
-                "cssom": "~0.3.6"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/cssstyle/node_modules/cssom": {
-            "version": "0.3.8",
-            "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
-            "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg=="
-        },
-        "node_modules/data-urls": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-2.0.0.tgz",
-            "integrity": "sha512-X5eWTSXO/BJmpdIKCRuKUgSCgAN0OwliVK3yPKbwIWU1Tdw5BRajxlzMidvh+gwko9AfQ9zIj52pzF91Q3YAvQ==",
-            "dependencies": {
-                "abab": "^2.0.3",
-                "whatwg-mimetype": "^2.3.0",
-                "whatwg-url": "^8.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
         "node_modules/debug": {
             "version": "4.3.3",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
             "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+            "dev": true,
             "dependencies": {
                 "ms": "2.1.2"
             },
@@ -1098,7 +989,8 @@
         "node_modules/debug/node_modules/ms": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+            "dev": true
         },
         "node_modules/decamelize": {
             "version": "4.0.0",
@@ -1111,11 +1003,6 @@
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
-        },
-        "node_modules/decimal.js": {
-            "version": "10.3.1",
-            "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.3.1.tgz",
-            "integrity": "sha512-V0pfhfr8suzyPGOx3nmq4aHqabehUZn6Ch9kyFpV79TGDTWFmHqUqXdabR7QHqxzrYolF4+tVmJhUG4OURg5dQ=="
         },
         "node_modules/decompress-response": {
             "version": "6.0.0",
@@ -1139,19 +1026,6 @@
             "dev": true,
             "engines": {
                 "node": ">=4.0.0"
-            }
-        },
-        "node_modules/deep-is": {
-            "version": "0.1.4",
-            "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
-            "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="
-        },
-        "node_modules/delayed-stream": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-            "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-            "engines": {
-                "node": ">=0.4.0"
             }
         },
         "node_modules/delegates": {
@@ -1194,25 +1068,6 @@
                     "url": "https://github.com/sponsors/fb55"
                 }
             ]
-        },
-        "node_modules/domexception": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/domexception/-/domexception-2.0.1.tgz",
-            "integrity": "sha512-yxJ2mFy/sibVQlu5qHjOkf9J3K6zgmCxgJ94u2EdvDOV09H+32LtRswEcUsmUWN72pVLOEnTSRaIVVzVQgS0dg==",
-            "dependencies": {
-                "webidl-conversions": "^5.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/domexception/node_modules/webidl-conversions": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-5.0.0.tgz",
-            "integrity": "sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA==",
-            "engines": {
-                "node": ">=8"
-            }
         },
         "node_modules/domhandler": {
             "version": "4.2.2",
@@ -1353,27 +1208,6 @@
                 "node": ">=0.8.0"
             }
         },
-        "node_modules/escodegen": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.0.0.tgz",
-            "integrity": "sha512-mmHKys/C8BFUGI+MAWNcSYoORYLMdPzjrknd2Vc+bUsjN5bXcr8EhrNB+UTqfL1y3I9c4fw2ihgtMPQLBRiQxw==",
-            "dependencies": {
-                "esprima": "^4.0.1",
-                "estraverse": "^5.2.0",
-                "esutils": "^2.0.2",
-                "optionator": "^0.8.1"
-            },
-            "bin": {
-                "escodegen": "bin/escodegen.js",
-                "esgenerate": "bin/esgenerate.js"
-            },
-            "engines": {
-                "node": ">=6.0"
-            },
-            "optionalDependencies": {
-                "source-map": "~0.6.1"
-            }
-        },
         "node_modules/eslint-scope": {
             "version": "5.1.1",
             "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
@@ -1396,18 +1230,6 @@
                 "node": ">=4.0"
             }
         },
-        "node_modules/esprima": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-            "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-            "bin": {
-                "esparse": "bin/esparse.js",
-                "esvalidate": "bin/esvalidate.js"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
         "node_modules/esrecurse": {
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
@@ -1424,16 +1246,9 @@
             "version": "5.2.0",
             "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
             "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
+            "dev": true,
             "engines": {
                 "node": ">=4.0"
-            }
-        },
-        "node_modules/esutils": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
-            "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
-            "engines": {
-                "node": ">=0.10.0"
             }
         },
         "node_modules/events": {
@@ -1489,11 +1304,6 @@
             "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
             "dev": true
         },
-        "node_modules/fast-levenshtein": {
-            "version": "2.0.6",
-            "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-            "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
-        },
         "node_modules/fastest-levenshtein": {
             "version": "1.0.12",
             "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.12.tgz",
@@ -1544,19 +1354,6 @@
             "dev": true,
             "bin": {
                 "flat": "cli.js"
-            }
-        },
-        "node_modules/form-data": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
-            "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
-            "dependencies": {
-                "asynckit": "^0.4.0",
-                "combined-stream": "^1.0.8",
-                "mime-types": "^2.1.12"
-            },
-            "engines": {
-                "node": ">= 6"
             }
         },
         "node_modules/fs-constants": {
@@ -1835,17 +1632,6 @@
                 "node": ">=10"
             }
         },
-        "node_modules/html-encoding-sniffer": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-2.0.1.tgz",
-            "integrity": "sha512-D5JbOMBIR/TVZkubHT+OyT2705QvogUW4IBn6nHd756OwieSF9aDYFj4dv6HHEVGYbHaLETa3WggZYWWMyy3ZQ==",
-            "dependencies": {
-                "whatwg-encoding": "^1.0.5"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
         "node_modules/htmlparser2": {
             "version": "6.1.0",
             "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.1.0.tgz",
@@ -1869,6 +1655,7 @@
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
             "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
+            "dev": true,
             "dependencies": {
                 "@tootallnate/once": "1",
                 "agent-base": "6",
@@ -1882,6 +1669,7 @@
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
             "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
+            "dev": true,
             "dependencies": {
                 "agent-base": "6",
                 "debug": "4"
@@ -1897,17 +1685,6 @@
             "dev": true,
             "engines": {
                 "node": ">=10.17.0"
-            }
-        },
-        "node_modules/iconv-lite": {
-            "version": "0.4.24",
-            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-            "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-            "dependencies": {
-                "safer-buffer": ">= 2.1.2 < 3"
-            },
-            "engines": {
-                "node": ">=0.10.0"
             }
         },
         "node_modules/ieee754": {
@@ -2061,11 +1838,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/is-potential-custom-element-name": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
-            "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ=="
-        },
         "node_modules/is-stream": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
@@ -2161,51 +1933,6 @@
                 "js-yaml": "bin/js-yaml.js"
             }
         },
-        "node_modules/jsdom": {
-            "version": "16.7.0",
-            "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-16.7.0.tgz",
-            "integrity": "sha512-u9Smc2G1USStM+s/x1ru5Sxrl6mPYCbByG1U/hUmqaVsm4tbNyS7CicOSRyuGQYZhTu0h84qkZZQ/I+dzizSVw==",
-            "dependencies": {
-                "abab": "^2.0.5",
-                "acorn": "^8.2.4",
-                "acorn-globals": "^6.0.0",
-                "cssom": "^0.4.4",
-                "cssstyle": "^2.3.0",
-                "data-urls": "^2.0.0",
-                "decimal.js": "^10.2.1",
-                "domexception": "^2.0.1",
-                "escodegen": "^2.0.0",
-                "form-data": "^3.0.0",
-                "html-encoding-sniffer": "^2.0.1",
-                "http-proxy-agent": "^4.0.1",
-                "https-proxy-agent": "^5.0.0",
-                "is-potential-custom-element-name": "^1.0.1",
-                "nwsapi": "^2.2.0",
-                "parse5": "6.0.1",
-                "saxes": "^5.0.1",
-                "symbol-tree": "^3.2.4",
-                "tough-cookie": "^4.0.0",
-                "w3c-hr-time": "^1.0.2",
-                "w3c-xmlserializer": "^2.0.0",
-                "webidl-conversions": "^6.1.0",
-                "whatwg-encoding": "^1.0.5",
-                "whatwg-mimetype": "^2.3.0",
-                "whatwg-url": "^8.5.0",
-                "ws": "^7.4.6",
-                "xml-name-validator": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "peerDependencies": {
-                "canvas": "^2.5.0"
-            },
-            "peerDependenciesMeta": {
-                "canvas": {
-                    "optional": true
-                }
-            }
-        },
         "node_modules/json-parse-better-errors": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
@@ -2262,18 +1989,6 @@
                 "node": ">=6"
             }
         },
-        "node_modules/levn": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-            "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
-            "dependencies": {
-                "prelude-ls": "~1.1.2",
-                "type-check": "~0.3.2"
-            },
-            "engines": {
-                "node": ">= 0.8.0"
-            }
-        },
         "node_modules/linkify-it": {
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-3.0.3.tgz",
@@ -2326,11 +2041,6 @@
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
-        },
-        "node_modules/lodash": {
-            "version": "4.17.21",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
         },
         "node_modules/log-symbols": {
             "version": "4.1.0",
@@ -2508,6 +2218,7 @@
             "version": "1.49.0",
             "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.49.0.tgz",
             "integrity": "sha512-CIc8j9URtOVApSFCQIF+VBkX1RwXp/oMMOrqdyXSBXq5RWNEsRfyj1kiRnQgmNXmHxPoFIxOroKA3zcU9P+nAA==",
+            "dev": true,
             "engines": {
                 "node": ">= 0.6"
             }
@@ -2516,6 +2227,7 @@
             "version": "2.1.32",
             "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.32.tgz",
             "integrity": "sha512-hJGaVS4G4c9TSMYh2n6SQAGrC4RnfU+daP8G7cSCmaqNjiOoUY0VHCMS42pxnQmVF1GWwFhbHWn3RIxCqTmZ9A==",
+            "dev": true,
             "dependencies": {
                 "mime-db": "1.49.0"
             },
@@ -2781,11 +2493,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/nwsapi": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.0.tgz",
-            "integrity": "sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ=="
-        },
         "node_modules/object-assign": {
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -2826,22 +2533,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/optionator": {
-            "version": "0.8.3",
-            "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
-            "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
-            "dependencies": {
-                "deep-is": "~0.1.3",
-                "fast-levenshtein": "~2.0.6",
-                "levn": "~0.3.0",
-                "prelude-ls": "~1.1.2",
-                "type-check": "~0.3.2",
-                "word-wrap": "~1.2.3"
-            },
-            "engines": {
-                "node": ">= 0.8.0"
             }
         },
         "node_modules/p-limit": {
@@ -2904,7 +2595,8 @@
         "node_modules/parse5": {
             "version": "6.0.1",
             "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
-            "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw=="
+            "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
+            "dev": true
         },
         "node_modules/parse5-htmlparser2-tree-adapter": {
             "version": "6.0.1",
@@ -3057,14 +2749,6 @@
                 "node": ">=10"
             }
         },
-        "node_modules/prelude-ls": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-            "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
-            "engines": {
-                "node": ">= 0.8.0"
-            }
-        },
         "node_modules/process-nextick-args": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -3076,11 +2760,6 @@
             "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
             "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
             "dev": true
-        },
-        "node_modules/psl": {
-            "version": "1.8.0",
-            "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
-            "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
         },
         "node_modules/pump": {
             "version": "3.0.0",
@@ -3096,6 +2775,7 @@
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
             "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+            "dev": true,
             "engines": {
                 "node": ">=6"
             }
@@ -3283,27 +2963,11 @@
                 }
             ]
         },
-        "node_modules/safer-buffer": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
-        },
         "node_modules/sax": {
             "version": "1.2.4",
             "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
             "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
             "dev": true
-        },
-        "node_modules/saxes": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/saxes/-/saxes-5.0.1.tgz",
-            "integrity": "sha512-5LBh1Tls8c9xgGjw3QrMwETmTMVk0oFgvrFSvWx62llR2hcEInrKNZ2GZCCuuy2lvWrdl5jhbpeqc5hRYKFOcw==",
-            "dependencies": {
-                "xmlchars": "^2.2.0"
-            },
-            "engines": {
-                "node": ">=10"
-            }
         },
         "node_modules/schema-utils": {
             "version": "3.1.1",
@@ -3460,7 +3124,7 @@
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
             "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-            "devOptional": true,
+            "dev": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -3547,11 +3211,6 @@
             "engines": {
                 "node": ">=4"
             }
-        },
-        "node_modules/symbol-tree": {
-            "version": "3.2.4",
-            "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
-            "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="
         },
         "node_modules/tapable": {
             "version": "1.1.3",
@@ -3695,30 +3354,6 @@
                 "node": ">=8.0"
             }
         },
-        "node_modules/tough-cookie": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.0.0.tgz",
-            "integrity": "sha512-tHdtEpQCMrc1YLrMaqXXcj6AxhYi/xgit6mZu1+EDWUn+qhUf8wMQoFIy9NXuq23zAwtcB0t/MjACGR18pcRbg==",
-            "dependencies": {
-                "psl": "^1.1.33",
-                "punycode": "^2.1.1",
-                "universalify": "^0.1.2"
-            },
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/tr46": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/tr46/-/tr46-2.1.0.tgz",
-            "integrity": "sha512-15Ih7phfcdP5YxqiB+iDtLoaTz4Nd35+IiAv0kQ5FNKHzXgdWqPoTIqEDDJmXceQt4JZk6lVPT8lnDlPpGDppw==",
-            "dependencies": {
-                "punycode": "^2.1.1"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/traverse": {
             "version": "0.3.9",
             "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
@@ -3845,17 +3480,6 @@
                 "node": "*"
             }
         },
-        "node_modules/type-check": {
-            "version": "0.3.2",
-            "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-            "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
-            "dependencies": {
-                "prelude-ls": "~1.1.2"
-            },
-            "engines": {
-                "node": ">= 0.8.0"
-            }
-        },
         "node_modules/typed-rest-client": {
             "version": "1.8.6",
             "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.8.6.tgz",
@@ -3891,14 +3515,6 @@
             "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.1.tgz",
             "integrity": "sha512-hzSoAVtJF+3ZtiFX0VgfFPHEDRm7Y/QPjGyNo4TVdnDTdft3tr8hEkD25a1jC+TjTuE7tkHGKkhwCgs9dgBB2g==",
             "dev": true
-        },
-        "node_modules/universalify": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-            "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-            "engines": {
-                "node": ">= 4.0.0"
-            }
         },
         "node_modules/unzipper": {
             "version": "0.10.11",
@@ -4038,25 +3654,6 @@
                 "node": ">=8.9.3"
             }
         },
-        "node_modules/w3c-hr-time": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.2.tgz",
-            "integrity": "sha512-z8P5DvDNjKDoFIHK7q8r8lackT6l+jo/Ye3HOle7l9nICP9lf1Ci25fy9vHd0JOWewkIFzXIEig3TdKT7JQ5fQ==",
-            "dependencies": {
-                "browser-process-hrtime": "^1.0.0"
-            }
-        },
-        "node_modules/w3c-xmlserializer": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-2.0.0.tgz",
-            "integrity": "sha512-4tzD0mF8iSiMiNs30BiLO3EpfGLZUT2MSX/G+o7ZywDzliWQ3OPtTZ0PTC3B3ca1UAf4cJMHB+2Bf56EriJuRA==",
-            "dependencies": {
-                "xml-name-validator": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
         "node_modules/watchpack": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.2.0.tgz",
@@ -4068,14 +3665,6 @@
             },
             "engines": {
                 "node": ">=10.13.0"
-            }
-        },
-        "node_modules/webidl-conversions": {
-            "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-6.1.0.tgz",
-            "integrity": "sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w==",
-            "engines": {
-                "node": ">=10.4"
             }
         },
         "node_modules/webpack": {
@@ -4222,32 +3811,6 @@
                 "node": ">=6"
             }
         },
-        "node_modules/whatwg-encoding": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz",
-            "integrity": "sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==",
-            "dependencies": {
-                "iconv-lite": "0.4.24"
-            }
-        },
-        "node_modules/whatwg-mimetype": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",
-            "integrity": "sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g=="
-        },
-        "node_modules/whatwg-url": {
-            "version": "8.7.0",
-            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.7.0.tgz",
-            "integrity": "sha512-gAojqb/m9Q8a5IV96E3fHJM70AzCkgt4uXYX2O7EmuyOnLrViCQlsEBmF9UQIu3/aeAIp2U17rtbpZWNntQqdg==",
-            "dependencies": {
-                "lodash": "^4.7.0",
-                "tr46": "^2.1.0",
-                "webidl-conversions": "^6.1.0"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
         "node_modules/which": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -4277,14 +3840,6 @@
             "resolved": "https://registry.npmjs.org/wildcard/-/wildcard-2.0.0.tgz",
             "integrity": "sha512-JcKqAHLPxcdb9KM49dufGXn2x3ssnfjbcaQdLlfZsL9rH9wgDQjUtDxbo8NE0F6SFvydeu1VhZe7hZuHsB2/pw==",
             "dev": true
-        },
-        "node_modules/word-wrap": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-            "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
-            "engines": {
-                "node": ">=0.10.0"
-            }
         },
         "node_modules/workerpool": {
             "version": "6.2.0",
@@ -4392,31 +3947,6 @@
             "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
             "dev": true
         },
-        "node_modules/ws": {
-            "version": "7.5.5",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.5.tgz",
-            "integrity": "sha512-BAkMFcAzl8as1G/hArkxOxq3G7pjUqQ3gzYbLL0/5zNkph70e+lCoxBGnm6AW1+/aiNeV4fnKqZ8m4GZewmH2w==",
-            "engines": {
-                "node": ">=8.3.0"
-            },
-            "peerDependencies": {
-                "bufferutil": "^4.0.1",
-                "utf-8-validate": "^5.0.2"
-            },
-            "peerDependenciesMeta": {
-                "bufferutil": {
-                    "optional": true
-                },
-                "utf-8-validate": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/xml-name-validator": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
-            "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw=="
-        },
         "node_modules/xml2js": {
             "version": "0.4.23",
             "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
@@ -4438,11 +3968,6 @@
             "engines": {
                 "node": ">=4.0"
             }
-        },
-        "node_modules/xmlchars": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
-            "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="
         },
         "node_modules/y18n": {
             "version": "5.0.8",
@@ -4586,7 +4111,8 @@
         "@tootallnate/once": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
-            "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw=="
+            "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
+            "dev": true
         },
         "@types/eslint": {
             "version": "7.28.0",
@@ -4624,17 +4150,6 @@
                 "@types/node": "*"
             }
         },
-        "@types/jsdom": {
-            "version": "16.2.13",
-            "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-16.2.13.tgz",
-            "integrity": "sha512-8JQCjdeAidptSsOcRWk2iTm9wCcwn9l+kRG6k5bzUacrnm1ezV4forq0kWjUih/tumAeoG+OspOvQEbbRucBTw==",
-            "dev": true,
-            "requires": {
-                "@types/node": "*",
-                "@types/parse5": "*",
-                "@types/tough-cookie": "*"
-            }
-        },
         "@types/json-schema": {
             "version": "7.0.9",
             "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
@@ -4659,22 +4174,10 @@
             "integrity": "sha512-D1sdW0EcSCmNdLKBGMYb38YsHUS6JcM7yQ6sLQ9KuZ35ck7LYCKE7kYFHOO59ayFOY3zobWVZxf4KXhYHcHYFA==",
             "dev": true
         },
-        "@types/parse5": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/@types/parse5/-/parse5-6.0.1.tgz",
-            "integrity": "sha512-ARATsLdrGPUnaBvxLhUlnltcMgn7pQG312S8ccdYlnyijabrX9RN/KN/iGj9Am96CoW8e/K9628BA7Bv4XHdrA==",
-            "dev": true
-        },
         "@types/semver": {
             "version": "7.3.8",
             "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.8.tgz",
             "integrity": "sha512-D/2EJvAlCEtYFEYmmlGwbGXuK886HzyCc3nZX/tkFTQdEU8jZDAgiv08P162yB17y4ZXZoq7yFAnW4GDBb9Now==",
-            "dev": true
-        },
-        "@types/tough-cookie": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.1.tgz",
-            "integrity": "sha512-Y0K95ThC3esLEYD6ZuqNek29lNX2EM1qxV8y2FTLUB0ff5wWrk7az+mLrnNFUnaXcgKye22+sFBRXOgpPILZNg==",
             "dev": true
         },
         "@types/vscode": {
@@ -4870,31 +4373,11 @@
             "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
             "dev": true
         },
-        "abab": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.5.tgz",
-            "integrity": "sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q=="
-        },
         "acorn": {
             "version": "8.5.0",
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.5.0.tgz",
-            "integrity": "sha512-yXbYeFy+jUuYd3/CDcg2NkIYE991XYX/bje7LmjJigUciaeO1JR4XxXgCIV1/Zc/dRuFEyw1L0pbA+qynJkW5Q=="
-        },
-        "acorn-globals": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-6.0.0.tgz",
-            "integrity": "sha512-ZQl7LOWaF5ePqqcX4hLuv/bLXYQNfNWw2c0/yX/TsPRKamzHcTGQnlCjHT3TsmkOUVEPS3crCxiPfdzE/Trlhg==",
-            "requires": {
-                "acorn": "^7.1.1",
-                "acorn-walk": "^7.1.1"
-            },
-            "dependencies": {
-                "acorn": {
-                    "version": "7.4.1",
-                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
-                    "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A=="
-                }
-            }
+            "integrity": "sha512-yXbYeFy+jUuYd3/CDcg2NkIYE991XYX/bje7LmjJigUciaeO1JR4XxXgCIV1/Zc/dRuFEyw1L0pbA+qynJkW5Q==",
+            "dev": true
         },
         "acorn-import-assertions": {
             "version": "1.7.6",
@@ -4903,15 +4386,11 @@
             "dev": true,
             "requires": {}
         },
-        "acorn-walk": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.2.0.tgz",
-            "integrity": "sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA=="
-        },
         "agent-base": {
             "version": "6.0.2",
             "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
             "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+            "dev": true,
             "requires": {
                 "debug": "4"
             }
@@ -4987,11 +4466,6 @@
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
             "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
             "dev": true
-        },
-        "asynckit": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-            "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
         },
         "azure-devops-node-api": {
             "version": "11.0.1",
@@ -5095,11 +4569,6 @@
             "requires": {
                 "fill-range": "^7.0.1"
             }
-        },
-        "browser-process-hrtime": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz",
-            "integrity": "sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow=="
         },
         "browser-stdout": {
             "version": "1.3.1",
@@ -5335,14 +4804,6 @@
             "integrity": "sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==",
             "dev": true
         },
-        "combined-stream": {
-            "version": "1.0.8",
-            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-            "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-            "requires": {
-                "delayed-stream": "~1.0.0"
-            }
-        },
         "commander": {
             "version": "6.2.1",
             "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
@@ -5396,40 +4857,11 @@
             "integrity": "sha512-FYDTSHb/7KXsWICVsxdmiExPjCfRC4qRFBdVwv7Ax9hMnvMmEjP9RfxTEZ3qPZGmADDn2vAKSo9UcN1jKVYscg==",
             "dev": true
         },
-        "cssom": {
-            "version": "0.4.4",
-            "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.4.4.tgz",
-            "integrity": "sha512-p3pvU7r1MyyqbTk+WbNJIgJjG2VmTIaB10rI93LzVPrmDJKkzKYMtxxyAvQXR/NS6otuzveI7+7BBq3SjBS2mw=="
-        },
-        "cssstyle": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-2.3.0.tgz",
-            "integrity": "sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==",
-            "requires": {
-                "cssom": "~0.3.6"
-            },
-            "dependencies": {
-                "cssom": {
-                    "version": "0.3.8",
-                    "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
-                    "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg=="
-                }
-            }
-        },
-        "data-urls": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-2.0.0.tgz",
-            "integrity": "sha512-X5eWTSXO/BJmpdIKCRuKUgSCgAN0OwliVK3yPKbwIWU1Tdw5BRajxlzMidvh+gwko9AfQ9zIj52pzF91Q3YAvQ==",
-            "requires": {
-                "abab": "^2.0.3",
-                "whatwg-mimetype": "^2.3.0",
-                "whatwg-url": "^8.0.0"
-            }
-        },
         "debug": {
             "version": "4.3.3",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
             "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+            "dev": true,
             "requires": {
                 "ms": "2.1.2"
             },
@@ -5437,7 +4869,8 @@
                 "ms": {
                     "version": "2.1.2",
                     "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+                    "dev": true
                 }
             }
         },
@@ -5446,11 +4879,6 @@
             "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
             "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
             "dev": true
-        },
-        "decimal.js": {
-            "version": "10.3.1",
-            "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.3.1.tgz",
-            "integrity": "sha512-V0pfhfr8suzyPGOx3nmq4aHqabehUZn6Ch9kyFpV79TGDTWFmHqUqXdabR7QHqxzrYolF4+tVmJhUG4OURg5dQ=="
         },
         "decompress-response": {
             "version": "6.0.0",
@@ -5466,16 +4894,6 @@
             "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
             "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
             "dev": true
-        },
-        "deep-is": {
-            "version": "0.1.4",
-            "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
-            "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="
-        },
-        "delayed-stream": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-            "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
         },
         "delegates": {
             "version": "1.0.0",
@@ -5505,21 +4923,6 @@
             "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.2.0.tgz",
             "integrity": "sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A==",
             "dev": true
-        },
-        "domexception": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/domexception/-/domexception-2.0.1.tgz",
-            "integrity": "sha512-yxJ2mFy/sibVQlu5qHjOkf9J3K6zgmCxgJ94u2EdvDOV09H+32LtRswEcUsmUWN72pVLOEnTSRaIVVzVQgS0dg==",
-            "requires": {
-                "webidl-conversions": "^5.0.0"
-            },
-            "dependencies": {
-                "webidl-conversions": {
-                    "version": "5.0.0",
-                    "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-5.0.0.tgz",
-                    "integrity": "sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA=="
-                }
-            }
         },
         "domhandler": {
             "version": "4.2.2",
@@ -5627,18 +5030,6 @@
             "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
             "dev": true
         },
-        "escodegen": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.0.0.tgz",
-            "integrity": "sha512-mmHKys/C8BFUGI+MAWNcSYoORYLMdPzjrknd2Vc+bUsjN5bXcr8EhrNB+UTqfL1y3I9c4fw2ihgtMPQLBRiQxw==",
-            "requires": {
-                "esprima": "^4.0.1",
-                "estraverse": "^5.2.0",
-                "esutils": "^2.0.2",
-                "optionator": "^0.8.1",
-                "source-map": "~0.6.1"
-            }
-        },
         "eslint-scope": {
             "version": "5.1.1",
             "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
@@ -5657,11 +5048,6 @@
                 }
             }
         },
-        "esprima": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-            "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
-        },
         "esrecurse": {
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
@@ -5674,12 +5060,8 @@
         "estraverse": {
             "version": "5.2.0",
             "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
-            "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ=="
-        },
-        "esutils": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
-            "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
+            "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
+            "dev": true
         },
         "events": {
             "version": "3.3.0",
@@ -5722,11 +5104,6 @@
             "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
             "dev": true
         },
-        "fast-levenshtein": {
-            "version": "2.0.6",
-            "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-            "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
-        },
         "fastest-levenshtein": {
             "version": "1.0.12",
             "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.12.tgz",
@@ -5766,16 +5143,6 @@
             "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
             "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
             "dev": true
-        },
-        "form-data": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
-            "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
-            "requires": {
-                "asynckit": "^0.4.0",
-                "combined-stream": "^1.0.8",
-                "mime-types": "^2.1.12"
-            }
         },
         "fs-constants": {
             "version": "1.0.0",
@@ -5990,14 +5357,6 @@
                 "lru-cache": "^6.0.0"
             }
         },
-        "html-encoding-sniffer": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-2.0.1.tgz",
-            "integrity": "sha512-D5JbOMBIR/TVZkubHT+OyT2705QvogUW4IBn6nHd756OwieSF9aDYFj4dv6HHEVGYbHaLETa3WggZYWWMyy3ZQ==",
-            "requires": {
-                "whatwg-encoding": "^1.0.5"
-            }
-        },
         "htmlparser2": {
             "version": "6.1.0",
             "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.1.0.tgz",
@@ -6014,6 +5373,7 @@
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
             "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
+            "dev": true,
             "requires": {
                 "@tootallnate/once": "1",
                 "agent-base": "6",
@@ -6024,6 +5384,7 @@
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
             "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
+            "dev": true,
             "requires": {
                 "agent-base": "6",
                 "debug": "4"
@@ -6034,14 +5395,6 @@
             "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
             "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
             "dev": true
-        },
-        "iconv-lite": {
-            "version": "0.4.24",
-            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-            "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-            "requires": {
-                "safer-buffer": ">= 2.1.2 < 3"
-            }
         },
         "ieee754": {
             "version": "1.2.1",
@@ -6147,11 +5500,6 @@
                 "isobject": "^3.0.1"
             }
         },
-        "is-potential-custom-element-name": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
-            "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ=="
-        },
         "is-stream": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
@@ -6219,40 +5567,6 @@
                 "argparse": "^2.0.1"
             }
         },
-        "jsdom": {
-            "version": "16.7.0",
-            "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-16.7.0.tgz",
-            "integrity": "sha512-u9Smc2G1USStM+s/x1ru5Sxrl6mPYCbByG1U/hUmqaVsm4tbNyS7CicOSRyuGQYZhTu0h84qkZZQ/I+dzizSVw==",
-            "requires": {
-                "abab": "^2.0.5",
-                "acorn": "^8.2.4",
-                "acorn-globals": "^6.0.0",
-                "cssom": "^0.4.4",
-                "cssstyle": "^2.3.0",
-                "data-urls": "^2.0.0",
-                "decimal.js": "^10.2.1",
-                "domexception": "^2.0.1",
-                "escodegen": "^2.0.0",
-                "form-data": "^3.0.0",
-                "html-encoding-sniffer": "^2.0.1",
-                "http-proxy-agent": "^4.0.1",
-                "https-proxy-agent": "^5.0.0",
-                "is-potential-custom-element-name": "^1.0.1",
-                "nwsapi": "^2.2.0",
-                "parse5": "6.0.1",
-                "saxes": "^5.0.1",
-                "symbol-tree": "^3.2.4",
-                "tough-cookie": "^4.0.0",
-                "w3c-hr-time": "^1.0.2",
-                "w3c-xmlserializer": "^2.0.0",
-                "webidl-conversions": "^6.1.0",
-                "whatwg-encoding": "^1.0.5",
-                "whatwg-mimetype": "^2.3.0",
-                "whatwg-url": "^8.5.0",
-                "ws": "^7.4.6",
-                "xml-name-validator": "^3.0.0"
-            }
-        },
         "json-parse-better-errors": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
@@ -6296,15 +5610,6 @@
             "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
             "dev": true
         },
-        "levn": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-            "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
-            "requires": {
-                "prelude-ls": "~1.1.2",
-                "type-check": "~0.3.2"
-            }
-        },
         "linkify-it": {
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-3.0.3.tgz",
@@ -6345,11 +5650,6 @@
             "requires": {
                 "p-locate": "^5.0.0"
             }
-        },
-        "lodash": {
-            "version": "4.17.21",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
         },
         "log-symbols": {
             "version": "4.1.0",
@@ -6482,12 +5782,14 @@
         "mime-db": {
             "version": "1.49.0",
             "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.49.0.tgz",
-            "integrity": "sha512-CIc8j9URtOVApSFCQIF+VBkX1RwXp/oMMOrqdyXSBXq5RWNEsRfyj1kiRnQgmNXmHxPoFIxOroKA3zcU9P+nAA=="
+            "integrity": "sha512-CIc8j9URtOVApSFCQIF+VBkX1RwXp/oMMOrqdyXSBXq5RWNEsRfyj1kiRnQgmNXmHxPoFIxOroKA3zcU9P+nAA==",
+            "dev": true
         },
         "mime-types": {
             "version": "2.1.32",
             "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.32.tgz",
             "integrity": "sha512-hJGaVS4G4c9TSMYh2n6SQAGrC4RnfU+daP8G7cSCmaqNjiOoUY0VHCMS42pxnQmVF1GWwFhbHWn3RIxCqTmZ9A==",
+            "dev": true,
             "requires": {
                 "mime-db": "1.49.0"
             }
@@ -6687,11 +5989,6 @@
             "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
             "dev": true
         },
-        "nwsapi": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.0.tgz",
-            "integrity": "sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ=="
-        },
         "object-assign": {
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -6720,19 +6017,6 @@
             "dev": true,
             "requires": {
                 "mimic-fn": "^2.1.0"
-            }
-        },
-        "optionator": {
-            "version": "0.8.3",
-            "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
-            "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
-            "requires": {
-                "deep-is": "~0.1.3",
-                "fast-levenshtein": "~2.0.6",
-                "levn": "~0.3.0",
-                "prelude-ls": "~1.1.2",
-                "type-check": "~0.3.2",
-                "word-wrap": "~1.2.3"
             }
         },
         "p-limit": {
@@ -6779,7 +6063,8 @@
         "parse5": {
             "version": "6.0.1",
             "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
-            "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw=="
+            "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
+            "dev": true
         },
         "parse5-htmlparser2-tree-adapter": {
             "version": "6.0.1",
@@ -6895,11 +6180,6 @@
                 "tunnel-agent": "^0.6.0"
             }
         },
-        "prelude-ls": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-            "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
-        },
         "process-nextick-args": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -6911,11 +6191,6 @@
             "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
             "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
             "dev": true
-        },
-        "psl": {
-            "version": "1.8.0",
-            "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
-            "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
         },
         "pump": {
             "version": "3.0.0",
@@ -6930,7 +6205,8 @@
         "punycode": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-            "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+            "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+            "dev": true
         },
         "qs": {
             "version": "6.10.1",
@@ -7066,24 +6342,11 @@
             "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
             "dev": true
         },
-        "safer-buffer": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
-        },
         "sax": {
             "version": "1.2.4",
             "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
             "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
             "dev": true
-        },
-        "saxes": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/saxes/-/saxes-5.0.1.tgz",
-            "integrity": "sha512-5LBh1Tls8c9xgGjw3QrMwETmTMVk0oFgvrFSvWx62llR2hcEInrKNZ2GZCCuuy2lvWrdl5jhbpeqc5hRYKFOcw==",
-            "requires": {
-                "xmlchars": "^2.2.0"
-            }
         },
         "schema-utils": {
             "version": "3.1.1",
@@ -7187,7 +6450,7 @@
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
             "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-            "devOptional": true
+            "dev": true
         },
         "source-map-support": {
             "version": "0.5.20",
@@ -7255,11 +6518,6 @@
             "requires": {
                 "has-flag": "^3.0.0"
             }
-        },
-        "symbol-tree": {
-            "version": "3.2.4",
-            "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
-            "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="
         },
         "tapable": {
             "version": "1.1.3",
@@ -7362,24 +6620,6 @@
                 "is-number": "^7.0.0"
             }
         },
-        "tough-cookie": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.0.0.tgz",
-            "integrity": "sha512-tHdtEpQCMrc1YLrMaqXXcj6AxhYi/xgit6mZu1+EDWUn+qhUf8wMQoFIy9NXuq23zAwtcB0t/MjACGR18pcRbg==",
-            "requires": {
-                "psl": "^1.1.33",
-                "punycode": "^2.1.1",
-                "universalify": "^0.1.2"
-            }
-        },
-        "tr46": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/tr46/-/tr46-2.1.0.tgz",
-            "integrity": "sha512-15Ih7phfcdP5YxqiB+iDtLoaTz4Nd35+IiAv0kQ5FNKHzXgdWqPoTIqEDDJmXceQt4JZk6lVPT8lnDlPpGDppw==",
-            "requires": {
-                "punycode": "^2.1.1"
-            }
-        },
         "traverse": {
             "version": "0.3.9",
             "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
@@ -7471,14 +6711,6 @@
                 "safe-buffer": "^5.0.1"
             }
         },
-        "type-check": {
-            "version": "0.3.2",
-            "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-            "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
-            "requires": {
-                "prelude-ls": "~1.1.2"
-            }
-        },
         "typed-rest-client": {
             "version": "1.8.6",
             "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.8.6.tgz",
@@ -7507,11 +6739,6 @@
             "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.1.tgz",
             "integrity": "sha512-hzSoAVtJF+3ZtiFX0VgfFPHEDRm7Y/QPjGyNo4TVdnDTdft3tr8hEkD25a1jC+TjTuE7tkHGKkhwCgs9dgBB2g==",
             "dev": true
-        },
-        "universalify": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-            "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
         },
         "unzipper": {
             "version": "0.10.11",
@@ -7635,22 +6862,6 @@
                 "unzipper": "^0.10.11"
             }
         },
-        "w3c-hr-time": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.2.tgz",
-            "integrity": "sha512-z8P5DvDNjKDoFIHK7q8r8lackT6l+jo/Ye3HOle7l9nICP9lf1Ci25fy9vHd0JOWewkIFzXIEig3TdKT7JQ5fQ==",
-            "requires": {
-                "browser-process-hrtime": "^1.0.0"
-            }
-        },
-        "w3c-xmlserializer": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-2.0.0.tgz",
-            "integrity": "sha512-4tzD0mF8iSiMiNs30BiLO3EpfGLZUT2MSX/G+o7ZywDzliWQ3OPtTZ0PTC3B3ca1UAf4cJMHB+2Bf56EriJuRA==",
-            "requires": {
-                "xml-name-validator": "^3.0.0"
-            }
-        },
         "watchpack": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.2.0.tgz",
@@ -7660,11 +6871,6 @@
                 "glob-to-regexp": "^0.4.1",
                 "graceful-fs": "^4.1.2"
             }
-        },
-        "webidl-conversions": {
-            "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-6.1.0.tgz",
-            "integrity": "sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w=="
         },
         "webpack": {
             "version": "5.52.1",
@@ -7761,29 +6967,6 @@
             "integrity": "sha512-t6BMVLQ0AkjBOoRTZgqrWm7xbXMBzD+XDq2EZ96+vMfn3qKgsvdXZhbPZ4ElUOpdv4u+iiGe+w3+J75iy/bYGA==",
             "dev": true
         },
-        "whatwg-encoding": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz",
-            "integrity": "sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==",
-            "requires": {
-                "iconv-lite": "0.4.24"
-            }
-        },
-        "whatwg-mimetype": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",
-            "integrity": "sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g=="
-        },
-        "whatwg-url": {
-            "version": "8.7.0",
-            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.7.0.tgz",
-            "integrity": "sha512-gAojqb/m9Q8a5IV96E3fHJM70AzCkgt4uXYX2O7EmuyOnLrViCQlsEBmF9UQIu3/aeAIp2U17rtbpZWNntQqdg==",
-            "requires": {
-                "lodash": "^4.7.0",
-                "tr46": "^2.1.0",
-                "webidl-conversions": "^6.1.0"
-            }
-        },
         "which": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -7807,11 +6990,6 @@
             "resolved": "https://registry.npmjs.org/wildcard/-/wildcard-2.0.0.tgz",
             "integrity": "sha512-JcKqAHLPxcdb9KM49dufGXn2x3ssnfjbcaQdLlfZsL9rH9wgDQjUtDxbo8NE0F6SFvydeu1VhZe7hZuHsB2/pw==",
             "dev": true
-        },
-        "word-wrap": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-            "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ=="
         },
         "workerpool": {
             "version": "6.2.0",
@@ -7894,17 +7072,6 @@
             "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
             "dev": true
         },
-        "ws": {
-            "version": "7.5.5",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.5.tgz",
-            "integrity": "sha512-BAkMFcAzl8as1G/hArkxOxq3G7pjUqQ3gzYbLL0/5zNkph70e+lCoxBGnm6AW1+/aiNeV4fnKqZ8m4GZewmH2w==",
-            "requires": {}
-        },
-        "xml-name-validator": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
-            "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw=="
-        },
         "xml2js": {
             "version": "0.4.23",
             "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
@@ -7920,11 +7087,6 @@
             "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
             "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
             "dev": true
-        },
-        "xmlchars": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
-            "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="
         },
         "y18n": {
             "version": "5.0.8",

--- a/code/package.json
+++ b/code/package.json
@@ -31,13 +31,11 @@
     },
     "main": "dist/extension",
     "dependencies": {
-        "jsdom": "^16.7.0",
         "semver": "^7.3.5",
         "vscode-languageclient": "^7.0.0"
     },
     "devDependencies": {
         "@types/glob": "^7.1.4",
-        "@types/jsdom": "^16.2.13",
         "@types/mocha": "^8.2.3",
         "@types/node": "^14.17.15",
         "@types/semver": "^7.3.8",

--- a/code/src/lsp/client.ts
+++ b/code/src/lsp/client.ts
@@ -272,6 +272,7 @@ export class EsbonioClient {
 
     this.client.onNotification("esbonio/buildComplete", (result: BuildCompleteResult) => {
       this.logger.debug(`Build complete ${JSON.stringify(result, null, 2)}`)
+      this.sphinxConfig = result.config.sphinx
       this.buildCompleteCallbacks.forEach(fn => {
         fn(result)
       })

--- a/code/webpack.config.js
+++ b/code/webpack.config.js
@@ -17,9 +17,6 @@ const config = {
     },
     devtool: 'source-map',
     externals: {
-        bufferutil: 'util',        // See [2]
-        canvas: "util",            // See [1]
-        'utf-8-validate': 'util',  // See [2]
         vscode: "commonjs vscode"
     },
     resolve: {
@@ -46,17 +43,3 @@ const config = {
 }
 
 module.exports = config
-
-/*
- [1] https://github.com/jsdom/jsdom/issues/2508#issuecomment-777387562
-
- We don't want or need canvas support, as we only use jsdom to rewrite some
- urls so that external assets load in the webview preview.
-
- This gets webpack to rewrite the "import canvas" statements to "import util"
- and apparently the library is able to degrade gracefully!
- */
-
-/*
-  [2]: Similar to above, we don't need websocket support.
- */

--- a/lib/esbonio/changes/275.feature.rst
+++ b/lib/esbonio/changes/275.feature.rst
@@ -1,0 +1,1 @@
+The server now provides an `esbonio.server.preview` command that can be used to preview HTML Sphinx projects via a local HTTP server.

--- a/lib/esbonio/esbonio/lsp/__init__.py
+++ b/lib/esbonio/esbonio/lsp/__init__.py
@@ -4,6 +4,8 @@ import json
 import logging
 import textwrap
 import traceback
+from typing import Any
+from typing import Dict
 from typing import Iterable
 from typing import Type
 
@@ -257,15 +259,23 @@ def _configure_lsp_methods(server: RstLanguageServer) -> RstLanguageServer:
         """Get the server's configuration.
 
         Not to be confused with the ``workspace/configuration`` request where the server
-        can request the client's configuration. This is so client's can ask for sphinx's
+        can request the client's configuration. This is so clients can ask for sphinx's
         output path for example.
 
         As far as I know, there isn't anything built into the spec to cater for this?
         """
         config = ls.configuration
-        ls.logger.debug("%s: %s", "esbonio.server.configuration", config)
+        ls.logger.debug("%s: %s", "esbonio.server.configuration", dump(config))
 
         return config
+
+    @server.command("esbonio.server.preview")
+    def preview(ls: RstLanguageServer, *args) -> Dict[str, Any]:
+        """Start/Generate a preview of the project"""
+        params = args[0][0]
+        ls.logger.debug("esbonio.server.preview: %s", params)
+
+        return ls.preview(params._asdict()) or {}
 
     return server
 

--- a/lib/esbonio/esbonio/lsp/rst/__init__.py
+++ b/lib/esbonio/esbonio/lsp/rst/__init__.py
@@ -443,6 +443,15 @@ class RstLanguageServer(LanguageServer):
         line = self.line_at_position(doc, position)
         return line[: position.character]
 
+    def preview(self, options: Dict[str, Any]) -> Dict[str, Any]:
+        """Generate a preview of the documentation."""
+        name = self.__class__.__name__
+        self.show_message(
+            f"Previews are not currently supported by {name} based servers"
+        )
+
+        return {}
+
     def text_to_position(self, doc: Document, position: Position) -> str:
         """Return the contents of the document up until the given position.
 

--- a/lib/esbonio/esbonio/lsp/rst/__init__.py
+++ b/lib/esbonio/esbonio/lsp/rst/__init__.py
@@ -118,6 +118,9 @@ class LanguageFeature:
     def initialized(self, params: InitializedParams) -> None:
         """Called once upon receipt of the `initialized` notification from the client."""
 
+    def on_shutdown(self, *args):
+        """Called as the server is shutting down."""
+
     def save(self, params: DidSaveTextDocumentParams) -> None:
         """Called each time a document is saved."""
 
@@ -257,6 +260,9 @@ class RstLanguageServer(LanguageServer):
         self._configure_logging(self.user_config.server)
 
     def initialized(self, params: InitializedParams):
+        pass
+
+    def on_shutdown(self, *args):
         pass
 
     def save(self, params: DidSaveTextDocumentParams):

--- a/lib/esbonio/esbonio/lsp/sphinx/preview.py
+++ b/lib/esbonio/esbonio/lsp/sphinx/preview.py
@@ -1,0 +1,27 @@
+import logging
+from functools import partial
+from http.server import HTTPServer
+from http.server import SimpleHTTPRequestHandler
+from typing import Any
+from typing import Type
+
+try:
+    from http.server import ThreadingHTTPServer
+
+    ServerClass: Type[HTTPServer] = ThreadingHTTPServer
+except ImportError:
+    # ThreadingHTTPServer is only availble in Python 3.7+
+    ServerClass = HTTPServer
+
+logger = logging.getLogger(__name__)
+
+
+class RequestHandler(SimpleHTTPRequestHandler):
+    def log_message(self, format: str, *args: Any) -> None:
+        return logger.debug(format, *args)
+
+
+def make_preview_server(directory: str) -> HTTPServer:
+    """Construst a http server that can be used to preview the docs."""
+    handler_class = partial(RequestHandler, directory=directory)
+    return ServerClass(("localhost", 0), handler_class)

--- a/lib/esbonio/esbonio/lsp/testing.py
+++ b/lib/esbonio/esbonio/lsp/testing.py
@@ -26,6 +26,7 @@ from pygls.lsp.methods import TEXT_DOCUMENT_DID_CLOSE
 from pygls.lsp.methods import TEXT_DOCUMENT_DID_OPEN
 from pygls.lsp.methods import TEXT_DOCUMENT_PUBLISH_DIAGNOSTICS
 from pygls.lsp.methods import WINDOW_LOG_MESSAGE
+from pygls.lsp.methods import WINDOW_SHOW_DOCUMENT
 from pygls.lsp.methods import WINDOW_SHOW_MESSAGE
 from pygls.lsp.types import ClientCapabilities
 from pygls.lsp.types import CompletionItem
@@ -42,6 +43,8 @@ from pygls.lsp.types import InitializeParams
 from pygls.lsp.types import Location
 from pygls.lsp.types import Position
 from pygls.lsp.types import Range
+from pygls.lsp.types import ShowDocumentParams
+from pygls.lsp.types import ShowMessageParams
 from pygls.lsp.types import TextDocumentContentChangeEvent
 from pygls.lsp.types import TextDocumentIdentifier
 from pygls.lsp.types import TextDocumentItem
@@ -542,8 +545,14 @@ class Client(LanguageServer):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        self.messages: List[Any] = []
+        self.messages: List[ShowMessageParams] = []
+        """Holds any received ``window/showMessage`` requests"""
+
         self.diagnostics: Dict[str, List[Diagnostic]] = {}
+        """Holds any received diagnostics"""
+
+        self.documents_shown: List[ShowDocumentParams] = []
+        """Holds any received ``window/showDocument`` requests"""
 
 
 def new_test_client() -> Client:
@@ -557,6 +566,10 @@ def new_test_client() -> Client:
     @client.feature(WINDOW_LOG_MESSAGE)
     def log_message(client: Client, params):
         pass
+
+    @client.feature(WINDOW_SHOW_DOCUMENT)
+    def show_document(client: Client, params: ShowDocumentParams):
+        client.documents_shown.append(params)
 
     @client.feature(WINDOW_SHOW_MESSAGE)
     def show_message(client: Client, params):


### PR DESCRIPTION
- The language server now spins up a local `http.server` in the build directory of the project which clients/browsers can connect to.
  Currently this is limited to Sphinx projects using the `html` builder.
- Switches the preview mechanism in the VSCode extension to use an `<iframe>` rather than trying to read the html content from disk

Closes #275 