### PR TITLE
Support for `sphinx-build` cli options

### DIFF
--- a/code/changes/360.deprecated.rst
+++ b/code/changes/360.deprecated.rst
@@ -1,0 +1,2 @@
+The ``esbonio.server.hideSphinxOutput`` option has been deprecated in favour of the new ``esbonio.sphinx.quiet`` and ``esbonio.sphinx.silent`` options.
+It will be removed when the server reaches ``v1.0``

--- a/code/changes/360.feature.rst
+++ b/code/changes/360.feature.rst
@@ -1,0 +1,2 @@
+Add new ``esbonio.sphinx.copyBuildCommand`` and ``esbonio.sphinx.setBuildCommand`` commands.
+As the name suggests, the first command will copy the equivalent ``sphinx-build`` command to the clipboard while the set build command prompts for a set of ``sphinx-build`` arguments and updates the server's configuration accordingly.

--- a/code/changes/374.misc.rst
+++ b/code/changes/374.misc.rst
@@ -1,0 +1,1 @@
+The ``esbonio.sphinx.numJobs`` configuration now defaults to ``1`` in line with ``sphinx-build`` defaults.

--- a/code/package.json
+++ b/code/package.json
@@ -100,6 +100,11 @@
                 "category": "Esbonio"
             },
             {
+                "command": "esbonio.sphinx.setBuildCommand",
+                "title": "Set Sphinx Build Command",
+                "category": "Esbonio"
+            },
+            {
                 "command": "esbonio.sphinx.selectConfDir",
                 "title": "Select Conf Dir",
                 "category": "Esbonio"
@@ -291,7 +296,7 @@
                         "scope": "window",
                         "type": "boolean",
                         "default": true,
-                        "description": "Flag indicating if the language server should behave like a sphinx-build -M ... command"
+                        "description": "Flag indicating if the language server should be have like a sphinx-build -M ... command"
                     },
                     "esbonio.sphinx.numJobs": {
                         "scope": "window",

--- a/code/package.json
+++ b/code/package.json
@@ -95,6 +95,11 @@
                 "category": "Esbonio"
             },
             {
+                "command": "esbonio.sphinx.copyBuildCommand",
+                "title": "Copy Sphinx Build Command",
+                "category": "Esbonio"
+            },
+            {
                 "command": "esbonio.sphinx.selectConfDir",
                 "title": "Select Conf Dir",
                 "category": "Esbonio"

--- a/code/package.json
+++ b/code/package.json
@@ -185,7 +185,8 @@
                         "scope": "window",
                         "type": "boolean",
                         "default": false,
-                        "description": "Hide Sphinx build output from the Language Server log."
+                        "description": "Hide Sphinx build output from the Language Server log.",
+                        "deprecationMessage": "This option will be removed when the language server reaches v1.0. The esbonio.sphinx.quiet and esbonio.sphinx.silent options should be used instead."
                     },
                     "esbonio.server.installBehavior": {
                         "scope": "window",
@@ -249,30 +250,91 @@
                         "description": "The directory in which to store Sphinx's build output.\n\nBy default the Language Server will store any build files in a storage area provided by VSCode, this option allows you to override this to be a directory of your choosing e.g. your local _build/ directory.",
                         "markdownDescription": "The directory in which to store Sphinx's build output.\n\nBy default the Language Server will store any build files in a storage area provided by VSCode, this option allows you to override this to be a directory of your choosing e.g. your local `_build/` directory."
                     },
+                    "esbonio.sphinx.builderName": {
+                        "scope": "window",
+                        "type": "string",
+                        "default": "html",
+                        "description": "The builder to use when building the documentation.",
+                        "markdownDescription": "The builder to use when building the documentation. **Note:** While many builders will work fine, many features (such as previews) will only work with the `html` builder."
+                    },
                     "esbonio.sphinx.confDir": {
                         "scope": "window",
                         "type": "string",
                         "default": null,
                         "description": "The Language Server should be able to automatically find the folder containing your project's 'conf.py' file. However this setting can be used to force the Language Server to use a particular directory if required."
                     },
+                    "esbonio.sphinx.configOverrides": {
+                        "scope": "window",
+                        "type": "object",
+                        "default": {},
+                        "description": "Any conf.py options to override."
+                    },
+                    "esbonio.sphinx.doctreeDir": {
+                        "scope": "window",
+                        "type": "string",
+                        "default": null,
+                        "description": "The directory in which to store Sphinx's doctree cache."
+                    },
                     "esbonio.sphinx.forceFullBuild": {
                         "scope": "window",
                         "type": "boolean",
+                        "default": false,
+                        "description": "Force a full build of the documentation project on server startup."
+                    },
+                    "esbonio.sphinx.keepGoing": {
+                        "scope": "window",
+                        "type": "boolean",
+                        "default": false,
+                        "description": "Continue building when errors generated from warnings are encountered"
+                    },
+                    "esbonio.sphinx.makeMode": {
+                        "scope": "window",
+                        "type": "boolean",
                         "default": true,
-                        "description": "By default the language server will force a full build of your documentation on startup to help improve the accuracy of some features like diagnostics. Disabling this option can help improve startup time for larger projects at the expense of certain features being less accurate."
+                        "description": "Flag indicating if the language server should behave like a sphinx-build -M ... command"
                     },
                     "esbonio.sphinx.numJobs": {
                         "scope": "window",
                         "type": "integer",
-                        "default": 0,
+                        "default": 1,
                         "markdownDescription": "The number of parallel jobs to use during a Sphinx build.\n\n- A value of `0` is equivalent to passing `-j auto` to a `sphinx-build` command.\n- A value of `1` will disable parallel processing."
+                    },
+                    "esbonio.sphinx.quiet": {
+                        "scope": "window",
+                        "type": "boolean",
+                        "default": false,
+                        "description": "Hide standard Sphinx output messages"
+                    },
+                    "esbonio.sphinx.silent": {
+                        "scope": "window",
+                        "type": "boolean",
+                        "default": false,
+                        "description": "Hide all Sphinx output"
                     },
                     "esbonio.sphinx.srcDir": {
                         "scope": "window",
                         "type": "string",
                         "default": null,
-                        "description": "The directory containing your rst source files. By default the Language Server will assume this is the same as `esbonio.sphinx.confDir` but this opton can override this if necessary.",
-                        "markdownDescription": "The directory containing your rst source files. By default the Language Server will assume this is the same as `#esbonio.sphinx.confDir#` but this opton can override this if necessary."
+                        "description": "The directory containing your rst source files. By default the Language Server will assume this is the same as `esbonio.sphinx.confDir` but this option can override this if necessary.",
+                        "markdownDescription": "The directory containing your rst source files. By default the Language Server will assume this is the same as `#esbonio.sphinx.confDir#` but this option can override this if necessary."
+                    },
+                    "esbonio.sphinx.tags": {
+                        "scope": "window",
+                        "type": "array",
+                        "default": [],
+                        "description": "Tags to enable during a build."
+                    },
+                    "esbonio.sphinx.verbosity": {
+                        "scope": "window",
+                        "type": "integer",
+                        "default": 0,
+                        "description": "The verbosity of Sphinx's output"
+                    },
+                    "esbonio.sphinx.warningIsError": {
+                        "scope": "window",
+                        "type": "boolean",
+                        "default": false,
+                        "description": "Treat any warnings as errors."
                     }
                 }
             }

