### PR TITLE
lsp: Lookup `:ref:` targets by name

### DIFF
--- a/lib/esbonio/changes/357.fix.rst
+++ b/lib/esbonio/changes/357.fix.rst
@@ -1,0 +1,1 @@
+Goto definition for ``:ref:`` targets now works for labels containing ``-`` characters

--- a/lib/esbonio/esbonio/lsp/sphinx/domains.py
+++ b/lib/esbonio/esbonio/lsp/sphinx/domains.py
@@ -138,7 +138,7 @@ class DomainFeatures:
             if "refid" not in node:
                 continue
 
-            if label == node["refid"].replace("-", "_"):
+            if doctree.nameids.get(label, "") == node["refid"]:
                 uri = Uri.from_fs_path(node.source)
                 line = node.line
                 break

--- a/lib/esbonio/tests/sphinx-default/test_sd_sphinx_domains.py
+++ b/lib/esbonio/tests/sphinx-default/test_sd_sphinx_domains.py
@@ -272,6 +272,17 @@ WELCOME_LABEL = Location(
                 ),
             ),
         ),
+        (
+            "definitions.rst",
+            Position(line=29, character=36),
+            Location(
+                uri="index.rst",
+                range=Range(
+                    start=Position(line=18, character=0),
+                    end=Position(line=19, character=0),
+                ),
+            ),
+        ),
     ],
 )
 async def test_role_target_definitions(client: Client, path, position, expected):

--- a/lib/esbonio/tests/sphinx-default/workspace/definitions.rst
+++ b/lib/esbonio/tests/sphinx-default/workspace/definitions.rst
@@ -26,3 +26,5 @@ Some literal includes now
 .. image:: /_static/vscode-screenshot.png
 
 .. figure:: /_static/bad.png
+
+This line refers to :ref:`setup-label`

--- a/lib/esbonio/tests/sphinx-default/workspace/index.rst
+++ b/lib/esbonio/tests/sphinx-default/workspace/index.rst
@@ -16,6 +16,8 @@ Welcome to Defaults's documentation!
    definitions
    glossary
 
+.. _setup-label:
+
 Setup
 =====
 


### PR DESCRIPTION
It turns out that when docutils transforms a label into the id used in
the parsed doctree, it also maintains a mapping of the "names" that
correspond to these ids.

To ensure that the language server correctly handles all forms of label
it now uses this map to look up the correct id to search for.

Closes #357 