### PR TITLE
Add parallel build support

### DIFF
--- a/code/changes/359.enhancement.rst
+++ b/code/changes/359.enhancement.rst
@@ -1,0 +1,1 @@
+Added the ``esbonio.sphinx.numJobs`` option (default: ``auto``) which can be used to control the number of parallel jobs used by Sphinx.

--- a/code/package.json
+++ b/code/package.json
@@ -256,6 +256,12 @@
                         "default": true,
                         "description": "By default the language server will force a full build of your documentation on startup to help improve the accuracy of some features like diagnostics. Disabling this option can help improve startup time for larger projects at the expense of certain features being less accurate."
                     },
+                    "esbonio.sphinx.numJobs": {
+                        "scope": "window",
+                        "type": "integer",
+                        "default": 0,
+                        "markdownDescription": "The number of parallel jobs to use during a Sphinx build.\n\n- A value of `0` is equivalent to passing `-j auto` to a `sphinx-build` command.\n- A value of `1` will disable parallel processing."
+                    },
                     "esbonio.sphinx.srcDir": {
                         "scope": "window",
                         "type": "string",

--- a/code/src/lsp/client.ts
+++ b/code/src/lsp/client.ts
@@ -19,21 +19,6 @@ const DEBUG = process.env.VSCODE_LSP_DEBUG === "true"
 export interface SphinxConfig {
 
   /**
-   * Sphinx's version number.
-   */
-  version?: string
-
-  /**
-   * The directory containing the project's 'conf.py' file.
-   */
-  confDir?: string
-
-  /**
-   * The source dir containing the *.rst files for the project.
-   */
-  srcDir?: string
-
-  /**
    * The directory where Sphinx's build output should be stored.
    */
   buildDir?: string
@@ -44,9 +29,29 @@ export interface SphinxConfig {
   builderName?: string
 
   /**
+   * The directory containing the project's 'conf.py' file.
+   */
+  confDir?: string
+
+  /**
    * Flag to force a full build of the documentation on startup.
    */
   forceFullBuild?: boolean
+
+  /**
+   * The number of parallel jobs to use
+   */
+  numJobs?: number | string
+
+  /**
+   * The source dir containing the *.rst files for the project.
+   */
+  srcDir?: string
+
+  /**
+   * Sphinx's version number.
+   */
+  version?: string
 }
 
 /**
@@ -289,19 +294,22 @@ export class EsbonioClient {
    */
   private getLanguageClientOptions(config: vscode.WorkspaceConfiguration): LanguageClientOptions {
 
-    let cache = this.context.storageUri.path
 
     let buildDir = config.get<string>('sphinx.buildDir')
+    let numJobs = config.get<number>('sphinx.numJobs')
+
     if (!buildDir) {
+      let cache = this.context.storageUri.path
       buildDir = join(cache, 'sphinx')
     }
 
     let initOptions: InitOptions = {
       sphinx: {
-        srcDir: config.get<string>("sphinx.srcDir"),
-        confDir: config.get<string>('sphinx.confDir'),
         buildDir: buildDir,
-        forceFullBuild: config.get<boolean>('sphinx.forceFullBuild')
+        confDir: config.get<string>('sphinx.confDir'),
+        forceFullBuild: config.get<boolean>('sphinx.forceFullBuild'),
+        numJobs: numJobs === 0 ? 'auto' : numJobs,
+        srcDir: config.get<string>("sphinx.srcDir"),
       },
       server: {
         logLevel: config.get<string>('server.logLevel'),

--- a/docs/lsp/api-reference.rst
+++ b/docs/lsp/api-reference.rst
@@ -11,13 +11,24 @@ Language Servers
 
 .. autofunction:: esbonio.lsp.create_language_server
 
+RstLanguageServer
+^^^^^^^^^^^^^^^^^
+
 .. autoclass:: esbonio.lsp.rst.RstLanguageServer
    :members:
    :show-inheritance:
 
+SphinxLanguageServer
+^^^^^^^^^^^^^^^^^^^^
+
+.. autoclass:: esbonio.lsp.sphinx.SphinxConfig
+   :members:
+
 .. autoclass:: esbonio.lsp.sphinx.SphinxLanguageServer
    :members:
    :show-inheritance:
+
+.. autoclass:: esbonio.lsp.sphinx.MissingConfigError
 
 Language Features
 -----------------

--- a/docs/lsp/getting-started.rst
+++ b/docs/lsp/getting-started.rst
@@ -208,6 +208,12 @@ Configuration
 
    Flag that indicates if the server should force a full build of the documentation on startup. (Default: ``true``)
 
+.. confval:: sphinx.numJobs (string or integer)
+
+   Controls the number of parallel jobs used during a Sphinx build.
+
+   The default value of ``"auto"`` will behave the same as passing ``-j auto`` to a ``sphinx-build`` command. Setting this value to ``1`` effectively disables parallel builds.
+
 .. confval:: server.logLevel (string)
 
    This can be used to set the level of log messages emitted by the server. This can be set

--- a/lib/esbonio/changes/359.enhancement.rst
+++ b/lib/esbonio/changes/359.enhancement.rst
@@ -1,0 +1,1 @@
+Language clients can now control the number of parallel jobs by providing a ``sphinx.numJobs`` initialization option, which defaults to ``auto``. Clients can disable parallel builds by setting this option to ``1``

--- a/lib/esbonio/setup.cfg
+++ b/lib/esbonio/setup.cfg
@@ -35,6 +35,8 @@ install_requires =
     sphinx
     pygls>=0.11.0,<0.12.0
     pyspellchecker
+    typing-extensions
+
 
 [options.packages.find]
 exclude = tests*

--- a/lib/esbonio/tests/unit_tests/test_sphinx.py
+++ b/lib/esbonio/tests/unit_tests/test_sphinx.py
@@ -2,9 +2,6 @@ import pathlib
 
 import pytest
 
-from esbonio.lsp.sphinx import expand_conf_dir
-from esbonio.lsp.sphinx import get_build_dir
-from esbonio.lsp.sphinx import get_src_dir
 from esbonio.lsp.sphinx import SphinxConfig
 
 
@@ -37,12 +34,13 @@ from esbonio.lsp.sphinx import SphinxConfig
         ),
     ],
 )
-def test_expand_conf_dir(setup, expected):
-    """Ensure that the ``expand_conf_dir`` function works as expected."""
+def test_resolve_conf_dir(setup, expected):
+    """Ensure that the ``resolve_conf_dir`` function works as expected."""
 
     root_uri, conf_dir = setup
+    config = SphinxConfig(confDir=conf_dir)
 
-    actual = expand_conf_dir(root_uri, conf_dir)
+    actual = config.resolve_conf_dir(root_uri)
     assert actual == expected
 
 
@@ -115,12 +113,12 @@ def test_expand_conf_dir(setup, expected):
         ),
     ],
 )
