### PR TITLE
Tweaks to the VSCode extension

### DIFF
--- a/code/changes/390.fix.rst
+++ b/code/changes/390.fix.rst
@@ -1,0 +1,1 @@
+The correct value of the ``esbonio.sphinx.doctreeDir`` setting is used when constructing the initializationOptions to send to the server.

--- a/code/changes/391.enhancement.rst
+++ b/code/changes/391.enhancement.rst
@@ -1,0 +1,1 @@
+Language status items are now shown in a project's ``conf.py``, while also correctly being omitted for rst files not under the project's ``srcDir``

--- a/code/src/constants.ts
+++ b/code/src/constants.ts
@@ -3,7 +3,7 @@ export const PYTHON_EXTENSION = "ms-python.python"
 
 export namespace Server {
   export const REQUIRED_PYTHON = "3.6.0"
-  export const REQUIRED_VERSION = "0.11.0"
+  export const REQUIRED_VERSION = "0.12.0"
 }
 
 export namespace Commands {

--- a/code/src/lsp/status.ts
+++ b/code/src/lsp/status.ts
@@ -10,8 +10,9 @@ import { BuildCompleteResult, EsbonioClient } from "./client";
  */
 interface StatusItemFields {
   busy?: boolean,
-  severity?: vscode.LanguageStatusSeverity,
   command?: vscode.Command,
+  selector?: vscode.DocumentSelector,
+  severity?: vscode.LanguageStatusSeverity,
 }
 
 function renderPath(workspaceRoot: string, value: string): string {
@@ -73,6 +74,7 @@ export class StatusManager {
     let confDir = ""
     let srcDir = ""
     let version = ""
+    let selector: (string | vscode.DocumentFilter)[] = []
 
     if (sphinx.buildDir) {
       buildDir = `Build Files - ${renderPath(workspaceRoot, sphinx.buildDir)}`
@@ -80,6 +82,7 @@ export class StatusManager {
 
     if (sphinx.confDir) {
       confDir = `Config - ${renderPath(workspaceRoot, sphinx.confDir)}`
+      selector.push({ language: 'python', pattern: `${sphinx.confDir}/conf.py` })
     }
 
     if (sphinx.builderName) {
@@ -88,6 +91,7 @@ export class StatusManager {
 
     if (sphinx.srcDir) {
       srcDir = `Sources - ${renderPath(workspaceRoot, sphinx.srcDir)}`
+      selector.push({ language: 'restructuredtext', pattern: `${sphinx.srcDir}/**/*` })
     }
 
     if (sphinx.version) {
@@ -98,6 +102,7 @@ export class StatusManager {
 
     this.setStatusItem('Sphinx Version', version, {
       busy: false,
+      selector: selector,
       severity: result.error ? vscode.LanguageStatusSeverity.Error : vscode.LanguageStatusSeverity.Information,
       command: {
         title: 'Restart Server',
@@ -107,6 +112,7 @@ export class StatusManager {
     })
     this.setStatusItem('Builder', builderName, {
       busy: false,
+      selector: selector,
       command: {
         title: "Set Build Command",
         tooltip: "Set the sphinx-build cli options to use",
@@ -114,6 +120,7 @@ export class StatusManager {
       }
     })
     this.setStatusItem('Config', confDir, {
+      selector: selector,
       command: {
         title: "Select Conf Dir",
         tooltip: "Select a new config directory",
@@ -121,6 +128,7 @@ export class StatusManager {
       }
     })
     this.setStatusItem('Sources', srcDir, {
+      selector: selector,
       command: {
         title: "Select Src Dir",
         tooltip: "Select a new sources directory",
@@ -128,6 +136,7 @@ export class StatusManager {
       }
     })
     this.setStatusItem("Build Files", buildDir, {
+      selector: selector,
       command: {
         title: "Select Build Dir",
         tooltip: "Select a new build directory",
@@ -159,7 +168,6 @@ export class StatusManager {
       statusItem.name = name
 
       this.statusItems.set(key, statusItem)
-      // this.context.subscriptions.push(statusItem)
     }
 
     statusItem.text = value
@@ -170,6 +178,10 @@ export class StatusManager {
 
     if (params && params.command) {
       statusItem.command = params.command
+    }
+
+    if (params && params.selector) {
+      statusItem.selector = params.selector
     }
   }
 


### PR DESCRIPTION
- Bump minimum language server version to `0.12.0`
- Language status items are now shown in a project's `conf,py` file, while not being shown in files outside the project's `srcDir`
