### PR TITLE
"Initial doctree" support

### DIFF
--- a/lib/esbonio/changes/361.fix.rst
+++ b/lib/esbonio/changes/361.fix.rst
@@ -1,0 +1,1 @@
+``.. include::`` directives no longer break goto definition for ``:ref:`` role targets

--- a/lib/esbonio/changes/374.api.rst
+++ b/lib/esbonio/changes/374.api.rst
@@ -1,0 +1,1 @@
+Add method ``get_initial_doctree`` to ``RstLanguageServer`` which can be used to obtain a doctree of the given file before any role and directives have been applied.

--- a/lib/esbonio/changes/374.enhancement.rst
+++ b/lib/esbonio/changes/374.enhancement.rst
@@ -1,0 +1,1 @@
+``textDocument/documentSymbol`` responses now include symbol information on directives.

--- a/lib/esbonio/esbonio/lsp/__init__.py
+++ b/lib/esbonio/esbonio/lsp/__init__.py
@@ -47,7 +47,7 @@ from .rst import DefinitionContext
 from .rst import DocumentLinkContext
 from .rst import LanguageFeature
 from .rst import RstLanguageServer
-from .rst import SymbolVisitor
+from .symbols import SymbolVisitor
 
 __version__ = "0.11.2"
 
@@ -279,7 +279,7 @@ def _configure_lsp_methods(server: RstLanguageServer) -> RstLanguageServer:
     @server.feature(DOCUMENT_SYMBOL)
     def on_document_symbol(ls: RstLanguageServer, params: DocumentSymbolParams):
 
-        doctree = ls.get_doctree(uri=params.text_document.uri)
+        doctree = ls.get_initial_doctree(uri=params.text_document.uri)
         if doctree is None:
             return []
 

--- a/lib/esbonio/esbonio/lsp/directives.py
+++ b/lib/esbonio/esbonio/lsp/directives.py
@@ -26,6 +26,8 @@ from esbonio.lsp import DocumentLinkContext
 from esbonio.lsp import LanguageFeature
 from esbonio.lsp import RstLanguageServer
 from esbonio.lsp.sphinx import SphinxLanguageServer
+from esbonio.lsp.util.patterns import DIRECTIVE
+from esbonio.lsp.util.patterns import DIRECTIVE_OPTION
 
 try:
     from typing import Protocol
@@ -33,60 +35,6 @@ except ImportError:
     # Protocol is only available in Python 3.8+
     class Protocol:  # type: ignore
         ...
-
-
-DIRECTIVE = re.compile(
-    r"""
-    (\s*)                             # directives can be indented
-    (?P<directive>
-      \.\.                            # directives start with a comment
-      [ ]?                            # followed by a space
-      ((?P<domain>[\w]+):(?!:))?      # directives may include a domain
-      (?P<name>([\w-]|:(?!:))+)?      # directives have a name
-      (::)?                           # directives end with '::'
-    )
-    ([\s]+(?P<argument>.*?)\s*$)?     # directives may take an argument
-    """,
-    re.VERBOSE,
-)
-"""A regular expression to detect and parse partial and complete directives.
-
-This does **not** include any options or content that may be included underneath
-the initial declaration. The language server breaks a directive down into a number
-of parts::
-
-                   vvvvvv argument
-   .. c:function:: malloc
-   ^^^^^^^^^^^^^^^ directive
-        ^^^^^^^^ name
-      ^ domain (optional)
-"""
-
-
-DIRECTIVE_OPTION = re.compile(
-    r"""
-    (?P<indent>\s+)       # directive options must be indented
-    (?P<option>
-      :                   # options start with a ':'
-      (?P<name>[\w-]+)?   # options have a name
-      :?                  # options end with a ':'
-    )
-    (\s*
-      (?P<value>.*)       # options can have a value
-    )?
-    """,
-    re.VERBOSE,
-)
-"""A regular expression used to detect and parse partial and complete directive options.
-
-The language server breaks an option down into a number of parts::
-
-               vvvvvv value
-   |   :align: center
-       ^^^^^^^ option
-        ^^^^^ name
-    ^^^ indent
-"""
 
 
 class ArgumentCompletion(Protocol):
