### PR TITLE
Add goto implementation support

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,13 @@ The language server is still in early development, but already provides the foll
   <img src="./resources/images/hover-demo.png" alt="Hover Demo"></img>
 </p>
 
+**Implementations**
+
+<p align="center">
+  <img src="./resources/images/implementation-demo.gif" alt="Implementations Demo"></img>
+</p>
+
+
 ## `code/` - A VSCode extension for editing Sphinx projects
 [![Visual Studio Marketplace Version](https://img.shields.io/visual-studio-marketplace/v/swyddfa.esbonio?style=flat-square)![Visual Studio Marketplace Installs](https://img.shields.io/visual-studio-marketplace/i/swyddfa.esbonio?style=flat-square)![Visual Studio Marketplace Downloads](https://img.shields.io/visual-studio-marketplace/d/swyddfa.esbonio?style=flat-square)](https://marketplace.visualstudio.com/items?itemName=swyddfa.esbonio)[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg?style=flat-square)](https://github.com/swyddfa/esbonio/blob/develop/code/LICENSE)
 

--- a/code/README.md
+++ b/code/README.md
@@ -48,6 +48,11 @@ Goto definition is currently implemented for objects linked to by
 
 ![Goto Defintion Demo](../resources/images/definition-demo.gif)
 
+### Goto Implementation
+
+Goto implementation is available for roles and directives
+
+![Goto Implementation Demo](../resources/images/implementation-demo.gif)
 ### Diagnostics
 
 Errors from a build are published to VSCode as diagnostics

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -66,6 +66,13 @@ Here is a quick summary of the features implemented by the language server.
          :align: center
          :target: /_images/hover-demo.png
 
+   .. collection-item:: Implementation
+
+      The language server implements :lsp:`textDocument/implementation` so you can easily find the implementation of a given role or directive.
+
+      .. figure:: ../resources/images/implementation-demo.gif
+         :align: center
+         :target: /_images/implementation-demo.gif
 
 - See the :ref:`lsp_getting_started` guide for details on how to get up and
   running.

--- a/lib/esbonio/README.md
+++ b/lib/esbonio/README.md
@@ -1,14 +1,47 @@
 ![Esbonio logo](https://github.com/swyddfa/esbonio/blob/release/resources/io.github.swyddfa.Esbonio.svg?raw=true)
-# Esbonio [![PyPI](https://img.shields.io/pypi/v/esbonio?style=flat-square)](https://pypi.org/project/esbonio) [![PyPI - Python Version](https://img.shields.io/pypi/pyversions/esbonio?style=flat-square)](https://pypi.org/project/esbonio)
+# Esbonio
 
-Esbonio - to explain.
+[![PyPI](https://img.shields.io/pypi/v/esbonio?style=flat-square)](https://pypi.org/project/esbonio)[![PyPI - Python Version](https://img.shields.io/pypi/pyversions/esbonio?style=flat-square)](https://pypi.org/project/esbonio)![PyPI - Downloads](https://img.shields.io/pypi/dm/esbonio?style=flat-square)[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg?style=flat-square)](https://github.com/swyddfa/esbonio/blob/develop/lib/esbonio/LICENSE)
 
-**This package is in early development**
+**esbonio - (v.) to explain**
 
-A [Language Server](https://microsoft.github.io/language-server-protocol/) that aims to make it easier to work with Sphinx documentation projects in editors that support it.
+A [Language Server](https://microsoft.github.io/language-server-protocol/) that aims to make it easier to work with [reStructuredText](https://docutils.sourceforge.io/rst.html) tools such as [Sphinx](https://www.sphinx-doc.org/en/master/)
+
+It's still in early development, but already provides the following features.
+
+## Completion
+
+![Completion Demo](https://github.com/swyddfa/esbonio/raw/release/resources/images/completion-demo.gif)
+
+## Definitions
+
+![Definition Demo](https://github.com/swyddfa/esbonio/raw/release/resources/images/definition-demo.gif)
+
+
+## Diagnostics
+
+![Diagnostics Demo](https://github.com/swyddfa/esbonio/raw/release/resources/images/diagnostic-sphinx-errors-demo.png)
+
+## Document Links
+
+![Document Link Demo](https://github.com/swyddfa/esbonio/raw/release/resources/images/document-links-demo.png)
+
+## Document Symbols
+
+![Document Symbols](https://github.com/swyddfa/esbonio/raw/release/resources/images/document-symbols-demo.png)
+
+## Hover
+
+![Hover Demo](https://github.com/swyddfa/esbonio/raw/release/resources/images/hover-demo.png)
+
+## Implementations
+
+![Implementations Demo](https://github.com/swyddfa/esbonio/raw/release/resources/images/implementation-demo.gif)
 ## Installation
 
 The Language Server can be installed via pip.
+
+Be sure to check out the [Getting Started](https://swyddfa.github.io/esbonio/docs/latest/en/lsp/getting-started.html) guide for details on integrating the server with your editor of choice.
 
 ```
 $ pip install esbonio

--- a/lib/esbonio/changes/431.api.rst
+++ b/lib/esbonio/changes/431.api.rst
@@ -1,0 +1,1 @@
+``LanguageFeatures`` can now respond to ``textDocument/implementation`` requests by providing an ``implementation`` method and a collection of ``implementation_triggers``.

--- a/lib/esbonio/changes/431.feature.rst
+++ b/lib/esbonio/changes/431.feature.rst
@@ -1,0 +1,1 @@
+The language server now supports ``textDocument/implementation`` requests for roles and directives.

--- a/lib/esbonio/esbonio/lsp/rst/__init__.py
+++ b/lib/esbonio/esbonio/lsp/rst/__init__.py
@@ -199,6 +199,32 @@ class DefinitionContext:
         )
 
 
+class ImplementationContext:
+    """A class that captures the context within which an implementation request has been
+    made."""
+
+    def __init__(
+        self, *, doc: Document, location: str, match: "re.Match", position: Position
+    ):
+
+        self.doc = doc
+        """The document within which the implementation request was made."""
+
+        self.location = location
+        """The location type where the request was made.
+        See :meth:`~esbonio.lsp.rst.RstLanguageServer.get_location_type` for details."""
+
+        self.match = match
+        """The match object describing the site of the implementation request."""
+
+        self.position = position
+        """The position at which the implementation request was made."""
+
+    def __repr__(self):
+        p = f"{self.position.line}:{self.position.character}"
+        return f"ImplementationContext<{self.doc.uri}:{p} ({self.location}) -- {self.match}>"
+
+
 class HoverContext:
     """A class that captures the context within a hover request has been made."""
 
@@ -307,6 +333,22 @@ class LanguageFeature:
         ----------
         context:
            The context of the definition request.
+        """
+        return []
+
+    implementation_triggers: List["re.Pattern"] = []
+    """A list of regular expressions used to determine if the
+    :meth:`~esbonio.lsp.rst.LanguageFeature.implementation` method should be called."""
+
+    def implementation(self, context: ImplementationContext) -> List[Location]:
+        """Called if any of the given ``implementation_triggers`` match the current line.
+
+        This method should return a list of ``Location`` objects.
+
+        Parameters
+        ----------
+        context:
+           The context of the implementation request.
         """
         return []
 

--- a/lib/esbonio/esbonio/lsp/testing.py
+++ b/lib/esbonio/esbonio/lsp/testing.py
@@ -16,23 +16,60 @@ from sphinx import __version__ as __sphinx_version__
 logger = logging.getLogger(__name__)
 
 
-def sphinx_version(eq: Optional[int] = None) -> bool:
+def sphinx_version(
+    eq: Optional[int] = None,
+    lt: Optional[int] = None,
+    lte: Optional[int] = None,
+    gt: Optional[int] = None,
+    gte: Optional[int] = None,
+) -> bool:
     """Helper function for determining which version of Sphinx we are
     testing with.
 
-    Currently this only cares about the major version number.
+    .. note::
+
+       Currently this function only considers the major version number.
 
     Parameters
     ----------
-    eq:
-       When set returns ``True`` if the Sphinx version exactly matches
+    eq
+       When set, this function returns ``True`` if Sphinx's version is exactly
        what's given.
+
+    gt
+       When set, this function returns ``True`` if Sphinx's version is strictly
+       greater than what's given
+
+    gte
+       When set, this function returns ``True`` if Sphinx's version is greater than
+       or equal to what's given
+
+    lt
+       When set, this function returns ``True`` if Sphinx's version is strictly
+       less than what's given
+
+    lte
+       When set, this function returns ``True`` if Sphinx's version is less than
+       or equal to what's given
+
     """
 
     major, _, _ = [int(v) for v in __sphinx_version__.split(".")]
 
-    if eq and major == eq:
-        return True
+    if eq is not None:
+        return major == eq
+
+    if gt is not None:
+        return major > gt
+
+    if gte is not None:
+        return major >= gte
+
+    if lt is not None:
+        return major < lt
+
+    if lte is not None:
+        return major <= lte
 
     return False
 

--- a/lib/esbonio/esbonio/lsp/util/inspect.py
+++ b/lib/esbonio/esbonio/lsp/util/inspect.py
@@ -1,0 +1,42 @@
+import inspect
+import logging
+import traceback
+from typing import Optional
+
+import pygls.uris as Uri
+from pygls.lsp.types import Location
+from pygls.lsp.types import Position
+from pygls.lsp.types import Range
+
+
+def get_object_location(obj: object, logger: logging.Logger) -> Optional[Location]:
+    """Given an object, attempt to find the location of its implementation.
+
+    Parameters
+    ----------
+    obj
+       The object to find the implementation of
+
+    logger
+       A logger object
+    """
+
+    try:
+        file = inspect.getsourcefile(obj)  # type: ignore
+        if file is None:
+            return None
+
+        source, line = inspect.getsourcelines(obj)  # type: ignore
+        return Location(
+            uri=Uri.from_fs_path(file),
+            range=Range(
+                start=Position(line=line - 1, character=0),
+                end=Position(line=line + len(source), character=0),
+            ),
+        )
+
+    except Exception:
+        logger.debug(
+            "Unable to get implementation location\n%s", traceback.format_exc()
+        )
+        return None


### PR DESCRIPTION
This adds `textDocument/implementation` support to the language server, in the case of roles and directives, navigating you to the Python code implementing it.