--- a/code/src/constants.ts
+++ b/code/src/constants.ts
@@ -11,6 +11,7 @@ export namespace Commands {
   export const OPEN_PREVIEW = "esbonio.preview.open"
   export const OPEN_PREVIEW_TO_SIDE = "esbonio.preview.openSide"
 
+  export const COPY_BUILD_COMMAND = "esbonio.sphinx.copyBuildCommand"
   export const SELECT_CONFDIR = "esbonio.sphinx.selectConfDir"
   export const SELECT_SRCDIR = "esbonio.sphinx.selectSrcDir"
   export const SELECT_BUILDDIR = "esbonio.sphinx.selectBuildDir"

--- a/code/src/constants.ts
+++ b/code/src/constants.ts
@@ -12,6 +12,7 @@ export namespace Commands {
   export const OPEN_PREVIEW_TO_SIDE = "esbonio.preview.openSide"
 
   export const COPY_BUILD_COMMAND = "esbonio.sphinx.copyBuildCommand"
+  export const SET_BUILD_COMMAND = "esbonio.sphinx.setBuildCommand"
   export const SELECT_CONFDIR = "esbonio.sphinx.selectConfDir"
   export const SELECT_SRCDIR = "esbonio.sphinx.selectSrcDir"
   export const SELECT_BUILDDIR = "esbonio.sphinx.selectBuildDir"

--- a/code/src/lsp/client.ts
+++ b/code/src/lsp/client.ts
@@ -34,9 +34,24 @@ export interface SphinxConfig {
   confDir?: string
 
   /**
+   * Any overriden conf.py options.
+   */
+  configOverrides?: object,
+
+  /**
+   * The directory in which to store Sphinx's doctree cache
+   */
+  doctreeDir?: string,
+
+  /**
    * Flag to force a full build of the documentation on startup.
    */
   forceFullBuild?: boolean
+
+  /**
+   * Flag to continue building when errors generated from warnings are encountered.
+   */
+  keepGoing?: boolean
 
   /**
    * The number of parallel jobs to use
@@ -44,10 +59,34 @@ export interface SphinxConfig {
   numJobs?: number | string
 
   /**
+   * Hide standard Sphinx output messages.
+   */
+  quiet?: boolean
+
+  /**
+   * Hide all Sphinx output.
+   */
+  silent?: boolean
+
+  /**
    * The source dir containing the *.rst files for the project.
    */
   srcDir?: string
 
+  /**
+   * Tags to enable during a build.
+   */
+  tags?: string[]
+
+  /**
+   * The verbosity of Sphinx's output.
+   */
+  verbosity?: number
+
+  /**
+   * Treat any warnings as errors.
+   */
+  warningIsError?: boolean
 }
 
 export interface SphinxInfo extends SphinxConfig {
@@ -324,10 +363,19 @@ export class EsbonioClient {
     let initOptions: InitOptions = {
       sphinx: {
         buildDir: buildDir,
+        builderName: config.get<string>('sphinx.builderName'),
         confDir: config.get<string>('sphinx.confDir'),
+        configOverrides: config.get<object>('sphinx.configOverrides'),
+        doctreeDir: config.get<string>('doctreeDir'),
         forceFullBuild: config.get<boolean>('sphinx.forceFullBuild'),
+        keepGoing: config.get<boolean>('sphinx.keepGoing'),
         numJobs: numJobs === 0 ? 'auto' : numJobs,
+        quiet: config.get<boolean>('sphinx.quiet'),
+        silent: config.get<boolean>('sphinx.silent'),
         srcDir: config.get<string>("sphinx.srcDir"),
+        tags: config.get<string[]>('sphinx.tags'),
+        verbosity: config.get<number>('sphinx.verbosity'),
+        warningIsError: config.get<boolean>('sphinx.warningIsError')
       },
       server: {
         logLevel: config.get<string>('server.logLevel'),

--- a/code/src/lsp/status.ts
+++ b/code/src/lsp/status.ts
@@ -105,7 +105,14 @@ export class StatusManager {
         command: Commands.RESTART_SERVER
       }
     })
-    this.setStatusItem('Builder', builderName, { busy: false })
+    this.setStatusItem('Builder', builderName, {
+      busy: false,
+      command: {
+        title: "Set Build Command",
+        tooltip: "Set the sphinx-build cli options to use",
+        command: Commands.SET_BUILD_COMMAND
+      }
+    })
     this.setStatusItem('Config', confDir, {
       command: {
         title: "Select Conf Dir",

--- a/code/src/preview/view.ts
+++ b/code/src/preview/view.ts
@@ -112,7 +112,7 @@ export class PreviewManager {
    * @returns
    */
   private async getHtmlPath(editor: vscode.TextEditor): Promise<string | undefined> {
-    let config = this.esbonio.sphinxConfig
+    let config = this.esbonio.sphinxInfo
     if (!config || !config.srcDir || !config.buildDir) {
       return undefined
     }

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -49,6 +49,7 @@ extensions = [
     "sphinx.ext.intersphinx",
     "sphinx.ext.napoleon",
     "sphinx.ext.viewcode",
+    "sphinxcontrib.autodoc_pydantic",
     "sphinx_panels",
     "esbonio.tutorial",
     "cli_help",
@@ -56,7 +57,12 @@ extensions = [
     "relevant_to",
 ]
 
+autodoc_member_order = "groupwise"
 autodoc_typehints = "description"
+autodoc_typehints_description_target = "documented"
+
+autodoc_pydantic_model_show_json = True
+
 
 intersphinx_mapping = {
     "ipython": ("https://ipython.readthedocs.io/en/stable/", None),

--- a/docs/lsp/api-reference.rst
+++ b/docs/lsp/api-reference.rst
@@ -18,17 +18,32 @@ RstLanguageServer
    :members:
    :show-inheritance:
 
+.. autoclass:: esbonio.lsp.rst.InitializationOptions
+   :members:
+
+.. autoclass:: esbonio.lsp.rst.ServerConfig
+   :members:
+
+
 SphinxLanguageServer
 ^^^^^^^^^^^^^^^^^^^^
 
-.. autoclass:: esbonio.lsp.sphinx.SphinxConfig
-   :members:
+.. currentmodule:: esbonio.lsp.sphinx
 
-.. autoclass:: esbonio.lsp.sphinx.SphinxLanguageServer
+.. autoclass:: SphinxLanguageServer
    :members:
    :show-inheritance:
 
-.. autoclass:: esbonio.lsp.sphinx.MissingConfigError
+.. autoclass:: InitializationOptions
+   :members:
+
+.. autoclass:: SphinxServerConfig
+   :members:
+
+.. autoclass:: SphinxConfig
+   :members:
+
+.. autoclass:: MissingConfigError
 
 Language Features
 -----------------

--- a/docs/lsp/getting-started.rst
+++ b/docs/lsp/getting-started.rst
@@ -170,13 +170,22 @@ Configuration
 
 .. confval:: sphinx.buildDir (string)
 
-   By default the language server will choose a cache directory (as determined by `appdirs <https://pypi.org/project/appdirs>`_) to put Sphinx's build output.
+   By default the language server will choose a cache directory (as determined by `appdirs <https://pypi.org/project/appdirs>`_) to place Sphinx's build output.
    This option can be used to force the language server to use a location of your choosing, currently accepted values include:
 
    - ``/path/to/src/`` - An absolute path
    - ``${workspaceRoot}/docs/src`` - A path relative to the root of your workspace
    - ``${workspaceFolder}/docs/src`` - Same as ``${workspaceRoot}``, placeholder for true multi-root workspace support.
    - ``${confDir}/../src/`` - A path relative to your project's ``confDir``
+
+.. confval:: sphinx.builderName (string)
+
+   By default the language server will use the ``html`` builder.
+   This option allows you to specify the builder you wish to use.
+
+   .. note::
+
+      Some features (such as previews) are currently only available for the ``html`` builder.
 
 .. confval:: sphinx.confDir (string)
 
@@ -187,6 +196,73 @@ Configuration
    - ``/path/to/docs`` - An absolute path
    - ``${workspaceRoot}/docs`` - A path relative to the root of your workspace.
    - ``${workspaceFolder}/docs`` - Same as ``${workspaceRoot}``, placeholder for true multi-root workspace support.
+
+.. confval:: sphinx.configOverrides (object)
+
+   This option can be used to override values set in the project's ``conf.py`` file.
+   This covers both the :option:`sphinx-build -D <sphinx:sphinx-build.-D>` and :option:`sphinx-build -A <sphinx:sphinx-build.-A>` cli options.
+
+   For example the cli argument ``-Dlanguage=cy`` overrides a project's language, the equivalent setting using the ``configOverrides`` setting would be::
+
+      {
+         "sphinx.configOverrides": {
+            "language": "cy"
+         }
+      }
+
+   Simiarly the argument ``-Adocstitle=ProjectName`` overrides the value of the ``docstitle`` variable inside HTML templates, the equivalent setting using ``configOverrides`` would be::
+
+      {
+         "sphinx.configOverrides": {
+            "docstitle": "ProjectName"
+         }
+      }
+
+.. confval:: sphinx.doctreeDir (string)
+
+   This option can be used to specify the directory into which the language server will write the project's doctree cache.
+   Currently accepted values include:
+
+   - ``/path/to/docs`` - An absolute path
+   - ``${workspaceRoot}/doctrees`` - A path relative to the root of your workspace.
+   - ``${workspaceFolder}/doctrees`` - Same as ``${workspaceRoot}``, placeholder for true multi-root workspace support.
+   - ``${confDir}/../doctrees`` - A path relative to your project's ``confDir``
+   - ``${buildDir}/.doctrees`` - A path relative to your project's ``buildDir``
+
+.. confval:: sphinx.forceFullBuild (boolean)
+
+   Flag that indicates if the server should force a full build of the documentation on startup.
+   (Default: ``false``)
+
+.. confval:: sphinx.keepGoing (boolean)
+
+   Continue building even when errors (from warnings) are encountered.
+   (Default: ``false``)
+
+.. confval:: sphinx.makeMode (boolean)
+
+   If ``true`` the language server will behave like ``sphinx-build`` when invoked with the :option:`-M <sphinx:sphinx-build.-M>` argument.
+   If ``false`` the language server will behave like ``sphinx-build`` when invoked with the :option:`-b <sphinx:sphinx-build.-b>` argument.
+   (Default: ``true``)
+
+.. confval:: sphinx.numJobs (string or integer)
+
+   Controls the number of parallel jobs used during a Sphinx build.
+
+   The default value of ``"auto"`` will behave the same as passing ``-j auto`` to a ``sphinx-build`` command.
+   Setting this value to ``1`` effectively disables parallel builds.
+
+.. confval:: sphinx.quiet (boolean)
+
+   Hides all standard Sphinx output messages.
+   Equivalent to the :option:`sphinx-build -q <sphinx:sphinx-build.-q>` cli option.
+   (Default ``false``)
+
+.. confval:: sphinx.silent (boolean)
+
+   Hides all Sphinx output.
+   Equivalent to the :option:`sphinx-build -Q <sphinx:sphinx-build.-Q>` cli option.
+   (Default ``false``)
 
 .. confval:: sphinx.srcDir (string)
 
@@ -199,16 +275,19 @@ Configuration
    - ``${workspaceFolder}/docs/src`` - Same as ``${workspaceRoot}``, placeholder for true multi-root workspace support.
    - ``${confDir}/../src/`` - A path relative to your project's ``confDir``
 
-.. confval:: sphinx.forceFullBuild (boolean)
+.. confval:: sphinx.tags (string[])
 
-   Flag that indicates if the server should force a full build of the documentation on startup. (Default: ``true``)
+   A list of tags to enable.
+   See the documentation on the :option:`sphinx-build -t <sphinx:sphinx-build.-t>` cli option for more details.
+   (Default: ``[]``)
 
-.. confval:: sphinx.numJobs (string or integer)
+.. confval:: sphinx.verbosity (integer)
 
-   Controls the number of parallel jobs used during a Sphinx build.
+   Set the verbosity level of Sphinx's output. (Default: ``0``)
 
-   The default value of ``"auto"`` will behave the same as passing ``-j auto`` to a ``sphinx-build`` command.
-   Setting this value to ``1`` effectively disables parallel builds.
+.. confval:: sphinx.warningIsError (boolean)
+
+   Treat warnings as errors. (Default: ``false``)
 
 .. confval:: server.logLevel (string)
 
@@ -225,6 +304,11 @@ Configuration
    This option can be used to restrict the log output to be only those named.
 
 .. confval:: server.hideSphinxOutput (boolean)
+
+   .. deprecated:: 0.12.0
+
+      The :confval:`sphinx.quiet` and :confval:`sphinx.silent` options should be used instead.
+      This will be removed in ``v1.0``.
 
    Normally any build output from Sphinx will be forwarded to the client as log messages.
    If you prefer this flag can be used to exclude any Sphinx output from the log.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,7 @@
 # This assumes you are running the pip install command from the root of the repo e.g.
 # $ pip install -r docs/requirements.txt
 sphinx
+autodoc-pydantic
 sphinx-panels
 furo
 -e lib/esbonio

--- a/lib/esbonio/changes/360.feature.rst
+++ b/lib/esbonio/changes/360.feature.rst
@@ -1,0 +1,16 @@
+The language server now supports many (but not all) ``sphinx-build`` command line options.
+The ``sphinx.*`` section of the server's initialization options has been extened to include the following options.
+
+- ``configOverrides``
+- ``doctreeDir``
+- ``keepGoing``
+- ``makeMode``
+- ``quiet``
+- ``silent``
+- ``tags``
+- ``verbosity``
+- ``warningIsError``
+
+See the `documentation <https://swyddfa.github.io/esbonio/docs/latest/en/lsp/getting-started.html#configuration>`_ for details.
+
+Additionally, a new cli application ``esbonio-sphinx`` is now available which language clients (or users) can use to convert ``sphinx-build`` cli options to/from the server's initialization options.

--- a/lib/esbonio/changes/374.misc.rst
+++ b/lib/esbonio/changes/374.misc.rst
@@ -1,0 +1,1 @@
+The ``esbonio.sphinx.numJobs`` configuration now defaults to ``1`` in line with ``sphinx-build`` defaults.

--- a/lib/esbonio/esbonio/lsp/sphinx/__init__.py
+++ b/lib/esbonio/esbonio/lsp/sphinx/__init__.py
@@ -30,6 +30,8 @@ from sphinx.application import Sphinx
 from sphinx.domains import Domain
 from sphinx.errors import ConfigError
 from sphinx.util import console
+from sphinx.util.logging import NAMESPACE as SPHINX_LOG_NAMESPACE
+from sphinx.util.logging import VERBOSITY_MAP
 
 from esbonio.cli import setup_cli
 from esbonio.lsp.rst import RstLanguageServer
@@ -255,11 +257,10 @@ class SphinxLanguageServer(RstLanguageServer):
         # This has to happen after app creation otherwise our logging handler
         # will get cleared by Sphinx's setup.
         if not server.hide_sphinx_output:
-            sphinx_logger = logging.getLogger("sphinx")
-            sphinx_logger.setLevel(logging.INFO)
+            sphinx_logger = logging.getLogger(SPHINX_LOG_NAMESPACE)
 
             self.sphinx_log = SphinxLogHandler(app, self)
-            self.sphinx_log.setLevel(logging.INFO)
+            self.sphinx_log.setLevel(VERBOSITY_MAP[app.verbosity])
 
             formatter = logging.Formatter("%(message)s")
             self.sphinx_log.setFormatter(formatter)

--- a/lib/esbonio/esbonio/lsp/sphinx/__init__.py
+++ b/lib/esbonio/esbonio/lsp/sphinx/__init__.py
@@ -268,7 +268,11 @@ class SphinxLanguageServer(RstLanguageServer):
             sphinx_logger = logging.getLogger(SPHINX_LOG_NAMESPACE)
 
             self.sphinx_log = SphinxLogHandler(app, self)
-            self.sphinx_log.setLevel(VERBOSITY_MAP[app.verbosity])
+
+            if sphinx.quiet:
+                self.sphinx_log.setLevel(logging.WARNING)
+            else:
+                self.sphinx_log.setLevel(VERBOSITY_MAP[app.verbosity])
 
             formatter = logging.Formatter("%(message)s")
             self.sphinx_log.setFormatter(formatter)

--- a/lib/esbonio/esbonio/lsp/sphinx/cli.py
+++ b/lib/esbonio/esbonio/lsp/sphinx/cli.py
@@ -1,0 +1,76 @@
+"""Additional command line utilities for the SphinxLanguageServer."""
+import argparse
+import json
+import sys
+from typing import List
+
+from esbonio.lsp.sphinx import SphinxConfig
+
+
+def config_cmd(args, extra):
+
+    if args.to_cli:
+        config_to_cli(args.to_cli)
+        return 0
+
+    return cli_to_config(extra)
+
+
+def config_to_cli(config: str):
+    conf = SphinxConfig(**json.loads(config))
+    print(" ".join(conf.to_cli_args()))
+    return 0
+
+
+def cli_to_config(cli_args: List[str]):
+    conf = SphinxConfig.from_arguments(cli_args=cli_args)
+    if conf is None:
+        return 1
+
+    print(json.dumps(conf.dict(by_alias=True), indent=2))
+    return 0
+
+
+cli = argparse.ArgumentParser(
+    prog="esbonio-sphinx",
+    description="Supporting commands and utilities for the SphinxLanguageServer.",
+)
+commands = cli.add_subparsers(title="commands")
+config = commands.add_parser(
+    "config",
+    usage="%(prog)s [--from-cli] -- ARGS",
+    description="configuration options helper.",
+)
+config.set_defaults(run=config_cmd)
+
+mode = config.add_mutually_exclusive_group()
+mode.add_argument(
+    "--from-cli",
+    action="store_true",
+    default=True,
+    help="convert sphinx-build cli options to esbonio's initialization options.",
+)
+mode.add_argument(
+    "--to-cli",
+    help="convert esbonio's initialization options to sphinx-build options",
+)
+
+
+def main():
+
+    try:
+        idx = sys.argv.index("--")
+        args, extra = sys.argv[1:idx], sys.argv[idx + 1 :]
+    except ValueError:
+        args, extra = sys.argv[1:], None
+
+    parsed_args = cli.parse_args(args)
+
+    if hasattr(parsed_args, "run"):
+        return parsed_args.run(parsed_args, extra)
+
+    cli.print_help()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/lib/esbonio/esbonio/lsp/sphinx/config.py
+++ b/lib/esbonio/esbonio/lsp/sphinx/config.py
@@ -533,6 +533,13 @@ class SphinxConfig(BaseModel):
 
 
 class SphinxServerConfig(ServerConfig):
+    """
+    .. deprecated:: 0.12.0
+
+       This will be removed in v1.0.
+       Use :confval:`sphinx.quiet (boolean)` and :confval:`sphinx.silent (boolean)`
+       options instead.
+    """
 
     hide_sphinx_output: bool = Field(False, alias="hideSphinxOutput")
     """A flag to indicate if Sphinx build output should be omitted from the log."""

--- a/lib/esbonio/esbonio/lsp/sphinx/config.py
+++ b/lib/esbonio/esbonio/lsp/sphinx/config.py
@@ -1,0 +1,650 @@
+import hashlib
+import inspect
+import logging
+import multiprocessing
+import pathlib
+import re
+import traceback
+from typing import Any
+from typing import Dict
+from typing import List
+from typing import Optional
+from typing import Tuple
+from typing import Union
+from unittest import mock
+
+import appdirs
+import pygls.uris as Uri
+from pydantic import BaseModel
+from pydantic import Field
+from pygls import IS_WIN
+from pygls.lsp.types import Diagnostic
+from pygls.lsp.types import DiagnosticSeverity
+from pygls.lsp.types import Position
+from pygls.lsp.types import Range
+from sphinx.application import Sphinx
+from sphinx.cmd.build import main as sphinx_build
+from sphinx.util.logging import SphinxLogRecord
+from sphinx.util.logging import WarningLogRecordTranslator
+from typing_extensions import Literal
+
+from esbonio.lsp.rst import LspHandler
+from esbonio.lsp.rst import ServerConfig
+
+try:
+    from sphinx.util.logging import OnceFilter
+except ImportError:
+    # OnceFilter is not defined in Sphinx 2.x
+    class OnceFilter:  # type: ignore
+        def filter(self, *args, **kwargs):
+            return True
+
+
+PATH_VAR_PATTERN = re.compile(r"^\${(\w+)}/?.*")
+
+
+class MissingConfigError(Exception):
+    """Indicates that we couldn't locate the project's 'conf.py'"""
+
+
+class SphinxConfig(BaseModel):
+    """Configuration values to pass to the Sphinx application instance."""
+
+    build_dir: Optional[str] = Field(None, alias="buildDir")
+    """The directory to write build outputs into."""
+
+    builder_name: str = Field("html", alias="builderName")
+    """The currently used builder name."""
+
+    conf_dir: Optional[str] = Field(None, alias="confDir")
+    """The directory containing the project's ``conf.py``."""
+
+    config_overrides: Dict[str, Any] = Field(
+        default_factory=dict, alias="configOverrides"
+    )
+    """Any overrides to configuration values."""
+
+    doctree_dir: Optional[str] = Field(None, alias="doctreeDir")
+    """The directory to write doctrees into."""
+
+    force_full_build: bool = Field(False, alias="forceFullBuild")
+    """Force a full build on startup."""
+
+    keep_going: bool = Field(False, alias="keepGoing")
+    """Continue building when errors (from warnings) are encountered."""
+
+    make_mode: bool = Field(True, alias="makeMode")
+    """Flag indicating if the server should align to "make mode" behavior."""
+
+    num_jobs: Union[Literal["auto"], int] = Field(1, alias="numJobs")
+    """The number of jobs to use for parallel builds."""
+
+    quiet: bool = Field(False)
+    """Hide standard Sphinx output messages"""
+
+    silent: bool = Field(False)
+    """Hide all Sphinx output."""
+
+    src_dir: Optional[str] = Field(None, alias="srcDir")
+    """The directory containing the project's source."""
+
+    tags: List[str] = Field(default_factory=list)
+    """Tags to enable during a build."""
+
+    verbosity: int = Field(0)
+    """The verbosity of Sphinx's output."""
+
+    warning_is_error: bool = Field(False, alias="warningIsError")
+    """Treat any warning as an error"""
+
+    @property
+    def parallel(self) -> int:
+        """The parsed value of the ``num_jobs`` field."""
+
+        if self.num_jobs == "auto":
+            return multiprocessing.cpu_count()
+
+        return self.num_jobs
+
+    @classmethod
+    def from_arguments(
+        cls,
+        *,
+        cli_args: Optional[List[str]] = None,
+        sphinx_args: Optional[Dict[str, Any]] = None,
+    ) -> Optional["SphinxConfig"]:
+        """Return the ``SphinxConfig`` instance that's equivalent to the given arguments.
+
+        .. note::
+
+            Only ``cli_args`` **or** ``sphinx_args`` may be given.
+
+        .. warning::
+
+            This method is unable to determine the value of the
+            :obj:`SphinxConfig.make_mode` setting when passing ``sphinx_args``
+
+
+        Parameters
+        ----------
+        cli_args
+           The cli arguments you would normally pass to ``sphinx-build``
+
+        sphinx_args:
+           The arguments you would use to create a ``Sphinx`` application instance.
+        """
+
+        make_mode: bool = False
+        neither_given = cli_args is None and sphinx_args is None
+        both_given = cli_args is not None and sphinx_args is not None
+        if neither_given or both_given:
+            raise ValueError("You must pass either 'cli_args' or 'sphinx_args'")
+
+        if cli_args is not None:
+            # The easiest way to handle this is to just call sphinx-build but with
+            # the Sphinx app object patched out - then we just use all the args it
+            # was given!
+            with mock.patch("sphinx.cmd.build.Sphinx") as m_Sphinx:
+                sphinx_build(cli_args)
+
+            if m_Sphinx.call_args is None:
+                return None
+
+            signature = inspect.signature(Sphinx)
+            keys = signature.parameters.keys()
+
+            values = m_Sphinx.call_args[0]
+            sphinx_args = {k: v for k, v in zip(keys, values)}
+
+            # `-M` has to be the first argument passed to `sphinx-build`
+            # https://github.com/sphinx-doc/sphinx/blob/1222bed88eb29cde43a81dd208448dc903c53de2/sphinx/cmd/build.py#L287
+            make_mode = cli_args[0] == "-M"
+            if make_mode and sphinx_args["outdir"].endswith(sphinx_args["buildername"]):
+                build_dir = pathlib.Path(sphinx_args["outdir"]).parts[:-1]
+                sphinx_args["outdir"] = str(pathlib.Path(*build_dir))
+
+        if sphinx_args is None:
+            return None
+
+        return cls(
+            confDir=sphinx_args.get("confdir", None),
+            configOverrides=sphinx_args.get("confoverrides", {}),
+            buildDir=sphinx_args.get("outdir", None),
+            builderName=sphinx_args.get("buildername", "html"),
+            doctreeDir=sphinx_args.get("doctreedir", None),
+            forceFullBuild=sphinx_args.get("freshenv", False),
+            keepGoing=sphinx_args.get("keep_going", False),
+            makeMode=make_mode,
+            numJobs=sphinx_args.get("parallel", 1),
+            quiet=sphinx_args.get("status", 1) is None,
+            silent=sphinx_args.get("warning", 1) is None,
+            srcDir=sphinx_args.get("srcdir", None),
+            tags=sphinx_args.get("tags", []),
+            verbosity=sphinx_args.get("verbosity", 0),
+            warningIsError=sphinx_args.get("warningiserror", False),
+        )
+
+    def to_cli_args(self) -> List[str]:
+        """Convert this into the equivalent ``sphinx-build`` cli arguments."""
+
+        if self.make_mode:
+            return self._build_make_cli_args()
+
+        return self._build_cli_args()
+
+    def _build_make_cli_args(self) -> List[str]:
+        args = ["-M", self.builder_name]
+        conf_dir = self.conf_dir or "${workspaceRoot}"
+        src_dir = self.src_dir or conf_dir
+
+        if self.build_dir is None:
+            build_dir = pathlib.Path(src_dir, "_build")
+        else:
+            build_dir = pathlib.Path(self.build_dir)
+
+        args += [src_dir, str(build_dir)]
+
+        args += self._build_standard_args()
+        default_dtree_dir = str(pathlib.Path(build_dir, "doctrees"))
+        if self.doctree_dir is not None and self.doctree_dir != default_dtree_dir:
+            args += ["-d", self.doctree_dir]
+
+        return args
+
+    def _build_cli_args(self) -> List[str]:
+        args = ["-b", self.builder_name]
+
+        conf_dir = self.conf_dir or "${workspaceRoot}"
+        src_dir = self.src_dir or conf_dir
+
+        build_dir = self.build_dir or pathlib.Path(src_dir, "_build")
+        default_dtree_dir = str(pathlib.Path(build_dir, ".doctrees"))
+
+        if self.doctree_dir is not None and self.doctree_dir != default_dtree_dir:
+            args += ["-d", self.doctree_dir]
+
+        args += self._build_standard_args()
+        args += [src_dir, str(build_dir)]
+        return args
+
+    def _build_standard_args(self) -> List[str]:
+        args: List[str] = []
+
+        conf_dir = self.conf_dir or "${workspaceRoot}"
+        src_dir = self.src_dir or self.conf_dir
+
+        if conf_dir != src_dir:
+            args += ["-c", conf_dir]
+
+        if self.force_full_build:
+            args += ["-E"]
+
+        if self.parallel > 1:
+            args += ["-j", str(self.num_jobs)]
+
+        if self.silent:
+            args += ["-Q"]
+
+        if self.quiet and not self.silent:
+            args += ["-q"]
+
+        if self.warning_is_error:
+            args += ["-W"]
+
+        if self.keep_going:
+            args += ["--keep-going"]
+
+        if self.verbosity > 0:
+            args += ["-" + ("v" * self.verbosity)]
+
+        for key, value in self.config_overrides.items():
+
+            if key == "nitpicky":
+                args += ["-n"]
+                continue
+
+            if key.startswith("html_context."):
+                char = "A"
+                key = key.replace("html_context.", "")
+            else:
+                char = "D"
+
+            args += [f"-{char}{key}={value}"]
+
+        for tag in self.tags:
+            args += ["-t", tag]
+
+        return args
+
+    def to_application_args(self) -> Dict[str, Any]:
+        """Convert this into the equivalent Sphinx application arguments."""
+
+        return {
+            "buildername": self.builder_name,
+            "confdir": self.conf_dir,
+            "confoverrides": self.config_overrides,
+            "doctreedir": self.doctree_dir,
+            "freshenv": self.force_full_build,
+            "keep_going": self.keep_going,
+            "outdir": self.build_dir,
+            "parallel": self.parallel,
+            "srcdir": self.src_dir,
+            "status": None,
+            "tags": self.tags,
+            "verbosity": self.verbosity,
+            "warning": None,
+            "warningiserror": self.warning_is_error,
+        }
+
+    def resolve(self, root_uri: str) -> "SphinxConfig":
+        conf_dir = self.resolve_conf_dir(root_uri)
+        if conf_dir is None:
+            raise MissingConfigError()
+
+        src_dir = self.resolve_src_dir(root_uri, str(conf_dir))
+        build_dir = self.resolve_build_dir(root_uri, str(conf_dir))
+        doctree_dir = self.resolve_doctree_dir(root_uri, str(conf_dir), str(build_dir))
+
+        if self.make_mode:
+            build_dir /= self.builder_name
+
+        return SphinxConfig(
+            confDir=str(conf_dir),
+            configOverrides=self.config_overrides,
+            buildDir=str(build_dir),
+            builderName=self.builder_name,
+            doctreeDir=str(doctree_dir),
+            forceFullBuild=self.force_full_build,
+            keepGoing=self.keep_going,
+            makeMode=self.make_mode,
+            numJobs=self.num_jobs,
+            quiet=self.quiet,
+            silent=self.silent,
+            srcDir=str(src_dir),
+            tags=self.tags,
+            verbosity=self.verbosity,
+            warningIsError=self.warning_is_error,
+        )
+
+    def resolve_build_dir(self, root_uri: str, actual_conf_dir: str) -> pathlib.Path:
+        """Get the build dir to use based on the user's config.
+
+        If nothing is specified in the given ``config``, this will choose a location
+        within the user's cache dir (as determined by
+        `appdirs <https://pypi.org/project/appdirs>`). The directory name will be a hash
+        derived from the given ``conf_dir`` for the project.
+
+        Alternatively the user (or least language client) can override this by setting
+        either an absolute path, or a path based on the following "variables".
+
+        - ``${workspaceRoot}`` which expands to the workspace root as provided
+          by the language client.
+
+        - ``${workspaceFolder}`` alias for ``${workspaceRoot}``, placeholder ready for
+          multi-root support.
+
+        - ``${confDir}`` which expands to the configured config dir.
+
+        Parameters
+        ----------
+        root_uri
+           The workspace root uri
+
+        actual_conf_dir:
+           The fully resolved conf dir for the project
+        """
+
+        if not self.build_dir:
+            # Try to pick a sensible dir based on the project's location
+            cache = appdirs.user_cache_dir("esbonio", "swyddfa")
+            project = hashlib.md5(str(actual_conf_dir).encode()).hexdigest()
+
+            return pathlib.Path(cache) / project
+
+        root_dir = Uri.to_fs_path(root_uri)
+        match = PATH_VAR_PATTERN.match(self.build_dir)
+
+        if match and match.group(1) in {"workspaceRoot", "workspaceFolder"}:
+            build = pathlib.Path(self.build_dir).parts[1:]
+            return pathlib.Path(root_dir, *build).resolve()
+
+        if match and match.group(1) == "confDir":
+            build = pathlib.Path(self.build_dir).parts[1:]
+            return pathlib.Path(actual_conf_dir, *build).resolve()
+
+        # Convert path to/from uri so that any path quirks from windows are
+        # automatically handled
+        build_uri = Uri.from_fs_path(self.build_dir)
+        build_dir = Uri.to_fs_path(build_uri)
+
+        # But make sure paths starting with '~' are not corrupted
+        if build_dir.startswith("/~"):
+            build_dir = build_dir.replace("/~", "~")
+
+        # But make sure (windows) paths starting with '~' are not corrupted
+        if build_dir.startswith("\\~"):
+            build_dir = build_dir.replace("\\~", "~")
+
+        return pathlib.Path(build_dir).expanduser()
+
+    def resolve_doctree_dir(
+        self, root_uri: str, actual_conf_dir: str, actual_build_dir: str
+    ) -> pathlib.Path:
+        """Get the directory to use for doctrees based on the user's config.
+
+        If ``doctree_dir`` is not set, this method will follow what ``sphinx-build``
+        does.
+
+        - If ``make_mode`` is true, this will be set to ``${buildDir}/doctrees``
+        - If ``make_mode`` is false, this will be set to ``${buildDir}/.doctrees``
+
+        Otherwise, if ``doctree_dir`` is set the following "variables" are handled by
+        this method.
+
+        - ``${workspaceRoot}`` which expands to the workspace root as provided by the
+          language client.
+
+        - ``${workspaceFolder}`` alias for ``${workspaceRoot}``, placeholder ready for
+          multi-root support.
+
+        - ``${confDir}`` which expands to the configured config dir.
+
+        - ``${buildDir}`` which expands to the configured build dir.
+
+        Parameters
+        ----------
+        root_uri
+           The workspace root uri
+
+        actual_conf_dir
+           The fully resolved conf dir for the project
+
+        actual_build_dir
+           The fully resolved build dir for the project.
+        """
+
+        if self.doctree_dir is None:
+            if self.make_mode:
+                return pathlib.Path(actual_build_dir, "doctrees")
+
+            return pathlib.Path(actual_build_dir, ".doctrees")
+
+        root_dir = Uri.to_fs_path(root_uri)
+        match = PATH_VAR_PATTERN.match(self.doctree_dir)
+
+        if match and match.group(1) in {"workspaceRoot", "workspaceFolder"}:
+            build = pathlib.Path(self.doctree_dir).parts[1:]
+            return pathlib.Path(root_dir, *build).resolve()
+
+        if match and match.group(1) == "confDir":
+            build = pathlib.Path(self.doctree_dir).parts[1:]
+            return pathlib.Path(actual_conf_dir, *build).resolve()
+
+        if match and match.group(1) == "buildDir":
+            build = pathlib.Path(self.doctree_dir).parts[1:]
+            return pathlib.Path(actual_build_dir, *build).resolve()
+
+        return pathlib.Path(self.doctree_dir).expanduser()
+
+    def resolve_conf_dir(self, root_uri: str) -> Optional[pathlib.Path]:
+        """Get the conf dir to use based on the user's config.
+
+        If ``conf_dir`` is not set, this method will attempt to find it by searching
+        within the ``root_uri`` for a ``conf.py`` file. If multiple files are found, the
+        first one found will be chosen.
+
+        If ``conf_dir`` is set the following "variables" are handled by this method
+
+        - ``${workspaceRoot}`` which expands to the workspace root as provided by the
+          language client.
+
+        - ``${workspaceFolder}`` alias for ``${workspaceRoot}``, placeholder ready for
+          multi-root support.
+
+        Parameters
+        ----------
+        root_uri
+            The workspace root uri
+        """
+        root = Uri.to_fs_path(root_uri)
+
+        if not self.conf_dir:
+            ignore_paths = [".tox", "site-packages"]
+
+            for candidate in pathlib.Path(root).glob("**/conf.py"):
+                # Skip any files that obviously aren't part of the project
+                if any(path in str(candidate) for path in ignore_paths):
+                    continue
+
+                return candidate.parent
+
+            # Nothing found
+            return None
+
+        match = PATH_VAR_PATTERN.match(self.conf_dir)
+        if not match or match.group(1) not in {"workspaceRoot", "workspaceFolder"}:
+            return pathlib.Path(self.conf_dir).expanduser()
+
+        conf = pathlib.Path(self.conf_dir).parts[1:]
+        return pathlib.Path(root, *conf).resolve()
+
+    def resolve_src_dir(self, root_uri: str, actual_conf_dir: str) -> pathlib.Path:
+        """Get the src dir to use based on the user's config.
+
+        By default the src dir will be the same as the conf dir, but this can
+        be overriden by setting the ``src_dir`` field.
+
+        There are a number of "variables" that can be included in the path,
+        currently we support
+
+        - ``${workspaceRoot}`` which expands to the workspace root as provided
+          by the language client.
+
+        - ``${workspaceFolder}`` alias for ``${workspaceRoot}``, placeholder ready for
+          multi-root support.
+
+        - ``${confDir}`` which expands to the configured config dir.
+
+        Parameters
+        ----------
+        root_uri
+           The workspace root uri
+
+        actual_conf_dir
+           The fully resolved conf dir for the project
+        """
+
+        if not self.src_dir:
+            return pathlib.Path(actual_conf_dir)
+
+        src_dir = self.src_dir
+        root_dir = Uri.to_fs_path(root_uri)
+
+        match = PATH_VAR_PATTERN.match(src_dir)
+        if match and match.group(1) in {"workspaceRoot", "workspaceFolder"}:
+            src = pathlib.Path(src_dir).parts[1:]
+            return pathlib.Path(root_dir, *src).resolve()
+
+        if match and match.group(1) == "confDir":
+            src = pathlib.Path(src_dir).parts[1:]
+            return pathlib.Path(actual_conf_dir, *src).resolve()
+
+        return pathlib.Path(src_dir).expanduser()
+
+
+class SphinxServerConfig(ServerConfig):
+
+    hide_sphinx_output: bool = Field(False, alias="hideSphinxOutput")
+    """A flag to indicate if Sphinx build output should be omitted from the log."""
+
+
+class InitializationOptions(BaseModel):
+    """The initialization options we can expect to receive from a client."""
+
+    sphinx: SphinxConfig = Field(default_factory=SphinxConfig)
+    """The ``esbonio.sphinx.*`` namespace of options."""
+
+    server: SphinxServerConfig = Field(default_factory=SphinxServerConfig)
+    """The ``esbonio.server.*`` namespace of options."""
+
+
+DIAGNOSTIC_SEVERITY = {
+    logging.ERROR: DiagnosticSeverity.Error,
+    logging.INFO: DiagnosticSeverity.Information,
+    logging.WARNING: DiagnosticSeverity.Warning,
+}
+
+
+class SphinxLogHandler(LspHandler):
+    """A logging handler that can extract errors from Sphinx's build output."""
+
+    def __init__(self, app, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.app = app
+        self.translator = WarningLogRecordTranslator(app)
+        self.only_once = OnceFilter()
+        self.diagnostics: Dict[str, List[Diagnostic]] = {}
+
+    def get_location(self, location: str) -> Tuple[str, Optional[int]]:
+
+        if not location:
+            conf = pathlib.Path(self.app.confdir, "conf.py")
+            return (str(conf), None)
+
+        path, *parts = location.split(":")
+        lineno = None
+
+        # On windows the rest of the path will be the first element of parts
+        if IS_WIN:
+            path += f":{parts.pop(0)}"
+
+        if len(parts) == 1:
+            try:
+                lineno = int(parts[0])
+            except ValueError:
+                pass
+
+        if len(parts) == 2:
+            # TODO: There's a possibility that there is an error in a docstring in a
+            #       *.py file somewhere. In which case parts would look like
+            #       ['docstring of {dotted.name}', '{lineno}']
+            #
+            #  e.g. ['docstring of esbonio.lsp.sphinx.SphinxLanguageServer.get_domains', '8']
+            #
+            #       It would be good to handle this case and look up the correct line
+            #       number to place a diagnostic.
+            pass
+
+        return (Uri.from_fs_path(path), lineno)
+
+    def emit(self, record: logging.LogRecord) -> None:
+
+        conditions = [
+            "sphinx" not in record.name,
+            record.levelno not in {logging.WARNING, logging.ERROR},
+            not self.translator,
+        ]
+
+        if any(conditions):
+            # Log the record as normal
+            super().emit(record)
+            return
+
+        # Only process errors/warnings once.
+        if not self.only_once.filter(record):
+            return
+
+        # Let sphinx do what it does to warning/error messages
+        self.translator.filter(record)
+
+        loc = record.location if isinstance(record, SphinxLogRecord) else ""
+        doc, lineno = self.get_location(loc)
+        line = lineno or 1
+        self.server.logger.debug("Reporting diagnostic at %s:%s", doc, line)
+
+        try:
+            message = record.msg % record.args
+        except Exception:
+            message = record.msg
+            self.server.logger.debug(
+                "Unable to format diagnostic message: %s", traceback.format_exc()
+            )
+
+        diagnostic = Diagnostic(
+            range=Range(
+                start=Position(line=line - 1, character=0),
+                end=Position(line=line, character=0),
+            ),
+            message=message,
+            severity=DIAGNOSTIC_SEVERITY.get(
+                record.levelno, DiagnosticSeverity.Warning
+            ),
+        )
+
+        if doc not in self.diagnostics:
+            self.diagnostics[doc] = [diagnostic]
+        else:
+            self.diagnostics[doc].append(diagnostic)
+
+        super().emit(record)

--- a/lib/esbonio/setup.cfg
+++ b/lib/esbonio/setup.cfg
@@ -44,6 +44,7 @@ exclude = tests*
 [options.entry_points]
 console_scripts =
     esbonio = esbonio.__main__:main
+    esbonio-sphinx = esbonio.lsp.sphinx.cli:main
 
 [options.extras_require]
 debug = lsp-devtools
@@ -64,4 +65,4 @@ dev =
 
 [flake8]
 max-line-length = 88
-ignore = E501,W503,E402
+ignore = E501,W503,E402,E203

--- a/lib/esbonio/setup.cfg
+++ b/lib/esbonio/setup.cfg
@@ -1,3 +1,4 @@
+
 [metadata]
 name = esbonio
 version = 0.11.2
@@ -33,7 +34,7 @@ include_package_data = True
 install_requires =
     appdirs
     sphinx
-    pygls>=0.11.2,<0.12.0
+    pygls>=0.11.0,<0.12.0
     pyspellchecker
     typing-extensions
 

--- a/lib/esbonio/tests/sphinx-default/test_sd_sphinx.py
+++ b/lib/esbonio/tests/sphinx-default/test_sd_sphinx.py
@@ -21,9 +21,19 @@ from pytest_lsp import make_test_client
 
 from esbonio.lsp import ESBONIO_SERVER_CONFIGURATION
 from esbonio.lsp import ESBONIO_SERVER_PREVIEW
+from esbonio.lsp.rst import ServerConfig
 from esbonio.lsp.sphinx import InitializationOptions
 from esbonio.lsp.sphinx import SphinxConfig
 from esbonio.lsp.testing import sphinx_version
+
+
+class SphinxInfo(SphinxConfig):
+
+    command: List[str]
+    """The equivalent ``sphinx-build`` command"""
+
+    version: str
+    """Sphinx's version number."""
 
 
 def make_esbonio_client(*args, **kwargs):
@@ -272,7 +282,7 @@ async def test_initialization(command: List[str], path: str, options, expected):
         assert len(test.client.messages) == 0
 
         assert "sphinx" in configuration
-        actual = SphinxConfig(**configuration["sphinx"])
+        actual = SphinxInfo(**configuration["sphinx"])
 
         assert actual.version is not None
         assert expected.build_dir in actual.build_dir
@@ -326,7 +336,7 @@ async def test_initialization_build_dir():
             assert len(test.client.messages) == 0
 
             assert "sphinx" in configuration
-            actual = SphinxConfig(**configuration["sphinx"])
+            actual = SphinxInfo(**configuration["sphinx"])
 
             assert actual.version is not None
             assert actual.builder_name == "html"
@@ -377,7 +387,7 @@ async def test_initialization_build_dir_workspace_var():
         assert len(test.client.messages) == 0
 
         assert "sphinx" in configuration
-        actual = SphinxConfig(**configuration["sphinx"])
+        actual = SphinxInfo(**configuration["sphinx"])
 
         assert actual.version is not None
         assert actual.builder_name == "html"
@@ -428,7 +438,7 @@ async def test_initialization_build_dir_workspace_folder():
         assert len(test.client.messages) == 0
 
         assert "sphinx" in configuration
-        actual = SphinxConfig(**configuration["sphinx"])
+        actual = SphinxInfo(**configuration["sphinx"])
 
         assert actual.version is not None
         assert actual.builder_name == "html"
@@ -479,7 +489,7 @@ async def test_initialization_build_dir_confdir():
         assert len(test.client.messages) == 0
 
         assert "sphinx" in configuration
-        actual = SphinxConfig(**configuration["sphinx"])
+        actual = SphinxInfo(**configuration["sphinx"])
         expected_dir = pathlib.Path(actual.conf_dir, "..", "_build", "html").resolve()
 
         assert actual.version is not None
@@ -513,6 +523,9 @@ async def test_initialization_sphinx_error():
         server_command=[sys.executable, "-m", "esbonio"],
         root_uri=root_uri,
         client_factory=make_esbonio_client,
+        initialization_options=InitializationOptions(
+            server=ServerConfig(logLevel="debug")
+        ),
     )
 
     test = make_client_server(config)
@@ -524,7 +537,6 @@ async def test_initialization_sphinx_error():
         )
 
         assert "sphinx" in configuration
-        assert configuration["sphinx"]["version"] is None
 
         conf_py = root_uri + "/conf.py"
         if IS_WIN:
@@ -609,7 +621,6 @@ async def test_initialization_missing_conf():
             )
 
             assert "sphinx" in configuration
-            assert configuration["sphinx"]["version"] is None
 
             assert len(test.client.messages) == 1
             message = test.client.messages[0]

--- a/lib/esbonio/tests/unit_tests/test_sphinx.py
+++ b/lib/esbonio/tests/unit_tests/test_sphinx.py
@@ -1,200 +1,388 @@
+import itertools
 import pathlib
+from typing import List
+from typing import Tuple
 
 import pytest
+from pygls import IS_WIN
 
 from esbonio.lsp.sphinx import SphinxConfig
 
 
-@pytest.mark.parametrize(
-    "setup, expected",
-    [
-        (
-            ("/path/to/root", "/path/to/config"),
-            pathlib.Path("/path/to/config"),
-        ),
-        (
-            ("/path/to/root", "~/path/to/config"),
-            pathlib.Path("~/path/to/config").expanduser(),
-        ),
-        (
-            ("/path/to/root", "${workspaceRoot}/config"),
-            pathlib.Path("/path/to/root/config").resolve(),
-        ),
-        (
-            ("/path/to/root", "${workspaceRoot}/../config"),
-            pathlib.Path("/path/to/config").resolve(),
-        ),
-        (
-            ("/path/to/root", "${workspaceFolder}/config"),
-            pathlib.Path("/path/to/root/config").resolve(),
-        ),
-        (
-            ("/path/to/root", "${workspaceFolder}/../config"),
-            pathlib.Path("/path/to/config").resolve(),
-        ),
-    ],
-)
-def test_resolve_conf_dir(setup, expected):
-    """Ensure that the ``resolve_conf_dir`` function works as expected."""
+def config_with(**kwargs) -> SphinxConfig:
+    """Return a SphinxConfig object with the given config dir."""
 
-    root_uri, conf_dir = setup
-    config = SphinxConfig(confDir=conf_dir)
+    args = {k: str(v) if isinstance(v, pathlib.Path) else v for k, v in kwargs.items()}
+    for dir_ in ["buildDir", "confDir", "doctreeDir", "srcDir"]:
+        if dir_ not in args:
+            args[dir_] = str(
+                pathlib.Path(f"/path/to/{dir_.replace('Dir', '')}").resolve()
+            )
 
-    actual = config.resolve_conf_dir(root_uri)
-    assert actual == expected
+    return SphinxConfig(**args)
 
 
 @pytest.mark.parametrize(
-    "setup, expected",
+    "root_uri, setup",
     [
-        (
-            (
-                "file:///path/to/root",
-                pathlib.Path("/path/to/config"),
-                SphinxConfig(srcDir="/path/to/src"),
-            ),
-            pathlib.Path("/path/to/src"),
-        ),
-        (
-            (
-                "file:///path/to/root",
-                pathlib.Path("/path/to/config"),
-                SphinxConfig(srcDir="~/path/to/src"),
-            ),
-            pathlib.Path("~/path/to/src").expanduser(),
-        ),
-        (
-            (
-                "file:///path/to/root",
-                pathlib.Path("/path/to/config"),
-                SphinxConfig(srcDir="${workspaceRoot}/src"),
-            ),
-            pathlib.Path("/path/to/root/src").resolve(),
-        ),
-        (
-            (
-                "file:///path/to/root",
-                pathlib.Path("/path/to/config"),
-                SphinxConfig(srcDir="${workspaceRoot}/../src"),
-            ),
-            pathlib.Path("/path/to/src").resolve(),
-        ),
-        (
-            (
-                "file:///path/to/root",
-                pathlib.Path("/path/to/config"),
-                SphinxConfig(srcDir="${workspaceFolder}/src"),
-            ),
-            pathlib.Path("/path/to/root/src").resolve(),
-        ),
-        (
-            (
-                "file:///path/to/root",
-                pathlib.Path("/path/to/config"),
-                SphinxConfig(srcDir="${workspaceFolder}/../src"),
-            ),
-            pathlib.Path("/path/to/src").resolve(),
-        ),
-        (
-            (
-                "file:///path/to/root",
-                pathlib.Path("/path/to/config"),
-                SphinxConfig(srcDir="${confDir}/src"),
-            ),
-            pathlib.Path("/path/to/config/src").resolve(),
-        ),
-        (
-            (
-                "file:///path/to/root",
-                pathlib.Path("/path/to/config"),
-                SphinxConfig(srcDir="${confDir}/../src"),
-            ),
-            pathlib.Path("/path/to/src").resolve(),
-        ),
+        *itertools.product(
+            ["file:///path/to/root"],
+            [
+                # buildDir handling
+                (
+                    config_with(buildDir="/path/to/build"),
+                    config_with(buildDir=pathlib.Path("/path/to/build/html")),
+                ),
+                (
+                    config_with(buildDir="~/path/to/build"),
+                    config_with(
+                        buildDir=pathlib.Path("~/path/to/build/html").expanduser()
+                    ),
+                ),
+                (
+                    config_with(buildDir="${workspaceRoot}/build"),
+                    config_with(
+                        buildDir=pathlib.Path("/path/to/root/build/html").resolve()
+                    ),
+                ),
+                (
+                    config_with(buildDir="${workspaceRoot}/../build"),
+                    config_with(buildDir=pathlib.Path("/path/to/build/html").resolve()),
+                ),
+                (
+                    config_with(buildDir="${workspaceFolder}/build"),
+                    config_with(
+                        buildDir=pathlib.Path("/path/to/root/build/html").resolve()
+                    ),
+                ),
+                (
+                    config_with(buildDir="${workspaceFolder}/../build"),
+                    config_with(buildDir=pathlib.Path("/path/to/build/html").resolve()),
+                ),
+                (
+                    config_with(buildDir="${confDir}/build"),
+                    config_with(
+                        buildDir=pathlib.Path("/path/to/conf/build/html").resolve()
+                    ),
+                ),
+                (
+                    config_with(buildDir="${confDir}/../build"),
+                    config_with(buildDir=pathlib.Path("/path/to/build/html").resolve()),
+                ),
+                (
+                    config_with(buildDir="/path/to/build", makeMode=False),
+                    config_with(
+                        buildDir=pathlib.Path("/path/to/build"), makeMode=False
+                    ),
+                ),
+                # confDir handling
+                (
+                    config_with(confDir="/path/to/config"),
+                    config_with(
+                        buildDir=pathlib.Path("/path/to/build/html").resolve(),
+                        confDir=pathlib.Path("/path/to/config"),
+                    ),
+                ),
+                (
+                    config_with(confDir="~/path/to/config"),
+                    config_with(
+                        buildDir=pathlib.Path("/path/to/build/html").resolve(),
+                        confDir=pathlib.Path("~/path/to/config").expanduser(),
+                    ),
+                ),
+                (
+                    config_with(confDir="${workspaceRoot}/config"),
+                    config_with(
+                        buildDir=pathlib.Path("/path/to/build/html").resolve(),
+                        confDir=pathlib.Path("/path/to/root/config").resolve(),
+                    ),
+                ),
+                (
+                    config_with(confDir="${workspaceRoot}/../config"),
+                    config_with(
+                        buildDir=pathlib.Path("/path/to/build/html").resolve(),
+                        confDir=pathlib.Path("/path/to/config").resolve(),
+                    ),
+                ),
+                (
+                    config_with(confDir="${workspaceFolder}/config"),
+                    config_with(
+                        buildDir=pathlib.Path("/path/to/build/html").resolve(),
+                        confDir=pathlib.Path("/path/to/root/config").resolve(),
+                    ),
+                ),
+                (
+                    config_with(confDir="${workspaceFolder}/../config"),
+                    config_with(
+                        buildDir=pathlib.Path("/path/to/build/html").resolve(),
+                        confDir=pathlib.Path("/path/to/config").resolve(),
+                    ),
+                ),
+                # doctreeDir handling (make mode)
+                (
+                    config_with(buildDir="/path/to/build", doctreeDir=None),
+                    config_with(
+                        buildDir=pathlib.Path("/path/to/build/html"),
+                        doctreeDir=pathlib.Path("/path/to/build/doctrees"),
+                    ),
+                ),
+                (
+                    config_with(
+                        buildDir="/path/to/build", doctreeDir="/path/to/doctrees"
+                    ),
+                    config_with(
+                        buildDir=pathlib.Path("/path/to/build/html"),
+                        doctreeDir=pathlib.Path("/path/to/doctrees"),
+                    ),
+                ),
+                (
+                    config_with(
+                        buildDir="/path/to/build",
+                        doctreeDir="${workspaceRoot}/doctrees",
+                    ),
+                    config_with(
+                        buildDir=pathlib.Path("/path/to/build/html"),
+                        doctreeDir=pathlib.Path("/path/to/root/doctrees").resolve(),
+                    ),
+                ),
+                (
+                    config_with(
+                        buildDir="/path/to/build",
+                        doctreeDir="${workspaceFolder}/../dts",
+                    ),
+                    config_with(
+                        buildDir=pathlib.Path("/path/to/build/html"),
+                        doctreeDir=pathlib.Path("/path/to/dts").resolve(),
+                    ),
+                ),
+                (
+                    config_with(
+                        buildDir="/path/to/build",
+                        doctreeDir="${confDir}/dts",
+                    ),
+                    config_with(
+                        buildDir=pathlib.Path("/path/to/build/html"),
+                        doctreeDir=pathlib.Path("/path/to/conf/dts").resolve(),
+                    ),
+                ),
+                (
+                    config_with(
+                        buildDir="/path/to/build",
+                        doctreeDir="${buildDir}/dts",
+                    ),
+                    config_with(
+                        buildDir=pathlib.Path("/path/to/build/html"),
+                        doctreeDir=pathlib.Path("/path/to/build/dts").resolve(),
+                    ),
+                ),
+                # doctreeDir handling (non make mode)
+                (
+                    config_with(
+                        buildDir="/path/to/build", doctreeDir=None, makeMode=False
+                    ),
+                    config_with(
+                        buildDir=pathlib.Path("/path/to/build"),
+                        doctreeDir=pathlib.Path("/path/to/build/.doctrees"),
+                        makeMode=False,
+                    ),
+                ),
+                (
+                    config_with(
+                        buildDir="/path/to/build",
+                        doctreeDir="/path/to/doctrees",
+                        makeMode=False,
+                    ),
+                    config_with(
+                        buildDir=pathlib.Path("/path/to/build"),
+                        doctreeDir=pathlib.Path("/path/to/doctrees"),
+                        makeMode=False,
+                    ),
+                ),
+                (
+                    config_with(
+                        buildDir="/path/to/build",
+                        doctreeDir="${workspaceRoot}/doctrees",
+                        makeMode=False,
+                    ),
+                    config_with(
+                        buildDir=pathlib.Path("/path/to/build"),
+                        doctreeDir=pathlib.Path("/path/to/root/doctrees").resolve(),
+                        makeMode=False,
+                    ),
+                ),
+                (
+                    config_with(
+                        buildDir="/path/to/build",
+                        doctreeDir="${workspaceFolder}/../dts",
+                        makeMode=False,
+                    ),
+                    config_with(
+                        buildDir=pathlib.Path("/path/to/build"),
+                        doctreeDir=pathlib.Path("/path/to/dts").resolve(),
+                        makeMode=False,
+                    ),
+                ),
+                (
+                    config_with(
+                        buildDir="/path/to/build",
+                        doctreeDir="${confDir}/../dts",
+                        makeMode=False,
+                    ),
+                    config_with(
+                        buildDir=pathlib.Path("/path/to/build"),
+                        doctreeDir=pathlib.Path("/path/to/dts").resolve(),
+                        makeMode=False,
+                    ),
+                ),
+                (
+                    config_with(
+                        buildDir="/path/to/build",
+                        doctreeDir="${buildDir}/dts",
+                        makeMode=False,
+                    ),
+                    config_with(
+                        buildDir=pathlib.Path("/path/to/build"),
+                        doctreeDir=pathlib.Path("/path/to/build/dts").resolve(),
+                        makeMode=False,
+                    ),
+                ),
+                # srcDir handling
+                (
+                    config_with(srcDir="/path/to/src"),
+                    config_with(
+                        buildDir=pathlib.Path("/path/to/build/html").resolve(),
+                        srcDir=pathlib.Path("/path/to/src"),
+                    ),
+                ),
+                (
+                    config_with(srcDir="~/path/to/src"),
+                    config_with(
+                        buildDir=pathlib.Path("/path/to/build/html").resolve(),
+                        srcDir=pathlib.Path("~/path/to/src").expanduser(),
+                    ),
+                ),
+                (
+                    config_with(srcDir="${workspaceRoot}/src"),
+                    config_with(
+                        buildDir=pathlib.Path("/path/to/build/html").resolve(),
+                        srcDir=pathlib.Path("/path/to/root/src").resolve(),
+                    ),
+                ),
+                (
+                    config_with(srcDir="${workspaceRoot}/../src"),
+                    config_with(
+                        buildDir=pathlib.Path("/path/to/build/html").resolve(),
+                        srcDir=pathlib.Path("/path/to/src").resolve(),
+                    ),
+                ),
+                (
+                    config_with(srcDir="${workspaceFolder}/src"),
+                    config_with(
+                        buildDir=pathlib.Path("/path/to/build/html").resolve(),
+                        srcDir=pathlib.Path("/path/to/root/src").resolve(),
+                    ),
+                ),
+                (
+                    config_with(srcDir="${workspaceFolder}/../src"),
+                    config_with(
+                        buildDir=pathlib.Path("/path/to/build/html").resolve(),
+                        srcDir=pathlib.Path("/path/to/src").resolve(),
+                    ),
+                ),
+                (
+                    config_with(srcDir="${confDir}/src"),
+                    config_with(
+                        buildDir=pathlib.Path("/path/to/build/html").resolve(),
+                        srcDir=pathlib.Path("/path/to/conf/src").resolve(),
+                    ),
+                ),
+                (
+                    config_with(srcDir="${confDir}/../src"),
+                    config_with(
+                        buildDir=pathlib.Path("/path/to/build/html").resolve(),
+                        srcDir=pathlib.Path("/path/to/src").resolve(),
+                    ),
+                ),
+            ],
+        )
     ],
 )
-def test_resolve_src_dir(setup, expected):
-    """Ensure that the ``resolve_src_dir`` function works as expected."""
+def test_resolve(root_uri, setup: Tuple[SphinxConfig, SphinxConfig]):
+    """Ensure that we can resolve a config relative to a project root correctly."""
+    config, expected = setup
+    actual = config.resolve(root_uri)
 
-    root_uri, conf_dir, config = setup
+    # This seems hacky, but paths on windows are case insensitive...
+    if IS_WIN:
+        assert expected.build_dir.lower() == actual.build_dir.lower()
+        assert expected.conf_dir.lower() == actual.conf_dir.lower()
+        assert expected.doctree_dir.lower() == actual.doctree_dir.lower()
+        assert expected.src_dir.lower() == actual.src_dir.lower()
 
-    actual = config.resolve_src_dir(root_uri, conf_dir)
-    assert actual == expected
+    else:
+        assert expected.build_dir == actual.build_dir
+        assert expected.conf_dir == actual.conf_dir
+        assert expected.doctree_dir == actual.doctree_dir
+        assert expected.src_dir == actual.src_dir
+
+    assert expected.builder_name == actual.builder_name
+    assert expected.config_overrides == actual.config_overrides
+    assert expected.force_full_build == actual.force_full_build
+    assert expected.keep_going == actual.keep_going
+    assert expected.make_mode == actual.make_mode
+    assert expected.num_jobs == actual.num_jobs
+    assert expected.quiet == actual.quiet
+    assert expected.silent == actual.silent
+    assert expected.tags == actual.tags
+    assert expected.verbosity == actual.verbosity
+    assert expected.warning_is_error == actual.warning_is_error
 
 
 @pytest.mark.parametrize(
-    "setup, expected",
+    "args",
     [
-        (
-            (
-                "file:///path/to/root",
-                pathlib.Path("/path/to/config"),
-                SphinxConfig(buildDir="/path/to/build"),
-            ),
-            pathlib.Path("/path/to/build"),
-        ),
-        (
-            (
-                "file:///path/to/root",
-                pathlib.Path("/path/to/config"),
-                SphinxConfig(buildDir="~/path/to/build"),
-            ),
-            pathlib.Path("~/path/to/build").expanduser(),
-        ),
-        (
-            (
-                "file:///path/to/root",
-                pathlib.Path("/path/to/config"),
-                SphinxConfig(buildDir="${workspaceRoot}/build"),
-            ),
-            pathlib.Path("/path/to/root/build").resolve(),
-        ),
-        (
-            (
-                "file:///path/to/root",
-                pathlib.Path("/path/to/config"),
-                SphinxConfig(buildDir="${workspaceRoot}/../build"),
-            ),
-            pathlib.Path("/path/to/build").resolve(),
-        ),
-        (
-            (
-                "file:///path/to/root",
-                pathlib.Path("/path/to/config"),
-                SphinxConfig(buildDir="${workspaceFolder}/build"),
-            ),
-            pathlib.Path("/path/to/root/build").resolve(),
-        ),
-        (
-            (
-                "file:///path/to/root",
-                pathlib.Path("/path/to/config"),
-                SphinxConfig(buildDir="${workspaceFolder}/../build"),
-            ),
-            pathlib.Path("/path/to/build").resolve(),
-        ),
-        (
-            (
-                "file:///path/to/root",
-                pathlib.Path("/path/to/config"),
-                SphinxConfig(buildDir="${confDir}/build"),
-            ),
-            pathlib.Path("/path/to/config/build").resolve(),
-        ),
-        (
-            (
-                "file:///path/to/root",
-                pathlib.Path("/path/to/config"),
-                SphinxConfig(buildDir="${confDir}/../build"),
-            ),
-            pathlib.Path("/path/to/build").resolve(),
-        ),
+        ["-M", "html", "src", "out"],
+        ["-M", "latex", "src", "out"],
+        ["-M", "html", "src", "out", "-E"],
+        ["-M", "html", "src", "out", "-c", "conf"],
+        ["-M", "html", "src", "out", "-d", "doctreedir"],
+        ["-M", "html", "src", "out", "-Dkey=value", "-Danother=v"],
+        ["-M", "html", "src", "out", "-Akey=value", "-Aanother=v"],
+        ["-M", "html", "src", "out", "-j", "4"],
+        ["-M", "html", "src", "out", "-n"],
+        ["-M", "html", "src", "out", "-q"],
+        ["-M", "html", "src", "out", "-Q"],
+        ["-M", "html", "src", "out", "-t", "tag1"],
+        ["-M", "html", "src", "out", "-t", "tag1", "-t", "tag2"],
+        ["-M", "html", "src", "out", "-v"],
+        ["-M", "html", "src", "out", "-vv"],
+        ["-M", "html", "src", "out", "-vvv"],
+        ["-M", "html", "src", "out", "-W"],
+        ["-M", "html", "src", "out", "-W", "--keep-going"],
+        ["-b", "html", "src", "out"],
+        ["-b", "latex", "src", "out"],
+        ["-b", "html", "-E", "src", "out"],
+        ["-b", "html", "-c", "conf", "src", "out"],
+        ["-b", "html", "-Dkey=value", "-Danother=v", "src", "out"],
+        ["-b", "html", "-Akey=value", "-Aanother=v", "src", "out"],
+        ["-b", "html", "-d", "doctreedir", "src", "out"],
+        ["-b", "html", "-j", "4", "src", "out"],
+        ["-b", "html", "-n", "src", "out"],
+        ["-b", "html", "-q", "src", "out"],
+        ["-b", "html", "-Q", "src", "out"],
+        ["-b", "html", "-t", "tag1", "src", "out"],
+        ["-b", "html", "-t", "tag1", "-t", "tag2", "src", "out"],
+        ["-b", "html", "-v", "src", "out"],
+        ["-b", "html", "-vv", "src", "out"],
+        ["-b", "html", "-vvv", "src", "out"],
+        ["-b", "html", "-W", "src", "out"],
+        ["-b", "html", "-W", "--keep-going", "src", "out"],
     ],
 )
-def test_resolve_build_dir(setup, expected):
-    """Ensure that the ``resolve_build_dir`` function works as expected."""
+def test_cli_arg_handling(args: List[str]):
+    """Ensure that we can convert ``sphinx-build`` to initialization options and back."""
 
-    root_uri, conf_dir, config = setup
+    config = SphinxConfig.from_arguments(cli_args=args)
+    actual = config.to_cli_args()
 
-    actual = config.resolve_build_dir(root_uri, conf_dir)
-    assert actual == expected
+    assert args == actual


### PR DESCRIPTION
- The server's initialization options have been extended to cover most of the available `sphinx-build` cli arguments. It should be the case that all the remaining arguments do not make sense for the language server (like dropping to pdb on errors)
- To help convert between cli arguments and initialization options, there is now a new utility cli program `esbonio-sphinx` that can take a set of `sphinx-build` arguments and convert them into initialization options.
  ```
  $ esbonio-sphinx config -- -M html '${confDir}/../src' '${confDir}/_build' -c '${workspaceRoot}/docs'
  {
    "confDir": "${workspaceRoot}/docs",
    "configOverrides": {},
    "srcDir": "${confDir}/../src",
    "buildDir": "${confDir}/_build/html",
    "doctreeDir": "${confDir}/_build/doctrees",
    "tags": []
  }
  ```
  The intention is that language clients can call this command to provide a workflow where a user enters the build args they wish to use and the language client can write the correct settings.
- As an example of this a "Set Sphinx Build Command" has been added to the Esbonio VSCode extension - as well as a command that can copy an equivalent `sphinx-build` commad to the clipboard.

  (Hopefully this video works, seems ok on mobile but I can't play it in Firefox.... :thinking: )

https://user-images.githubusercontent.com/2675694/169419298-ee800cd3-3cd3-41a6-97ea-d9a0a923941e.mp4

Closes #360 
Closes #374 