@@ -671,7 +619,6 @@ class Directives(LanguageFeature):
 
 def esbonio_setup(rst: RstLanguageServer):
     """Configure and reigster the directives feature with the server."""
-
     directives = Directives(rst)
     rst.add_feature(directives)
 

--- a/lib/esbonio/esbonio/lsp/rst/io.py
+++ b/lib/esbonio/esbonio/lsp/rst/io.py
@@ -1,0 +1,210 @@
+import logging
+import pathlib
+import typing
+from typing import Any
+from typing import Callable
+from typing import IO
+from typing import Optional
+from typing import Type
+
+from docutils import nodes
+from docutils.core import Publisher
+from docutils.io import FileInput
+from docutils.io import NullOutput
+from docutils.parsers.rst import Directive
+from docutils.parsers.rst import directives
+from docutils.parsers.rst import Parser
+from docutils.parsers.rst import roles
+from docutils.readers.standalone import Reader
+from docutils.utils import Reporter
+from docutils.writers import Writer
+from sphinx.environment import default_settings
+
+from esbonio.lsp.util.patterns import DIRECTIVE
+from esbonio.lsp.util.patterns import ROLE
+
+
+class a_directive(nodes.Element):
+    """Represents a directive."""
+
+
+class a_role(nodes.Element):
+    """Represents a role."""
+
+
+def dummy_role(name, rawtext, text, lineno, inliner, options={}, content=[]):
+    node = a_role()
+    node.line = lineno
+
+    match = ROLE.match(rawtext)
+    node.attributes.update(match.groupdict())
+    node.attributes["text"] = match.group(0)
+
+    return [node], []
+
+
+class DummyDirective(Directive):
+    has_content = True
+
+    def run(self):
+        node = a_directive()
+        node.line = self.lineno
+
+        match = DIRECTIVE.match(self.block_text.split("\n")[0])
+        node.attributes.update(match.groupdict())
+        node.attributes["text"] = match.group(0)
+
+        if self.content:
+            # This is essentially what `nested_parse_with_titles` does in Sphinx.
+            # But by passing the content_offset to state.nested_parse we ensure any line
+            # numbers remain relative to the start of the current file.
+            current_titles = self.state.memo.title_styles
+            current_sections = self.state.memo.section_level
+            self.state.memo.title_styles = []
+            self.state.memo.section_level = 0
+            try:
+                self.state.nested_parse(
+                    self.content, self.content_offset, node, match_titles=1
+                )
+            finally:
+                self.state.memo.title_styles = current_titles
+                self.state.memo.section_level = current_sections
+
+        return [node]
+
+
+class disable_roles_and_directives:
+    """Disables all roles and directives from being expanded.
+
+    The ``CustomReSTDispactcher`` from Sphinx is *very* cool.
+    It provides a way to override the mechanism used to lookup roles and directives
+    during parsing!
+
+    It's perfect for temporarily replacing all role and directive implementations with
+    dummy ones. Parsing an rst document with these dummy implementations effectively
+    gives us something that could be called an abstract syntax tree.
+
+    Unfortunately, it's only available in a relatively recent version of Sphinx (4.4)
+    so we have to implement the same idea ourselves for now.
+    """
+
+    def __init__(self) -> None:
+        self.directive_backup: Optional[Callable] = None
+        self.role_backup: Optional[Callable] = None
+
+    def __enter__(self) -> None:
+        self.directive_backup = directives.directive
+        self.role_backup = roles.role
+
+        directives.directive = self.directive
+        roles.role = self.role
+
+    def __exit__(self, exc_type: Type[Exception], exc_value: Exception, traceback: Any):
+        directives.directive = self.directive_backup  # type: ignore
+        roles.role = self.role_backup  # type: ignore
+
+        self.directive_backup = None
+        self.role_backup = None
+
+    def directive(self, directive_name, language_module, document):
+        return DummyDirective, []
+
+    def role(self, role_name, language_module, lineno, reporter):
+        return dummy_role, []
+
+
+class DummyWriter(Writer):
+    """A writer that doesn't do anything."""
+
+    def translate(self):
+        pass
+
+
+class LogStream:
+    def __init__(self, logger: logging.Logger):
+        self.logger = logger
+
+    def write(self, text: str):
+        self.logger.debug(text)
+
+
+class LogReporter(Reporter):
+    """A docutils reporter that writes to the given logger."""
+
+    def __init__(
+        self,
+        logger: logging.Logger,
+        source: str,
+        report_level: int,
+        halt_level: int,
+        debug: bool,
+        error_handler: str,
+    ) -> None:
+        stream = typing.cast(IO, LogStream(logger))
+        super().__init__(
+            source, report_level, halt_level, stream, debug, error_handler=error_handler
+        )  # type: ignore
+
+
+class InitialDoctreeReader(Reader):
+    """A reader that replaces the default reporter with one compatible with esbonio's
+    logging setup."""
+
+    def __init__(self, logger: logging.Logger, *args, **kwargs):
+        self.logger = logger
+        super().__init__(*args, **kwargs)
+
+    def new_document(self) -> nodes.document:
+        document = super().new_document()
+
+        reporter = document.reporter
+        document.reporter = LogReporter(
+            self.logger,
+            reporter.source,
+            reporter.report_level,
+            reporter.halt_level,
+            reporter.debug_flag,
+            reporter.error_handler,
+        )
+
+        return document
+
+
+def read_initial_doctree(
+    filename: pathlib.Path, logger: logging.Logger
+) -> Optional[nodes.document]:
+    """Parse the given reStructuredText file into its "initial" doctree.
+
+    An "initial" doctree can be thought of as the abstract syntax tree of a
+    reStructuredText document. This method disables all role and directives
+    from being executed, instead they are replaced with nodes that simply
+    represent that they exist.
+
+    Parameters
+    ----------
+    filename
+       Returns the doctree that corresponds with the given file.
+
+    logger
+       Logger to log debug info to.
+    """
+
+    parser = Parser()
+
+    if filename.suffix.replace(".", "") not in parser.supported:
+        return None
+
+    logger.debug("Getting initial doctree for: '%s'", filename)
+    with disable_roles_and_directives():
+        publisher = Publisher(
+            reader=InitialDoctreeReader(logger),
+            parser=parser,
+            writer=DummyWriter(),
+            source_class=FileInput,
+            destination=NullOutput(),
+        )
+        publisher.process_programmatic_settings(None, default_settings, None)
+        publisher.set_source(source_path=str(filename))
+        publisher.publish()
+
+        return publisher.document

