### PR TITLE
Better type annotations and dependency injection

### DIFF
--- a/lib/esbonio/changes/409.api.rst
+++ b/lib/esbonio/changes/409.api.rst
@@ -1,0 +1,1 @@
+Improved type annotations allow ``rst.get_feature`` to be called with a language feature's type and have the return type match accordingly. This should allow editors to provide better autocomplete suggestions etc.

--- a/lib/esbonio/changes/409.deprecated.rst
+++ b/lib/esbonio/changes/409.deprecated.rst
@@ -1,0 +1,1 @@
+Calling ``rst.get_feature`` with a string will become an error in ``v.1.0``, a language feature's class should be given instead.

--- a/lib/esbonio/changes/410.api.rst
+++ b/lib/esbonio/changes/410.api.rst
@@ -1,0 +1,9 @@
+``esbonio_setup`` functions can now request specific language features and servers, just by providing type annotations e.g::
+
+     from esbonio.lsp.roles import Roles
+     from esbonio.lsp.sphinx import SphinxLanguageServer
+
+     def esbonio_setup(rst: SphinxLanguageServer, roles: Roles):
+         ...
+
+  This function will then only be called when the language server is actually an instance of ``SphinxLanguageServer`` and only when that lanuage server instance contains an intance of the ``Roles`` feature.

--- a/lib/esbonio/changes/417.fix.rst
+++ b/lib/esbonio/changes/417.fix.rst
@@ -1,0 +1,1 @@
+Log messages from the server's startup are now captured and forwarded onto the language client.

--- a/lib/esbonio/esbonio/cli.py
+++ b/lib/esbonio/esbonio/cli.py
@@ -1,4 +1,5 @@
 import argparse
+import logging
 import sys
 
 
@@ -50,6 +51,8 @@ def main(cli: argparse.ArgumentParser):
     # Put these here to avoid circular import issues.
     from esbonio.lsp import __version__
     from esbonio.lsp import create_language_server
+    from esbonio.lsp.log import LOG_NAMESPACE
+    from esbonio.lsp.log import MemoryHandler
 
     args = cli.parse_args()
 
@@ -65,6 +68,15 @@ def main(cli: argparse.ArgumentParser):
     for mod in args.excluded_modules:
         if mod in modules:
             modules.remove(mod)
+
+    # Setup a temporary logging handler that can cache messages until the language server
+    # is ready to forward them onto the client.
+    logger = logging.getLogger(LOG_NAMESPACE)
+    logger.setLevel(logging.DEBUG)
+
+    handler = MemoryHandler()
+    handler.setLevel(logging.DEBUG)
+    logger.addHandler(handler)
 
     server = create_language_server(args.server_cls, modules)
 

--- a/lib/esbonio/esbonio/lsp/__init__.py
+++ b/lib/esbonio/esbonio/lsp/__init__.py
@@ -1,12 +1,16 @@
 import enum
 import importlib
+import inspect
 import json
 import logging
 import textwrap
 import traceback
+import typing
 from typing import Any
+from typing import Callable
 from typing import Dict
 from typing import Iterable
+from typing import Optional
 from typing import Type
 
 from pygls.lsp.methods import CODE_ACTION
@@ -360,26 +364,86 @@ def _configure_lsp_methods(server: RstLanguageServer) -> RstLanguageServer:
     return server
 
 
-def _load_module(server: RstLanguageServer, module: str):
+def _load_module(server: RstLanguageServer, modname: str):
+    """Load an extension module by calling its ``esbonio_setup`` function, if it exists."""
 
-    try:
-        mod = importlib.import_module(module)
-    except ImportError:
-        logger.error("Unable to import module '%s'\n%s", module, traceback.format_exc())
+    setup = _get_setup_function(modname)
+    if not setup:
         return
 
-    if not hasattr(mod, "esbonio_setup"):
-        logger.error(
-            "Unable to load module '%s', missing 'esbonio_setup' function", module
-        )
+    args = _get_setup_arguments(server, setup, modname)
+    if not args:
         return
 
     try:
-        mod.esbonio_setup(server)
+        setup(**args)
     except Exception:
         logger.error(
-            "Error while setting up module '%s'\n%s", module, traceback.format_exc()
+            "Error while setting up module '%s'\n%s", modname, traceback.format_exc()
         )
