### PR TITLE
Implement goto definition for `image::` and `figure::`

### DIFF
--- a/lib/esbonio/changes/318.feature.rst
+++ b/lib/esbonio/changes/318.feature.rst
@@ -1,0 +1,1 @@
+The language server now supports ``textDocument/definition`` requests for ``.. image::`` directive arguments.

--- a/lib/esbonio/changes/319.feature.rst
+++ b/lib/esbonio/changes/319.feature.rst
@@ -1,0 +1,1 @@
+The language server now supports ``textDocument/definition`` requests for ``.. figure::`` directive arguments.

--- a/lib/esbonio/esbonio/lsp/sphinx/images.py
+++ b/lib/esbonio/esbonio/lsp/sphinx/images.py
@@ -1,12 +1,18 @@
 import os.path
+import pathlib
 import typing
 from typing import List
+from typing import Optional
 
 import pygls.uris as Uri
 from pygls.lsp.types import CompletionItem
+from pygls.lsp.types import Location
+from pygls.lsp.types import Position
+from pygls.lsp.types import Range
 
 from esbonio.lsp.directives import Directives
 from esbonio.lsp.rst import CompletionContext
+from esbonio.lsp.rst import DefinitionContext
 from esbonio.lsp.rst import RstLanguageServer
 from esbonio.lsp.sphinx import SphinxLanguageServer
 from esbonio.lsp.util.filepaths import complete_sphinx_filepaths
@@ -35,6 +41,43 @@ class Images:
 
         return [path_to_completion_item(context, p) for p in items]
 
+    def find_definitions(
+            self,
+            context: DefinitionContext,
+            directive: str,
+            domain: Optional[str],
+            argument: str,
+        ) -> List[Location]:
+
+            if domain or directive not in {"figure", "image"}:
+                return []
+
+            if argument.startswith("/"):
+                if not self.rst.app:
+                    return []
+
+                basedir = pathlib.Path(self.rst.app.srcdir)
+
+                # Remove the leading '/' otherwise is will wipe out the basedir when
+                # concatenated
+                argument = argument[1:]
+
+            else:
+                basedir = pathlib.Path(Uri.to_fs_path(context.doc.uri)).parent
+
+            fpath = (basedir / argument).resolve()
+            if not fpath.exists():
+                return []
+
+            return [
+                Location(
+                    uri=Uri.from_fs_path(str(fpath)),
+                    range=Range(
+                        start=Position(line=0, character=0),
+                        end=Position(line=1, character=0),
+                    ),
+                )
+            ]
 
 def esbonio_setup(rst: RstLanguageServer):
 
@@ -47,4 +90,6 @@ def esbonio_setup(rst: RstLanguageServer):
     # To keep mypy happy.
     directives = typing.cast(Directives, directives)
 
-    directives.add_argument_completion_provider(Images(rst))
+    images = Images(rst)
+    directives.add_argument_definition_provider(images)
+    directives.add_argument_completion_provider(images)

--- a/lib/esbonio/tests/data/sphinx-default/definitions.rst
+++ b/lib/esbonio/tests/data/sphinx-default/definitions.rst
@@ -22,3 +22,7 @@ Some literal includes now
 .. literalinclude:: /theorems/pythagoras.rst
 
 .. literalinclude:: ../sphinx-default/index.rst
+
+.. image:: /_static/vscode-screenshot.png
+
+.. figure:: /_static/bad.png

--- a/lib/esbonio/tests/sphinx/test_includes.py
+++ b/lib/esbonio/tests/sphinx/test_includes.py
@@ -96,6 +96,24 @@ THEOREM_FILES = {"index.rst", "pythagoras.rst"}
                 ),
             ),
         ),
+        (
+            "sphinx-default",
+            "definitions.rst",
+            Position(line=25, character=25),
+            Location(
+                uri="_static/vscode-screenshot.png",
+                range=Range(
+                    start=Position(line=0, character=0),
+                    end=Position(line=1, character=0),
+                ),
+            ),
+        ),
+        (
+            "sphinx-default",
+            "definitions.rst",
+            Position(line=27, character=25),
+            None
+        ),
     ],
 )
 async def test_include_definitions(


### PR DESCRIPTION
Implement goto definition for `image::` and `figure::`

Closes #318
Closes #319 