--- a/lib/esbonio/esbonio/lsp/sphinx/__init__.py
+++ b/lib/esbonio/esbonio/lsp/sphinx/__init__.py
@@ -374,7 +374,7 @@ class SphinxLanguageServer(RstLanguageServer):
     def get_doctree(
         self, *, docname: Optional[str] = None, uri: Optional[str] = None
     ) -> Optional[Any]:
-        """Return the doctree that corresponds with the specified document.
+        """Return the initial doctree corresponding to the specified document.
 
         The ``docname`` of a document is its path relative to the project's ``srcdir``
         minus the extension e.g. the docname of the file ``docs/lsp/features.rst``

--- a/lib/esbonio/esbonio/lsp/sphinx/domains.py
+++ b/lib/esbonio/esbonio/lsp/sphinx/domains.py
@@ -142,7 +142,10 @@ class DomainFeatures:
         if docname is None:
             return []
 
-        doctree = self.rst.get_doctree(docname=docname)
+        path = self.rst.app.env.doc2path(docname)
+        uri = Uri.from_fs_path(path)
+
+        doctree = self.rst.get_initial_doctree(uri)
         if doctree is None:
             return []
 

--- a/lib/esbonio/esbonio/lsp/sphinx/domains.py
+++ b/lib/esbonio/esbonio/lsp/sphinx/domains.py
@@ -130,6 +130,9 @@ class DomainFeatures:
     def ref_definition(self, label: str) -> List[Location]:
         """Goto definition implementation for ``:ref:`` targets"""
 