+
+
+def _get_setup_function(modname: str) -> Optional[Callable]:
+
+    try:
+        module = importlib.import_module(modname)
+    except ImportError:
+        logger.error(
+            "Unable to import module '%s'\n%s", modname, traceback.format_exc()
+        )
+        return None
+
+    if not hasattr(module, "esbonio_setup"):
+        logger.error(
+            "Unable to load module '%s', missing 'esbonio_setup' function", modname
+        )
+        return None
+
+    return module.esbonio_setup
+
+
+def _get_setup_arguments(
+    server: RstLanguageServer, setup: Callable, modname: str
+) -> Optional[Dict[str, Any]]:
+    """Given a setup function, try to construct the collection of arguments to pass to
+    it.
+    """
+    annotations = typing.get_type_hints(setup)
+    parameters = {
+        p.name: annotations[p.name]
+        for p in inspect.signature(setup).parameters.values()
+    }
+
+    args = {}
+    for name, type_ in parameters.items():
+
+        if issubclass(server.__class__, type_):
+            args[name] = server
+            continue
+
+        if issubclass(type_, LanguageFeature):
+            # Try and obtain an instance of the requested language feature.
+            feature = server.get_feature(type_)
+            if feature is not None:
+                args[name] = feature
+                continue
+
+            logger.debug(
+                "Skipping module '%s', server missing requested feature: '%s'",
+                modname,
+                type_,
+            )
+            return None
+
+        logger.error(
+            "Skipping module '%s', parameter '%s' has unsupported type: '%s'",
+            modname,
+            name,
+            type_,
+        )
+        return None
+
+    return args
 
 
 def dump(obj) -> str:

--- a/lib/esbonio/esbonio/lsp/__init__.py
+++ b/lib/esbonio/esbonio/lsp/__init__.py
@@ -65,7 +65,7 @@ __all__ = [
     "CompletionContext",
     "DefinitionContext",
     "DocumentLinkContext",
-    "LanguageFeature",
+    "HoverContext",
     "RstLanguageServer",
     "create_language_server",
 ]
@@ -377,6 +377,7 @@ def _load_module(server: RstLanguageServer, modname: str):
 
     try:
         setup(**args)
