### PR TITLE
Treat Sphinx modules as potential Esbonio modules

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -10,12 +10,20 @@
 #
 import os
 import sys
+from typing import List
 
 sys.path.insert(0, os.path.abspath("../lib/esbonio"))
 sys.path.insert(0, os.path.abspath("./ext"))
 
 from docutils.parsers.rst import nodes
 from sphinx.application import Sphinx
+
+import pygls.lsp.methods as M
+from pygls.lsp.types import CompletionItem
+from pygls.lsp.types import CompletionItemKind
+
+from esbonio.lsp.roles import TargetCompletion
+from esbonio.lsp.rst import CompletionContext
 
 import esbonio.lsp
 
@@ -81,6 +89,33 @@ if DEV_BUILD:
     )
 
 
+class LspMethod(TargetCompletion):
+    """Provides completion suggestions for the custom ``:lsp:`` role."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._index_methods()
+
+    def _index_methods(self):
+        self.items = []
+
+        for name, meth in M.__dict__.items():
+
+            if not isinstance(meth, str) or not name.isupper():
+                continue
+
+            item = CompletionItem(label=meth, kind=CompletionItemKind.Constant)
+            self.items.append(item)
+
+    def complete_targets(
+        self, context: CompletionContext, name: str, domain: str
+    ) -> List[CompletionItem]:
+        if name == "lsp":
+            return self.items
+
+        return []
+
+
 def lsp_role(name, rawtext, text, lineno, inliner, options={}, content=[]):
     """Link to sections within the lsp specification."""
 
@@ -110,3 +145,9 @@ def setup(app: Sphinx):
         objname="IPython magic",
         indextemplate="pair: %s; IPython magic",
     )
+
+
+def esbonio_setup(rst):
+    roles = rst.get_feature("esbonio.lsp.roles.Roles")
+    if roles:
+        roles.add_target_completion_provider(LspMethod())

--- a/lib/esbonio/changes/327.fix.rst
+++ b/lib/esbonio/changes/327.fix.rst
@@ -1,0 +1,1 @@
+Goto definition on a directive's arguments is no longer foiled by trailing whitespace.

--- a/lib/esbonio/changes/331.feature.rst
+++ b/lib/esbonio/changes/331.feature.rst
@@ -1,0 +1,1 @@
+The language server will now look in sphinx extension modules and ``conf.py`` files for extensions to the language server.

--- a/lib/esbonio/esbonio/lsp/directives.py
+++ b/lib/esbonio/esbonio/lsp/directives.py
@@ -34,15 +34,15 @@ except ImportError:
 
 DIRECTIVE = re.compile(
     r"""
-    (\s*)                           # directives can be indented
+    (\s*)                             # directives can be indented
     (?P<directive>
-      \.\.                          # directives start with a comment
-      [ ]?                          # followed by a space
-      ((?P<domain>[\w]+):(?!:))?    # directives may include a domain
-      (?P<name>([\w-]|:(?!:))+)?    # directives have a name
-      (::)?                         # directives end with '::'
+      \.\.                            # directives start with a comment
+      [ ]?                            # followed by a space
+      ((?P<domain>[\w]+):(?!:))?      # directives may include a domain
+      (?P<name>([\w-]|:(?!:))+)?      # directives have a name
+      (::)?                           # directives end with '::'
     )
-    ([\s]+(?P<argument>.*$))?       # directives may take an argument
+    ([\s]+(?P<argument>.*?)\s*$)?     # directives may take an argument
     """,
     re.VERBOSE,
 )

--- a/lib/esbonio/esbonio/lsp/rst/__init__.py
+++ b/lib/esbonio/esbonio/lsp/rst/__init__.py
@@ -239,6 +239,9 @@ class RstLanguageServer(LanguageServer):
         self._diagnostics: Dict[Tuple[str, str], List[Diagnostic]] = {}
         """Where we store and manage diagnostics."""
 
+        self._loaded_modules: Dict[str, Any] = {}
+        """Record of modules that have been loaded."""
+
         self._features: Dict[str, LanguageFeature] = {}
         """The list of language features registered with the server."""
 

--- a/lib/esbonio/tests/test_directives.py
+++ b/lib/esbonio/tests/test_directives.py
@@ -536,6 +536,14 @@ async def test_insert_range(client_server, project, text, character, expected_ra
             {"name": "image", "argument": "filename.png", "directive": ".. image::"},
         ),
         (
+            ".. image:: filename.png  ",
+            {"name": "image", "argument": "filename.png", "directive": ".. image::"},
+        ),
+        (
+            ".. image:: filename.png\r",
+            {"name": "image", "argument": "filename.png", "directive": ".. image::"},
+        ),
+        (
             ".. cpp:function:: malloc",
             {
                 "name": "function",


### PR DESCRIPTION
- Anywhere where you can extend sphinx you can now extend Esbonio, this allows for Sphinx extensions and any additional LSP support to co-exist in the same module
  Closes #331
- Prevent trailing whitespace from appearing in the `argument` group of the `DIRECTIVE` regex
  Closes #327 