+        if not self.rst.app or not self.rst.app.env:
+            return []
+
         types = set(self.rst.get_role_target_types("ref"))
         std = self.rst.get_domain("std")
         if std is None:

--- a/lib/esbonio/esbonio/lsp/symbols.py
+++ b/lib/esbonio/esbonio/lsp/symbols.py
@@ -1,0 +1,130 @@
+from typing import Optional
+
+from docutils import nodes
+from docutils.nodes import NodeVisitor
+from pygls.lsp.types import DocumentSymbol
+from pygls.lsp.types import Position
+from pygls.lsp.types import Range
+from pygls.lsp.types import SymbolKind
+
+
+class SymbolVisitor(NodeVisitor):
+    """A visitor used to build the hierarchy we return from a
+    ``textDocument/documentSymbol`` request.
+
+    """
+
+    def __init__(self, rst, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.logger = rst.logger
+        self.symbols = []
+        self.symbol_stack = []
+
+    @property
+    def current_symbol(self) -> Optional[DocumentSymbol]:
+
+        if len(self.symbol_stack) == 0:
+            return None
+
+        return self.symbol_stack[-1]
+
+    def push_symbol(self):
+        symbol = DocumentSymbol(
+            name="",
+            kind=SymbolKind.String,
+            range=Range(
+                start=Position(line=1, character=0),
+                end=Position(line=1, character=10),
+            ),
+            selection_range=Range(
+                start=Position(line=1, character=0),
+                end=Position(line=1, character=10),
+            ),
+            children=[],
+        )
+        current_symbol = self.current_symbol
+
+        if not current_symbol:
+            self.symbols.append(symbol)
+        else:
+            current_symbol.children.append(symbol)
+
+        self.symbol_stack.append(symbol)
+        return symbol
+
+    def pop_symbol(self):
+        self.symbol_stack.pop()
+
+    def visit_section(self, node: nodes.Node) -> None:
+        self.push_symbol()
+
+    def depart_section(self, node: nodes.Node) -> None:
+        self.pop_symbol()
+
+    def visit_title(self, node: nodes.Node) -> None:
+
+        symbol = self.current_symbol
+        has_parent = True
+
+        if symbol is None:
+            has_parent = False
+            symbol = self.push_symbol()
+
+        name = node.astext()
+        line = (node.line or 1) - 1
+
+        symbol.name = name
+        symbol.range.start.line = line
+        symbol.range.end.line = line
+        symbol.range.end.character = len(name) - 1
+        symbol.selection_range.start.line = line
+        symbol.selection_range.end.line = line
+        symbol.selection_range.end.character = len(name) - 1
+
+        if not has_parent:
+            self.pop_symbol()
+
+    def depart_title(self, node: nodes.Node) -> None:
+        pass
+
+    def visit_a_directive(self, node: nodes.Element):
+        symbol = self.push_symbol()
+
+        name = node["text"]  # type: ignore
+        line = (node.line or 1) - 1
+
+        symbol.name = name
+        symbol.kind = SymbolKind.Class
+        symbol.range.start.line = line
+        symbol.range.end.line = line
+        symbol.range.end.character = len(name) - 1
+        symbol.selection_range.start.line = line
+        symbol.selection_range.end.line = line
+        symbol.selection_range.end.character = len(name) - 1
+
+    def depart_a_directive(self, node: nodes.Node):
+        self.pop_symbol()
+
+    # TODO: Enable symbols for roles
+    #       However the reported line numbers can be inaccurate...
+    def visit_a_role(self, node: nodes.Node) -> None:
+        ...
+
+    def depart_a_role(self, node: nodes.Node) -> None:
+        ...
+
+    # TODO: Enable symbols for definition list items
+    #       However the reported line numbers appear to be inaccurate...
+
+    def visit_Text(self, node: nodes.Node) -> None:
+        pass
+
+    def depart_Text(self, node: nodes.Node) -> None:
+        pass
+
+    def unknown_visit(self, node: nodes.Node) -> None:
+        pass
+
+    def unknown_departure(self, node: nodes.Node) -> None:
+        pass

--- a/lib/esbonio/esbonio/lsp/util/patterns.py
+++ b/lib/esbonio/esbonio/lsp/util/patterns.py
@@ -1,0 +1,125 @@
+import re
+
+
+DIRECTIVE = re.compile(
+    r"""
+    (\s*)                             # directives can be indented
+    (?P<directive>
+      \.\.                            # directives start with a comment
+      [ ]?                            # followed by a space
+      ((?P<domain>[\w]+):(?!:))?      # directives may include a domain
+      (?P<name>([\w-]|:(?!:))+)?      # directives have a name
+      (::)?                           # directives end with '::'
+    )
+    ([\s]+(?P<argument>.*?)\s*$)?     # directives may take an argument
+    """,
+    re.VERBOSE,
+)
+"""A regular expression to detect and parse partial and complete directives.
+
+This does **not** include any options or content that may be included underneath
+the initial declaration. The language server breaks a directive down into a number
+of parts::
+
+                   vvvvvv argument
+   .. c:function:: malloc
+   ^^^^^^^^^^^^^^^ directive
+        ^^^^^^^^ name
+      ^ domain (optional)
+"""
+
+
+DIRECTIVE_OPTION = re.compile(
+    r"""
+    (?P<indent>\s+)       # directive options must be indented
+    (?P<option>
+      :                   # options start with a ':'
+      (?P<name>[\w-]+)?   # options have a name
+      :?                  # options end with a ':'
+    )
+    (\s*
+      (?P<value>.*)       # options can have a value
+    )?
+    """,
+    re.VERBOSE,
+)
+"""A regular expression used to detect and parse partial and complete directive options.
+
+The language server breaks an option down into a number of parts::
+
+               vvvvvv value
+   |   :align: center
+       ^^^^^^^ option
+        ^^^^^ name
+    ^^^ indent
+"""
+ROLE = re.compile(
+    r"""
+    ([^\w:]|^\s*)                     # roles cannot be preceeded by letter chars
+    (?P<role>
+      :                               # roles begin with a ':' character
+      (?!:)                           # the next character cannot be a ':'
+      ((?P<domain>[\w]+):(?=\w))?     # roles may include a domain (that must be followed by a word character)
+      ((?P<name>[\w-]+):?)?           # roles have a name
+    )
+    (?P<target>
+      `                               # targets begin with a '`' character
+      ((?P<alias>[^<`>]*?)<)?         # targets may specify an alias
+      (?P<modifier>[!~])?             # targets may have a modifier
+      (?P<label>[^<`>]*)?             # targets contain a label
+      >?                              # labels end with a '>' when there's an alias
+      `?                              # targets end with a '`' character
+    )?
+    """,
+    re.VERBOSE,
+)
+"""A regular expression to detect and parse parial and complete roles.
+
+I'm not sure if there are offical names for the components of a role, but the
+language server breaks a role down into a number of parts::
+
+                 vvvvvv label
+                v modifier(optional)
+               vvvvvvvv target
+   :c:function:`!malloc`
+   ^^^^^^^^^^^^ role
+      ^^^^^^^^ name
+    ^ domain (optional)
+
+The language server sometimes refers to the above as a "plain" role, in that the
+role's target contains just the label of the object it is linking to. However it's
+also possible to define "aliased" roles, where the link text in the final document
+is overriden, for example::
+
+                vvvvvvvvvvvvvvvvvvvvvvvv alias
+                                          vvvvvv label
+                                         v modifier (optional)
+               vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv target
+   :c:function:`used to allocate memory <~malloc>`
+   ^^^^^^^^^^^^ role
+      ^^^^^^^^ name
+    ^ domain (optional)
+
+See :func:`tests.test_roles.test_role_regex` for a list of example strings this pattern
+is expected to match.
+"""
+
+
+DEFAULT_ROLE = re.compile(
+    r"""
+    (?<![:`])
+    (?P<target>
+      `                               # targets begin with a '`' character
+      ((?P<alias>[^<`>]*?)<)?         # targets may specify an alias
+      (?P<modifier>[!~])?             # targets may have a modifier
+      (?P<label>[^<`>]*)?             # targets contain a label
+      >?                              # labels end with a '>' when there's an alias
+      `?                              # targets end with a '`' character
+    )
+    """,
+    re.VERBOSE,
+)
+"""A regular expression to detect and parse parial and complete "default" roles.
+
+A "default" role is the target part of a normal role - but without the ``:name:`` part.
+"""

--- a/lib/esbonio/pyproject.toml
+++ b/lib/esbonio/pyproject.toml
@@ -5,8 +5,8 @@ build-backend = "setuptools.build_meta"
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 filterwarnings = [
-     "ignore:'contextfunction' is renamed to 'pass_context',*:DeprecationWarning",
-     "ignore:'environmentfilter' is renamed to 'pass_environment',*:DeprecationWarning",
+    "ignore:'contextfunction' is renamed to 'pass_context',*:DeprecationWarning",
+    "ignore:'environmentfilter' is renamed to 'pass_environment',*:DeprecationWarning",
 ]
 
 [tool.towncrier]
@@ -34,6 +34,11 @@ showcontent = true
 [[tool.towncrier.type]]
 directory = "doc"
 name = "Docs"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "api"
+name = "API Changes"
 showcontent = true
 
 [[tool.towncrier.type]]

--- a/lib/esbonio/tests/sphinx-default/test_sd_sphinx_domains.py
+++ b/lib/esbonio/tests/sphinx-default/test_sd_sphinx_domains.py
@@ -283,6 +283,17 @@ WELCOME_LABEL = Location(
                 ),
             ),
         ),
