### PR TITLE
Bugfix for Sphinx extension loader

### DIFF
--- a/lib/esbonio/esbonio/lsp/sphinx/__init__.py
+++ b/lib/esbonio/esbonio/lsp/sphinx/__init__.py
@@ -619,7 +619,7 @@ class SphinxLanguageServer(RstLanguageServer):
             if name in self._loaded_modules:
                 self.logger.debug("Skipping previously loaded module '%s'", name)
 
-            if not hasattr(ext, "esbonio_setup"):
+            if not hasattr(mod, "esbonio_setup"):
                 continue
 
             self.logger.debug("Loading sphinx module '%s'", name)


### PR DESCRIPTION
Analyses the module instead of the extension object
to detect an esbonio_setup() function.

Fixes #381