-def test_get_src_dir(setup, expected):
-    """Ensure that the ``get_src_dir`` function works as expected."""
+def test_resolve_src_dir(setup, expected):
+    """Ensure that the ``resolve_src_dir`` function works as expected."""
 
-    root_uri, conf_dir, sphinx_config = setup
+    root_uri, conf_dir, config = setup
 
-    actual = get_src_dir(root_uri, conf_dir, sphinx_config)
+    actual = config.resolve_src_dir(root_uri, conf_dir)
     assert actual == expected
 
 
@@ -193,10 +191,10 @@ def test_get_src_dir(setup, expected):
         ),
     ],
 )
-def test_get_build_dir(setup, expected):
-    """Ensure that the ``get_build_dir`` function works as expected."""
+def test_resolve_build_dir(setup, expected):
+    """Ensure that the ``resolve_build_dir`` function works as expected."""
 
-    root_uri, conf_dir, sphinx_config = setup
+    root_uri, conf_dir, config = setup
 
-    actual = get_build_dir(root_uri, conf_dir, sphinx_config)
+    actual = config.resolve_build_dir(root_uri, conf_dir)
     assert actual == expected


### PR DESCRIPTION
This adds a new `sphinx.numJobs` initialization option that can control the number of parallel builds used by Sphinx. Its default value is ``"auto"`` (and behaves just like `-j auto`). Parallel builds can be disabled by setting its value to `1`

Closes #359 