+        (
+            "definitions.rst",
+            Position(line=35, character=32),
+            Location(
+                uri="theorems/pythagoras.rst",
+                range=Range(
+                    start=Position(line=12, character=0),
+                    end=Position(line=13, character=0),
+                ),
+            ),
+        ),
     ],
 )
 async def test_role_target_definitions(client: Client, path, position, expected):

--- a/lib/esbonio/tests/sphinx-default/test_sd_symbols.py
+++ b/lib/esbonio/tests/sphinx-default/test_sd_symbols.py
@@ -1,0 +1,140 @@
+from typing import List
+from typing import Optional
+
+import py.test
+from pygls.lsp.types import DocumentSymbol
+from pygls.lsp.types import Position
+from pygls.lsp.types import Range
+from pygls.lsp.types import SymbolKind
+from pytest_lsp import Client
+
+
+def from_str(spec: str):
+    """Create a range from the given string a:b-x:y"""
+    start, end = spec.split("-")
+    sl, sc = start.split(":")
+    el, ec = end.split(":")
+
+    return Range(
+        start=Position(line=int(sl), character=int(sc)),
+        end=Position(line=int(el), character=int(ec)),
+    )
+
+
+def symbol(
+    name: str,
+    kind: SymbolKind,
+    range: str,
+    selection_range: str = "",
+    children: Optional[List[DocumentSymbol]] = None,
+) -> DocumentSymbol:
+    """Helper for writing symbols."""
+    return DocumentSymbol(
+        name=name,
+        kind=kind,
+        range=from_str(range),
+        selection_range=from_str(selection_range or range),
+        children=children or [],
+    )
+
+
+@py.test.mark.parametrize(
+    "filepath,expected",
+    [
+        ("conf.py", []),
+        (
+            "theorems/pythagoras.rst",
+            [
+                symbol(
+                    name="Pythagoras' Theorem",
+                    kind=SymbolKind.String,
+                    range="3:0-3:18",
+                    children=[
+                        symbol(
+                            name=".. include:: ../math.rst",
+                            kind=SymbolKind.Class,
+                            range="8:0-8:23",
+                        ),
+                        symbol(
+                            name=".. include:: /math.rst",
+                            kind=SymbolKind.Class,
+                            range="10:0-10:21",
+                        ),
+                        symbol(
+                            name="Implementation",
+                            kind=SymbolKind.String,
+                            range="15:0-15:13",
+                            children=[
+                                symbol(
+                                    name=".. module:: pythagoras",
+                                    kind=SymbolKind.Class,
+                                    range="20:0-20:21",
+                                ),
+                                symbol(
+                                    name=".. currentmodule:: pythagoras",
+                                    kind=SymbolKind.Class,
+                                    range="22:0-22:28",
+                                ),
+                                symbol(
+                                    name=".. data:: PI",
+                                    kind=SymbolKind.Class,
+                                    range="24:0-24:11",
+                                ),
+                                symbol(
+                                    name=".. data:: UNKNOWN",
+                                    kind=SymbolKind.Class,
+                                    range="28:0-28:16",
+                                ),
+                                symbol(
+                                    name=".. class:: Triangle(a: float, b: float, c: float)",
+                                    kind=SymbolKind.Class,
+                                    range="32:0-32:48",
+                                    children=[
+                                        symbol(
+                                            name=".. attribute:: a",
+                                            kind=SymbolKind.Class,
+                                            range="36:0-36:15",
+                                        ),
+                                        symbol(
+                                            name=".. attribute:: b",
+                                            kind=SymbolKind.Class,
+                                            range="40:0-40:15",
+                                        ),
+                                        symbol(
+                                            name=".. attribute:: c",
+                                            kind=SymbolKind.Class,
+                                            range="44:0-44:15",
+                                        ),
+                                        symbol(
+                                            name=".. method:: is_right_angled() -> bool",
+                                            kind=SymbolKind.Class,
+                                            range="48:0-48:36",
+                                            children=[],
+                                        ),
+                                    ],
+                                ),
+                                symbol(
+                                    name=".. function:: calc_hypotenuse(a: float, b: float) -> float",
+                                    kind=SymbolKind.Class,
+                                    range="53:0-53:57",
+                                ),
+                                symbol(
+                                    name=".. function:: calc_side(c: float, b: float) -> float",
+                                    kind=SymbolKind.Class,
+                                    range="62:0-62:51",
+                                ),
+                            ],
+                        ),
+                    ],
+                )
+            ],
+        ),
+    ],
+)
+async def test_document_symbols(client: Client, filepath: str, expected):
+    """Ensure that we handle ``textDocument/documentSymbols`` requests correctly"""
+
+    test_uri = client.root_uri + f"/{filepath}"
+    symbols = await client.document_symbols_request(test_uri)
+
+    assert symbols == expected