+        logger.debug("Loaded module '%s'", modname)
     except Exception:
         logger.error(
             "Error while setting up module '%s'\n%s", modname, traceback.format_exc()

--- a/lib/esbonio/esbonio/lsp/directives.py
+++ b/lib/esbonio/esbonio/lsp/directives.py
@@ -1,5 +1,3 @@
-"""Logic around directive completions goes here."""
-import json
 import re
 import typing
 from typing import Any
@@ -8,7 +6,6 @@ from typing import List
 from typing import Optional
 from typing import Tuple
 
-import pkg_resources
 from pygls.lsp.types import CompletionItem
 from pygls.lsp.types import CompletionItemKind
 from pygls.lsp.types import DocumentLink
@@ -662,15 +659,4 @@ class Directives(LanguageFeature):
 
 
 def esbonio_setup(rst: RstLanguageServer):
-    """Configure and reigster the directives feature with the server."""
-    directives = Directives(rst)
-    rst.add_feature(directives)
-
-    docutils_docs = pkg_resources.resource_string("esbonio.lsp.rst", "directives.json")
-    directives.add_documentation(json.loads(docutils_docs.decode("utf8")))
-
-    if isinstance(rst, SphinxLanguageServer):
-        sphinx_docs = pkg_resources.resource_string(
-            "esbonio.lsp.sphinx", "directives.json"
-        )
-        directives.add_documentation(json.loads(sphinx_docs.decode("utf8")))
+    rst.add_feature(Directives(rst))

--- a/lib/esbonio/esbonio/lsp/log.py
+++ b/lib/esbonio/esbonio/lsp/log.py
@@ -1,0 +1,97 @@
+import logging
+import typing
+from typing import List
+
+from pygls.server import LanguageServer
+
+if typing.TYPE_CHECKING:
+    from .rst import ServerConfig
+
+
+LOG_NAMESPACE = "esbonio.lsp"
+LOG_LEVELS = {
+    "debug": logging.DEBUG,
+    "error": logging.ERROR,
+    "info": logging.INFO,
+}
+
+
+class LogFilter(logging.Filter):
+    """A log filter that accepts message from any of the listed logger names."""
+
+    def __init__(self, names):
+        self.names = names
+
+    def filter(self, record):
+        return any(record.name == name for name in self.names)
+
+
+class MemoryHandler(logging.Handler):
+    """A log filter that caches messages in memory."""
+
+    def __init__(self):
+        super().__init__()
+        self.records: List[logging.LogRecord] = []
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self.records.append(record)
+
+
+class LspHandler(logging.Handler):
+    """A logging handler that will send log records to an LSP client."""
+
+    def __init__(self, server: LanguageServer):
+        super().__init__()
+        self.server = server
+
+    def emit(self, record: logging.LogRecord) -> None:
+        """Sends the record to the client."""
+
+        # To avoid infinite recursions, it's simpler to just ignore all log records
+        # coming from pygls...
+        if "pygls" in record.name:
+            return
+
+        log = self.format(record).strip()
+        self.server.show_message_log(log)
+
+
+def setup_logging(server: LanguageServer, config: "ServerConfig"):
+    """Setup logging to route log messages to the language client as
+    ``window/logMessage`` messages.
+
+    Parameters
+    ----------
+    server
+       The server to use to send messages
+
+    config
+       The configuration to use
+    """
+
+    level = LOG_LEVELS[config.log_level]
+
+    logger = logging.getLogger(LOG_NAMESPACE)
+    logger.setLevel(level)
+
+    lsp_handler = LspHandler(server)
+    lsp_handler.setLevel(level)
+
+    if len(config.log_filter) > 0:
+        lsp_handler.addFilter(LogFilter(config.log_filter))
+
+    formatter = logging.Formatter("[%(name)s] %(message)s")
+    lsp_handler.setFormatter(formatter)
+
+    # Look to see if there are any cached messages we should forward to the client.
+    for handler in logger.handlers:
+        if not isinstance(handler, MemoryHandler):
+            continue
+
+        for record in handler.records:
+            if logger.isEnabledFor(record.levelno):
+                lsp_handler.emit(record)
+
+        logger.removeHandler(handler)
+
+    logger.addHandler(lsp_handler)

--- a/lib/esbonio/esbonio/lsp/roles.py
+++ b/lib/esbonio/esbonio/lsp/roles.py
@@ -1,5 +1,4 @@
 """Role support."""
-import json
 import typing
 from typing import Any
 from typing import Dict
@@ -7,7 +6,6 @@ from typing import List
 from typing import Optional
 from typing import Tuple
 
-import pkg_resources
 from pygls.lsp.types import CompletionItem
 from pygls.lsp.types import CompletionItemKind
 from pygls.lsp.types import DocumentLink
@@ -559,13 +557,4 @@ class Roles(LanguageFeature):
 
 
 def esbonio_setup(rst: RstLanguageServer):
-
-    roles = Roles(rst)
-    rst.add_feature(roles)
-
-    docutils_docs = pkg_resources.resource_string("esbonio.lsp.rst", "roles.json")
-    roles.add_documentation(json.loads(docutils_docs.decode("utf8")))
-
-    if isinstance(rst, SphinxLanguageServer):
-        sphinx_docs = pkg_resources.resource_string("esbonio.lsp.sphinx", "roles.json")
-        roles.add_documentation(json.loads(sphinx_docs.decode("utf8")))
+    rst.add_feature(Roles(rst))

--- a/lib/esbonio/esbonio/lsp/rst/__init__.py
+++ b/lib/esbonio/esbonio/lsp/rst/__init__.py
@@ -16,9 +16,9 @@ from typing import TypeVar
 from typing import Union
 
 import docutils.parsers.rst.directives as docutils_directives
+import docutils.parsers.rst.roles as docutils_roles
 import pygls.uris as Uri
 from docutils.parsers.rst import Directive
-from docutils.parsers.rst import roles
 from pydantic import BaseModel
 from pydantic import Field
 from pygls import IS_WIN
@@ -54,6 +54,7 @@ DEFAULT_MODULES = [
     "esbonio.lsp.directives",      # Generic directive support
     "esbonio.lsp.roles",           # Generic roles support
     "esbonio.lsp.rst.directives",  # Specialised support for docutils directives
+    "esbonio.lsp.rst.roles",       # Specialised support for docutils roles
 ]
 """The modules to load in the default configuration of the server."""
 # fmt: on
@@ -521,10 +522,12 @@ class RstLanguageServer(LanguageServer):
         if self._roles is not None:
             return self._roles
 
-        found_roles = {**roles._roles, **roles._role_registry}
+        found_roles = {**docutils_roles._roles, **docutils_roles._role_registry}
 
         self._roles = {
-            k: v for k, v in found_roles.items() if v != roles.unimplemented_role
+            k: v
+            for k, v in found_roles.items()
+            if v != docutils_roles.unimplemented_role
         }
 
         return self._roles

--- a/lib/esbonio/esbonio/lsp/rst/__init__.py
+++ b/lib/esbonio/esbonio/lsp/rst/__init__.py
@@ -15,7 +15,7 @@ from typing import Type
 from typing import TypeVar
 from typing import Union
 
-import docutils.parsers.rst.directives as directives
+import docutils.parsers.rst.directives as docutils_directives
 import pygls.uris as Uri
 from docutils.parsers.rst import Directive
 from docutils.parsers.rst import roles
@@ -51,8 +51,9 @@ TRIPLE_QUOTE = re.compile("(\"\"\"|''')")
 # fmt: off
 # Order matters!
 DEFAULT_MODULES = [
-    "esbonio.lsp.directives",  # Generic directive support
-    "esbonio.lsp.roles",       # Generic roles support
+    "esbonio.lsp.directives",      # Generic directive support
+    "esbonio.lsp.roles",           # Generic roles support
+    "esbonio.lsp.rst.directives",  # Specialised support for docutils directives
 ]
 """The modules to load in the default configuration of the server."""
 # fmt: on
@@ -492,7 +493,10 @@ class RstLanguageServer(LanguageServer):
             return self._directives
 
         ignored_directives = ["restructuredtext-test-directive"]
-        found_directives = {**directives._directive_registry, **directives._directives}
+        found_directives = {
+            **docutils_directives._directive_registry,
+            **docutils_directives._directives,
+        }
 
         self._directives = {
             k: resolve_directive(v)

--- a/lib/esbonio/esbonio/lsp/rst/directives.py
+++ b/lib/esbonio/esbonio/lsp/rst/directives.py
@@ -1,0 +1,11 @@
+import json
+
+import pkg_resources
+
+from esbonio.lsp.directives import Directives
+from esbonio.lsp.rst import RstLanguageServer
+
+
+def esbonio_setup(rst: RstLanguageServer, directives: Directives):
+    docutils_docs = pkg_resources.resource_string("esbonio.lsp.rst", "directives.json")
+    directives.add_documentation(json.loads(docutils_docs.decode("utf8")))

--- a/lib/esbonio/esbonio/lsp/rst/roles.py
+++ b/lib/esbonio/esbonio/lsp/rst/roles.py
@@ -1,0 +1,11 @@
+import json
+
+import pkg_resources
+
+from esbonio.lsp.roles import Roles
+from esbonio.lsp.rst import RstLanguageServer
+
+
+def esbonio_setup(rst: RstLanguageServer, roles: Roles):
+    docutils_docs = pkg_resources.resource_string("esbonio.lsp.rst", "roles.json")
+    roles.add_documentation(json.loads(docutils_docs.decode("utf8")))

--- a/lib/esbonio/esbonio/lsp/spelling.py
+++ b/lib/esbonio/esbonio/lsp/spelling.py
@@ -187,8 +187,5 @@ def find_words(
     return words
 
 
-def esbonio_setup(rst):
-
-    if isinstance(rst, SphinxLanguageServer):
-        spelling = Spelling(rst)
-        rst.add_feature(spelling)
+def esbonio_setup(rst: SphinxLanguageServer):
+    rst.add_feature(Spelling(rst))

--- a/lib/esbonio/esbonio/lsp/sphinx/__init__.py
+++ b/lib/esbonio/esbonio/lsp/sphinx/__init__.py
@@ -59,6 +59,7 @@ DEFAULT_MODULES = [
     "esbonio.lsp.directives",         # Generic directive support
     "esbonio.lsp.roles",              # Generic roles support
     "esbonio.lsp.rst.directives",     # Specialised support for docutils directives
+    "esbonio.lsp.rst.roles",          # Specialised support for docutils roles
     "esbonio.lsp.sphinx.codeblocks",  # Support for code-block, highlight, etc.
     "esbonio.lsp.sphinx.domains",     # Support for Sphinx domains
     "esbonio.lsp.sphinx.directives",  # Specialised support for Sphinx directives

--- a/lib/esbonio/esbonio/lsp/sphinx/__init__.py
+++ b/lib/esbonio/esbonio/lsp/sphinx/__init__.py
@@ -58,8 +58,10 @@ IS_LINUX = platform.system() == "Linux"
 DEFAULT_MODULES = [
     "esbonio.lsp.directives",         # Generic directive support
     "esbonio.lsp.roles",              # Generic roles support
+    "esbonio.lsp.rst.directives",     # Specialised support for docutils directives
     "esbonio.lsp.sphinx.codeblocks",  # Support for code-block, highlight, etc.
     "esbonio.lsp.sphinx.domains",     # Support for Sphinx domains
+    "esbonio.lsp.sphinx.directives",  # Specialised support for Sphinx directives
     "esbonio.lsp.sphinx.images",      # Support for image, figure etc
     "esbonio.lsp.sphinx.includes",    # Support for include, literal-include etc.
     "esbonio.lsp.sphinx.roles",       # Support for misc roles added by Sphinx e.g. :download:

--- a/lib/esbonio/esbonio/lsp/sphinx/codeblocks.py
+++ b/lib/esbonio/esbonio/lsp/sphinx/codeblocks.py
@@ -1,6 +1,5 @@
 """Support for code-blocks and related directives."""
 import textwrap
-import typing
 from typing import List
 
 from pygls.lsp.types import CompletionItem
@@ -11,7 +10,6 @@ from pygments.lexers import get_all_lexers
 
 from esbonio.lsp.directives import Directives
 from esbonio.lsp.rst import CompletionContext
-from esbonio.lsp.rst import RstLanguageServer
 from esbonio.lsp.sphinx import SphinxLanguageServer
 
 
@@ -62,14 +60,5 @@ class CodeBlocks:
                 self._lexers.append(item)
 
 
-def esbonio_setup(rst: RstLanguageServer):
-
-    name = "esbonio.lsp.directives.Directives"
-    directives = rst.get_feature(name)
-
-    if not isinstance(rst, SphinxLanguageServer) or not directives:
-        return
-
-    # To keep mypy happy.
-    directives = typing.cast(Directives, directives)
+def esbonio_setup(rst: SphinxLanguageServer, directives: Directives):
     directives.add_argument_completion_provider(CodeBlocks(rst))

--- a/lib/esbonio/esbonio/lsp/sphinx/config.py
+++ b/lib/esbonio/esbonio/lsp/sphinx/config.py
@@ -28,6 +28,7 @@ from sphinx.util.logging import SphinxLogRecord
 from sphinx.util.logging import WarningLogRecordTranslator
 from typing_extensions import Literal
 
+from esbonio.lsp.log import LOG_NAMESPACE
 from esbonio.lsp.log import LspHandler
 from esbonio.lsp.rst import ServerConfig
 
@@ -41,6 +42,7 @@ except ImportError:
 
 
 PATH_VAR_PATTERN = re.compile(r"^\${(\w+)}/?.*")
+logger = logging.getLogger(LOG_NAMESPACE)
 
 
 class MissingConfigError(Exception):
@@ -628,7 +630,7 @@ class SphinxLogHandler(LspHandler):
         loc = record.location if isinstance(record, SphinxLogRecord) else ""
         doc, lineno = self.get_location(loc)
         line = lineno or 1
-        self.server.logger.debug("Reporting diagnostic at %s:%s", doc, line)
+        logger.debug("Reporting diagnostic at %s:%s", doc, line)
 
         try:
             # Not every message contains a string...
@@ -643,7 +645,7 @@ class SphinxLogHandler(LspHandler):
 
         except Exception:
             message = str(record.msg)
-            self.server.logger.error(
+            logger.error(
                 "Unable to format diagnostic message: %s", traceback.format_exc()
             )
 

--- a/lib/esbonio/esbonio/lsp/sphinx/config.py
+++ b/lib/esbonio/esbonio/lsp/sphinx/config.py
@@ -28,7 +28,7 @@ from sphinx.util.logging import SphinxLogRecord
 from sphinx.util.logging import WarningLogRecordTranslator
 from typing_extensions import Literal
 
-from esbonio.lsp.rst import LspHandler
+from esbonio.lsp.log import LspHandler
 from esbonio.lsp.rst import ServerConfig
 
 try:

--- a/lib/esbonio/esbonio/lsp/sphinx/directives.py
+++ b/lib/esbonio/esbonio/lsp/sphinx/directives.py
@@ -1,0 +1,11 @@
+import json
+
+import pkg_resources
+
+from esbonio.lsp.directives import Directives
+from esbonio.lsp.sphinx import SphinxLanguageServer
+
+
+def esbonio_setup(rst: SphinxLanguageServer, directives: Directives):
+    sphinx_docs = pkg_resources.resource_string("esbonio.lsp.sphinx", "directives.json")
+    directives.add_documentation(json.loads(sphinx_docs.decode("utf8")))

--- a/lib/esbonio/esbonio/lsp/sphinx/domains.py
+++ b/lib/esbonio/esbonio/lsp/sphinx/domains.py
@@ -1,6 +1,5 @@
 """Support for Sphinx domains."""
 import pathlib
-import typing
 from typing import List
 from typing import Optional
 from typing import Set
@@ -20,7 +19,6 @@ from esbonio.lsp.roles import Roles
 from esbonio.lsp.rst import CompletionContext
 from esbonio.lsp.rst import DefinitionContext
 from esbonio.lsp.rst import DocumentLinkContext
-from esbonio.lsp.rst import RstLanguageServer
 from esbonio.lsp.sphinx import SphinxLanguageServer
 
 
@@ -300,14 +298,9 @@ def project_to_completion_item(project: str) -> CompletionItem:
     )
 
 
-def esbonio_setup(rst: RstLanguageServer):
+def esbonio_setup(rst: SphinxLanguageServer, roles: Roles):
+    domains = DomainFeatures(rst)
 
-    if isinstance(rst, SphinxLanguageServer):
-        domains = DomainFeatures(rst)
-        roles = rst.get_feature("esbonio.lsp.roles.Roles")
-
-        if roles:
-            roles = typing.cast(Roles, roles)  # let's keep mypy happy
-            roles.add_target_definition_provider(domains)
-            roles.add_target_completion_provider(domains)
-            roles.add_target_link_provider(domains)
+    roles.add_target_definition_provider(domains)
+    roles.add_target_completion_provider(domains)
+    roles.add_target_link_provider(domains)

--- a/lib/esbonio/esbonio/lsp/sphinx/images.py
+++ b/lib/esbonio/esbonio/lsp/sphinx/images.py
@@ -1,6 +1,5 @@
 import os.path
 import pathlib
-import typing
 from typing import List
 from typing import Optional
 from typing import Tuple
@@ -16,7 +15,6 @@ from esbonio.lsp.directives import Directives
 from esbonio.lsp.rst import CompletionContext
 from esbonio.lsp.rst import DefinitionContext
 from esbonio.lsp.rst import DocumentLinkContext
-from esbonio.lsp.rst import RstLanguageServer
 from esbonio.lsp.sphinx import SphinxLanguageServer
 from esbonio.lsp.util.filepaths import complete_sphinx_filepaths
 from esbonio.lsp.util.filepaths import path_to_completion_item
@@ -104,18 +102,9 @@ class Images:
         return Uri.from_fs_path(str(fpath))
 
 
-def esbonio_setup(rst: RstLanguageServer):
-
-    name = "esbonio.lsp.directives.Directives"
-    directives = rst.get_feature(name)
-
-    if not isinstance(rst, SphinxLanguageServer) or not directives:
-        return
-
-    # To keep mypy happy.
-    directives = typing.cast(Directives, directives)
-
+def esbonio_setup(rst: SphinxLanguageServer, directives: Directives):
     images = Images(rst)
+
     directives.add_argument_definition_provider(images)
     directives.add_argument_completion_provider(images)
     directives.add_argument_link_provider(images)

--- a/lib/esbonio/esbonio/lsp/sphinx/includes.py
+++ b/lib/esbonio/esbonio/lsp/sphinx/includes.py
@@ -1,6 +1,5 @@
 import os.path
 import pathlib
-import typing
 from typing import List
 from typing import Optional
 from typing import Tuple
@@ -16,7 +15,6 @@ from esbonio.lsp.directives import Directives
 from esbonio.lsp.rst import CompletionContext
 from esbonio.lsp.rst import DefinitionContext
 from esbonio.lsp.rst import DocumentLinkContext
-from esbonio.lsp.rst import RstLanguageServer
 from esbonio.lsp.sphinx import SphinxLanguageServer
 from esbonio.lsp.util.filepaths import complete_sphinx_filepaths
 from esbonio.lsp.util.filepaths import path_to_completion_item
@@ -104,17 +102,9 @@ class Includes:
         return Uri.from_fs_path(str(fpath))
 
 
-def esbonio_setup(rst: RstLanguageServer):
-
-    name = "esbonio.lsp.directives.Directives"
-    directives = rst.get_feature(name)
-    if not isinstance(rst, SphinxLanguageServer) or not directives:
-        return
-
-    # To keep mypy happy.
-    directives = typing.cast(Directives, directives)
-
+def esbonio_setup(rst: SphinxLanguageServer, directives: Directives):
     includes = Includes(rst)
+
     directives.add_argument_definition_provider(includes)
     directives.add_argument_completion_provider(includes)
     directives.add_argument_link_provider(includes)

--- a/lib/esbonio/esbonio/lsp/sphinx/roles.py
+++ b/lib/esbonio/esbonio/lsp/sphinx/roles.py
@@ -1,15 +1,15 @@
 """Extra support for roles added by sphinx."""
+import json
 import os.path
-import typing
 from typing import List
 from typing import Optional
 
+import pkg_resources
 import pygls.uris as Uri
 from pygls.lsp.types import CompletionItem
 
 from esbonio.lsp.roles import Roles
 from esbonio.lsp.rst import CompletionContext
-from esbonio.lsp.rst import RstLanguageServer
 from esbonio.lsp.sphinx import SphinxLanguageServer
 from esbonio.lsp.util.filepaths import complete_sphinx_filepaths
 from esbonio.lsp.util.filepaths import path_to_completion_item
@@ -38,14 +38,8 @@ class Downloads:
         return [path_to_completion_item(context, p) for p in items]
 
 
-def esbonio_setup(rst: RstLanguageServer):
+def esbonio_setup(rst: SphinxLanguageServer, roles: Roles):
+    sphinx_docs = pkg_resources.resource_string("esbonio.lsp.sphinx", "roles.json")
+    roles.add_documentation(json.loads(sphinx_docs.decode("utf8")))
 
-    name = "esbonio.lsp.roles.Roles"
-    roles = rst.get_feature(name)
-
-    if not isinstance(rst, SphinxLanguageServer) or not roles:
-        return
-
-    # To keep mypy happy
-    roles = typing.cast(Roles, roles)
     roles.add_target_completion_provider(Downloads(rst))

--- a/lib/esbonio/tests/unit_tests/test_lsp.py
+++ b/lib/esbonio/tests/unit_tests/test_lsp.py
@@ -1,0 +1,122 @@
+import pytest
+
+from esbonio.lsp import _get_setup_arguments
+from esbonio.lsp.roles import Roles
+from esbonio.lsp.rst import RstLanguageServer
+from esbonio.lsp.sphinx import SphinxLanguageServer
+
+
+@pytest.mark.filterwarnings("ignore:There is no current event loop")
+def test_get_setup_arguments_rst_server():
+    """Ensure that we can correctly construct the set of arguments to pass to a module's
+    setup function."""
+
+    def setup(rst: RstLanguageServer):
+        ...
+
+    server = RstLanguageServer()
+    args = _get_setup_arguments(server, setup, "modname")
+
+    assert args == {"rst": server}
+
+
+@pytest.mark.filterwarnings("ignore:There is no current event loop")
+def test_get_setup_arguments_server_superclass():
+    """If the setup function is not compatible with the given server it should be
+    skipped."""
+
+    def setup(rst: SphinxLanguageServer):
+        ...
+
+    server = RstLanguageServer()
+    args = _get_setup_arguments(server, setup, "modname")
+
+    assert args is None
+
+
+@pytest.mark.filterwarnings("ignore:There is no current event loop")
+def test_get_setup_arguments_sphinx_server():
+    """Ensure that we can correctly construct the set of arguments to pass to a module's
+    setup function."""
+
+    def setup(ls: SphinxLanguageServer):
+        ...
+
+    server = SphinxLanguageServer()
+    args = _get_setup_arguments(server, setup, "modname")
+
+    assert args == {"ls": server}
+
+
+@pytest.mark.filterwarnings("ignore:There is no current event loop")
+def test_get_setup_arguments_server_subclass():
+    """Ensure that we can correctly construct the set of arguments to pass to a module's
+    setup function."""
+
+    def setup(ls: RstLanguageServer):
+        ...
+
+    server = SphinxLanguageServer()
+    args = _get_setup_arguments(server, setup, "modname")
+
+    assert args == {"ls": server}
+
+
+@pytest.mark.filterwarnings("ignore:There is no current event loop")
+def test_get_setup_arguments_server_and_feature():
+    """We should also be able to automatically pass the correct language features"""
+
+    def setup(rst: RstLanguageServer, rs: Roles):
+        ...
+
+    server = RstLanguageServer()
+
+    roles = Roles(server)
+    server.add_feature(roles)
+
+    args = _get_setup_arguments(server, setup, "modname")
+
+    assert args == {"rst": server, "rs": roles}
+
+
+@pytest.mark.filterwarnings("ignore:There is no current event loop")
+def test_get_setup_arguments_feature_only():
+    """It should be possible to request just language features."""
+
+    def setup(roles: Roles):
+        ...
+
+    server = RstLanguageServer()
+
+    roles = Roles(server)
+    server.add_feature(roles)
+
+    args = _get_setup_arguments(server, setup, "modname")
+
+    assert args == {"roles": roles}
+
+
+@pytest.mark.filterwarnings("ignore:There is no current event loop")
+def test_get_setup_arguments_missing_feature():
+    """If a requested feature is not available the function should be skipped."""
+
+    def setup(rst: RstLanguageServer, rs: Roles):
+        ...
+
+    server = RstLanguageServer()
+    args = _get_setup_arguments(server, setup, "modname")
+
+    assert args is None
+
+
+@pytest.mark.filterwarnings("ignore:There is no current event loop")
+def test_get_setup_arguments_wrong_type():
+    """If an unsupported type is requested it should be skipped."""
+
+    def setup(rst: RstLanguageServer, rs: int):
+        ...
+
+    server = RstLanguageServer()
+    args = _get_setup_arguments(server, setup, "modname")
+
+    assert args is None

--- a/lib/esbonio/tests/unit_tests/test_rst.py
+++ b/lib/esbonio/tests/unit_tests/test_rst.py
@@ -1,0 +1,55 @@
+import pytest
+
+from esbonio.lsp.roles import Roles
+from esbonio.lsp.rst import RstLanguageServer
+
+
+@pytest.mark.filterwarnings("ignore:There is no current event loop")
+def test_get_feature_by_string():
+    """Ensure that a language feature can be retrieved by a string, but raises a
+    deprecation warning."""
+
+    rst = RstLanguageServer()
+    expected = Roles(rst)
+
+    rst.add_feature(expected)
+    key = f"{expected.__module__}.{expected.__class__.__name__}"
+
+    with pytest.deprecated_call():
+        actual = rst.get_feature(key)
+
+    assert actual is expected
+
+
+@pytest.mark.filterwarnings("ignore:There is no current event loop")
+def test_get_feature_by_cls():
+    """Ensure that a language feature can be retrieved via its class definition."""
+
+    rst = RstLanguageServer()
+    expected = Roles(rst)
+
+    rst.add_feature(expected)
+    actual = rst.get_feature(Roles)
+
+    assert actual is expected
+
+
+@pytest.mark.filterwarnings("ignore:There is no current event loop")
+def test_get_missing_feature_by_string():
+    """Ensure that if a language feature is missing ``None`` is returned, but a
+    deprecation warning is raised."""
+
+    rst = RstLanguageServer()
+
+    with pytest.deprecated_call():
+        actual = rst.get_feature("xxx")
+
+    assert actual is None
+
+
+@pytest.mark.filterwarnings("ignore:There is no current event loop")
+def test_get_missing_feature_by_cls():
+    """Ensure that if a language feature is missing ``None`` is returned."""
+
+    rst = RstLanguageServer()
+    assert rst.get_feature(Roles) is None


### PR DESCRIPTION
- Type annotations for the `rst.get_feature` method have been improved so that when called with a language feature's class definition, the returned object will be annotated as the given class.
  Closes #409 
- `esbonio_setup` functions can now request specific language features and servers, just by providing type annotations e.g
  ```python
  from esbonio.lsp.roles import Roles
  from esbonio.lsp.sphinx import SphinxLanguageServer

  def esbonio_setup(rst: SphinxLanguageServer, roles: Roles):
      ...
  ```
  This function will then only be called when the language server is actually an instance of `SphinxLanguageServer` and when that lanuage server instance contains an intance of the `Roles` feature.
  Closes #410 
- Log messages emitted during the server's startup (i.e. before the `LspHandler` log handler is created) are now captured and forwarded to the client. 
  Closes #417 