--- a/lib/esbonio/tests/sphinx-default/workspace/definitions.rst
+++ b/lib/esbonio/tests/sphinx-default/workspace/definitions.rst
@@ -32,3 +32,5 @@ This line refers to :ref:`setup-label`
 See the :doc:`/glossary` for details
 
 Find more info :cpp:func:`ExampleClass::isExample`
+
+Here is the :ref:`the-implementation`

--- a/lib/esbonio/tests/sphinx-default/workspace/theorems/pythagoras.rst
+++ b/lib/esbonio/tests/sphinx-default/workspace/theorems/pythagoras.rst
@@ -10,6 +10,8 @@ sides of a right angled triangle.
 
 .. include:: /math.rst
 
+.. _the-implementation:
+
 Implementation
 --------------
 

--- a/scripts/sphinx-app.py
+++ b/scripts/sphinx-app.py
@@ -32,6 +32,7 @@ The HTML pages are in docs/_build.
 import pathlib
 
 from sphinx.application import Sphinx
+
 from esbonio.lsp.sphinx import SphinxLanguageServer
 
 root = pathlib.Path(__file__).parent.parent

--- a/scripts/sphinx-app.py
+++ b/scripts/sphinx-app.py
@@ -32,6 +32,7 @@ The HTML pages are in docs/_build.
 import pathlib
 
 from sphinx.application import Sphinx
+from esbonio.lsp.sphinx import SphinxLanguageServer
 
 root = pathlib.Path(__file__).parent.parent
 
@@ -44,3 +45,5 @@ app = Sphinx(
     freshenv=True,  # Have Sphinx reload everything on first build.
 )
 app.build()
+ls = SphinxLanguageServer()
+ls.app = app


### PR DESCRIPTION
- Adds a mechanism for retrieving the doctree of a file - before any roles or directives have been evaluated. 
- Directives are now included in `textDocument/documentSymbol` responses
- ``.. include::`` directives no longer break goto definition for `:ref:` role targets
  Closes #361  