### PR TITLE
Introducing `DirectiveLanguageFeatures`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,8 +18,8 @@ repos:
   - id: flake8
     args: [--config=lib/esbonio/setup.cfg]
 
-- repo: https://github.com/asottile/reorder_python_imports
-  rev: v3.8.2
+- repo: https://github.com/pycqa/isort
+  rev: 5.10.1
   hooks:
-  - id: reorder-python-imports
-    args: [--application-directories=lib:esbonio]
+    - id: isort
+      name: isort (python)

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,6 +2,7 @@
     "recommendations": [
         "ms-python.python",
         "ms-python.black-formatter",
+        "ms-python.isort",
         "swyddfa.esbonio"
     ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,9 @@
 {
     "[python]": {
         "editor.defaultFormatter": "ms-python.black-formatter",
+        "editor.codeActionsOnSave": {
+            "source.organizeImports": true
+        },
         "editor.formatOnSave": true,
     },
     "[restructuredtext]": {
@@ -29,6 +32,10 @@
         "**/.mypy_cache": true
     },
     "esbonio.sphinx.buildDir": "${confDir}/_build",
+    "isort.args": [
+        "--settings-file",
+        "./lib/esbonio/pyproject.toml"
+    ],
     "python.defaultInterpreterPath": "${workspaceRoot}/.env/bin/python",
     "python.pythonPath": "${workspaceRoot}/.env/bin/python",
     "python.testing.pytestArgs": [

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,17 +15,16 @@ from typing import List
 sys.path.insert(0, os.path.abspath("../lib/esbonio"))
 sys.path.insert(0, os.path.abspath("./ext"))
 
-from docutils.parsers.rst import nodes
-from sphinx.application import Sphinx
-
 import pygls.lsp.methods as M
+from docutils.parsers.rst import nodes
 from pygls.lsp.types import CompletionItem
 from pygls.lsp.types import CompletionItemKind
-
-from esbonio.lsp.roles import Roles, TargetCompletion
-from esbonio.lsp.rst import CompletionContext
+from sphinx.application import Sphinx
 
 import esbonio.lsp
+from esbonio.lsp.roles import Roles
+from esbonio.lsp.roles import TargetCompletion
+from esbonio.lsp.rst import CompletionContext
 
 # -- Project information -----------------------------------------------------
 project = "Esbonio"

--- a/lib/esbonio-extensions/esbonio/relevant_to/__init__.py
+++ b/lib/esbonio-extensions/esbonio/relevant_to/__init__.py
@@ -9,7 +9,6 @@ from sphinx.util.docutils import SphinxDirective
 from sphinx.util.nodes import make_id
 from sphinx.util.nodes import nested_parse_with_titles
 
-
 __version__ = "0.2.0"
 
 

--- a/lib/esbonio-extensions/tests/conftest.py
+++ b/lib/esbonio-extensions/tests/conftest.py
@@ -3,8 +3,8 @@ from unittest import mock
 
 import py.test
 from docutils.io import StringInput
-from docutils.parsers.rst import directives
 from docutils.parsers.rst import Parser
+from docutils.parsers.rst import directives
 from docutils.readers.standalone import Reader
 from sphinx.ext.doctest import DoctestDirective
 

--- a/lib/esbonio/changes/443.api.rst
+++ b/lib/esbonio/changes/443.api.rst
@@ -1,0 +1,1 @@
+Added ``add_diagnostics`` method to the ``RstLanguageServer`` to enable adding diagnostics to a document incrementally.

--- a/lib/esbonio/changes/444.api.rst
+++ b/lib/esbonio/changes/444.api.rst
@@ -1,0 +1,2 @@
+The ``Directives`` language feature can now be extended by registering ``DirectiveLanguageFeatures`` using the new ``add_feature`` method.
+This is now the preferred extension mechanism and should be used by all extensions going forward.

--- a/lib/esbonio/changes/444.deprecated.rst
+++ b/lib/esbonio/changes/444.deprecated.rst
@@ -1,0 +1,1 @@
+``ArgumentCompletion``, ``ArgumentDefinition`` and ``ArgumentLink`` directive providers have been deprecated in favour of ``DirectiveLanguageFeatures`` and will be removed in ``v1.0``

--- a/lib/esbonio/esbonio/lsp/log.py
+++ b/lib/esbonio/esbonio/lsp/log.py
@@ -10,8 +10,8 @@ from pygls.lsp.types import Position
 from pygls.lsp.types import Range
 
 if typing.TYPE_CHECKING:
-    from .rst import ServerConfig
     from .rst import RstLanguageServer
+    from .rst import ServerConfig
 
 
 LOG_NAMESPACE = "esbonio.lsp"

--- a/lib/esbonio/esbonio/lsp/rst/__init__.py
+++ b/lib/esbonio/esbonio/lsp/rst/__init__.py
@@ -41,10 +41,10 @@ from pygls.lsp.types import Position
 from pygls.server import LanguageServer
 from pygls.workspace import Document
 
-from .io import read_initial_doctree
 from esbonio.cli import setup_cli
 from esbonio.lsp.log import setup_logging
 
+from .io import read_initial_doctree
 
 LF = TypeVar("LF", bound="LanguageFeature")
 TRIPLE_QUOTE = re.compile("(\"\"\"|''')")

--- a/lib/esbonio/esbonio/lsp/rst/io.py
+++ b/lib/esbonio/esbonio/lsp/rst/io.py
@@ -1,8 +1,8 @@
 import logging
 import typing
+from typing import IO
 from typing import Any
 from typing import Callable
-from typing import IO
 from typing import Optional
 from typing import Type
 
@@ -12,8 +12,8 @@ from docutils.core import Publisher
 from docutils.io import NullOutput
 from docutils.io import StringInput
 from docutils.parsers.rst import Directive
-from docutils.parsers.rst import directives
 from docutils.parsers.rst import Parser
+from docutils.parsers.rst import directives
 from docutils.parsers.rst import roles
 from docutils.readers.standalone import Reader
 from docutils.utils import Reporter

--- a/lib/esbonio/esbonio/lsp/spelling.py
+++ b/lib/esbonio/esbonio/lsp/spelling.py
@@ -21,7 +21,6 @@ from spellchecker import SpellChecker  # type: ignore
 from esbonio.lsp.rst import LanguageFeature
 from esbonio.lsp.sphinx import SphinxLanguageServer
 
-
 IGNORED_NODES = {nodes.raw, nodes.literal, nodes.literal_block}
 """Don't spell check Text contained in any of these nodes."""
 

--- a/lib/esbonio/esbonio/lsp/sphinx/__init__.py
+++ b/lib/esbonio/esbonio/lsp/sphinx/__init__.py
@@ -7,9 +7,9 @@ import typing
 from functools import partial
 from multiprocessing import Process
 from multiprocessing import Queue
+from typing import IO
 from typing import Any
 from typing import Dict
-from typing import IO
 from typing import Iterator
 from typing import List
 from typing import Optional

--- a/lib/esbonio/esbonio/lsp/sphinx/__main__.py
+++ b/lib/esbonio/esbonio/lsp/sphinx/__main__.py
@@ -3,5 +3,4 @@ import sys
 from esbonio.cli import main
 from esbonio.lsp.sphinx import cli
 
-
 sys.exit(main(cli))

--- a/lib/esbonio/esbonio/lsp/sphinx/config.py
+++ b/lib/esbonio/esbonio/lsp/sphinx/config.py
@@ -35,7 +35,6 @@ from esbonio.lsp.log import LOG_NAMESPACE
 from esbonio.lsp.log import LspHandler
 from esbonio.lsp.rst import ServerConfig
 
-
 PATH_VAR_PATTERN = re.compile(r"^\${(\w+)}/?.*")
 logger = logging.getLogger(LOG_NAMESPACE)
 

--- a/lib/esbonio/esbonio/lsp/sphinx/domains.py
+++ b/lib/esbonio/esbonio/lsp/sphinx/domains.py
@@ -21,7 +21,6 @@ from esbonio.lsp.rst import DefinitionContext
 from esbonio.lsp.rst import DocumentLinkContext
 from esbonio.lsp.sphinx import SphinxLanguageServer
 
-
 TARGET_KINDS = {
     "attribute": CompletionItemKind.Field,
     "doc": CompletionItemKind.File,

--- a/lib/esbonio/esbonio/lsp/util/patterns.py
+++ b/lib/esbonio/esbonio/lsp/util/patterns.py
@@ -1,6 +1,5 @@
 import re
 
-
 DIRECTIVE = re.compile(
     r"""
     (\s*)                             # directives can be indented

--- a/lib/esbonio/pyproject.toml
+++ b/lib/esbonio/pyproject.toml
@@ -2,6 +2,11 @@
 requires = ["setuptools >= 35.0.2", "wheel >= 0.29.0"]
 build-backend = "setuptools.build_meta"
 
+[tool.isort]
+force_single_line = true
+known_first_party = ["esbonio"]
+profile = "black"
+
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 filterwarnings = [

--- a/lib/esbonio/tests/sphinx-default/conftest.py
+++ b/lib/esbonio/tests/sphinx-default/conftest.py
@@ -13,7 +13,6 @@ from esbonio.lsp.sphinx import InitializationOptions
 from esbonio.lsp.sphinx import SphinxServerConfig
 from esbonio.lsp.testing import make_esbonio_client
 
-
 root_path = pathlib.Path(__file__).parent / "workspace"
 
 SERVER_CMD = ["-m", "esbonio"]

--- a/lib/esbonio/tests/sphinx-default/test_sd_directives.py
+++ b/lib/esbonio/tests/sphinx-default/test_sd_directives.py
@@ -7,8 +7,8 @@ import pytest
 from pygls.lsp.types import MarkupKind
 from pygls.lsp.types import Position
 from pygls.lsp.types import Range
-from pytest_lsp import check
 from pytest_lsp import Client
+from pytest_lsp import check
 
 from esbonio.lsp.testing import completion_request
 from esbonio.lsp.testing import hover_request

--- a/lib/esbonio/tests/sphinx-default/test_sd_roles.py
+++ b/lib/esbonio/tests/sphinx-default/test_sd_roles.py
@@ -8,14 +8,13 @@ from typing import Tuple
 import pytest
 from pygls.lsp.types import Position
 from pygls.lsp.types import Range
-from pytest_lsp import check
 from pytest_lsp import Client
+from pytest_lsp import check
 
 from esbonio.lsp.testing import completion_request
 from esbonio.lsp.testing import hover_request
 from esbonio.lsp.testing import role_patterns
 from esbonio.lsp.testing import sphinx_version
-
 
 C_EXPECTED = {"c:func", "c:macro"}
 C_UNEXPECTED = {"py:func", "py:mod"}

--- a/lib/esbonio/tests/sphinx-default/test_sd_sphinx.py
+++ b/lib/esbonio/tests/sphinx-default/test_sd_sphinx.py
@@ -13,9 +13,9 @@ from pygls.lsp.types import DocumentLink
 from pygls.lsp.types import MessageType
 from pygls.lsp.types import Position
 from pygls.lsp.types import Range
-from pytest_lsp import check
 from pytest_lsp import Client
 from pytest_lsp import ClientServerConfig
+from pytest_lsp import check
 from pytest_lsp import make_client_server
 from pytest_lsp import make_test_client
 

--- a/lib/esbonio/tests/sphinx-default/test_sd_sphinx_codeblocks.py
+++ b/lib/esbonio/tests/sphinx-default/test_sd_sphinx_codeblocks.py
@@ -1,12 +1,11 @@
 import itertools
 
 import pytest
-from pytest_lsp import check
 from pytest_lsp import Client
+from pytest_lsp import check
 
 from esbonio.lsp.testing import completion_request
 from esbonio.lsp.testing import directive_argument_patterns
-
 
 ROOT_FILES = {
     "_static",

--- a/lib/esbonio/tests/sphinx-default/test_sd_sphinx_domains.py
+++ b/lib/esbonio/tests/sphinx-default/test_sd_sphinx_domains.py
@@ -4,8 +4,8 @@ import pytest
 from pygls.lsp.types import Location
 from pygls.lsp.types import Position
 from pygls.lsp.types import Range
-from pytest_lsp import check
 from pytest_lsp import Client
+from pytest_lsp import check
 
 from esbonio.lsp.testing import completion_request
 from esbonio.lsp.testing import intersphinx_target_patterns

--- a/lib/esbonio/tests/sphinx-default/test_sd_sphinx_images.py
+++ b/lib/esbonio/tests/sphinx-default/test_sd_sphinx_images.py
@@ -1,12 +1,11 @@
 import itertools
 
 import pytest
-from pytest_lsp import check
 from pytest_lsp import Client
+from pytest_lsp import check
 
 from esbonio.lsp.testing import completion_request
 from esbonio.lsp.testing import directive_argument_patterns
-
 
 ROOT_FILES = {
     "_static",

--- a/lib/esbonio/tests/sphinx-default/test_sd_sphinx_includes.py
+++ b/lib/esbonio/tests/sphinx-default/test_sd_sphinx_includes.py
@@ -4,12 +4,11 @@ import pytest
 from pygls.lsp.types import Location
 from pygls.lsp.types import Position
 from pygls.lsp.types import Range
-from pytest_lsp import check
 from pytest_lsp import Client
+from pytest_lsp import check
 
 from esbonio.lsp.testing import completion_request
 from esbonio.lsp.testing import directive_argument_patterns
-
 
 ROOT_FILES = {
     "_static",

--- a/lib/esbonio/tests/sphinx-default/test_sd_sphinx_roles.py
+++ b/lib/esbonio/tests/sphinx-default/test_sd_sphinx_roles.py
@@ -1,8 +1,8 @@
 import itertools
 
 import pytest
-from pytest_lsp import check
 from pytest_lsp import Client
+from pytest_lsp import check
 
 from esbonio.lsp.testing import completion_request
 from esbonio.lsp.testing import role_target_patterns

--- a/lib/esbonio/tests/sphinx-extensions/test_se_directives.py
+++ b/lib/esbonio/tests/sphinx-extensions/test_se_directives.py
@@ -3,8 +3,8 @@ from typing import Set
 
 import pytest
 from pygls.lsp.types import MarkupKind
-from pytest_lsp import check
 from pytest_lsp import Client
+from pytest_lsp import check
 
 from esbonio.lsp.testing import completion_request
 

--- a/lib/esbonio/tests/sphinx-extensions/test_se_roles.py
+++ b/lib/esbonio/tests/sphinx-extensions/test_se_roles.py
@@ -4,12 +4,11 @@ from typing import Set
 from typing import Tuple
 
 import pytest
-from pytest_lsp import check
 from pytest_lsp import Client
+from pytest_lsp import check
 
 from esbonio.lsp.testing import completion_request
 from esbonio.lsp.testing import role_patterns
-
 
 EXPECTED = {"doc", "py:func", "py:mod", "ref", "func"}
 UNEXPECTED = {"c:func", "c:macro", "restructuredtext-unimplemented-role"}

--- a/lib/esbonio/tests/sphinx-extensions/test_se_sphinx.py
+++ b/lib/esbonio/tests/sphinx-extensions/test_se_sphinx.py
@@ -7,8 +7,8 @@ from pygls.lsp.types import DiagnosticSeverity
 from pygls.lsp.types import DocumentLink
 from pygls.lsp.types import Position
 from pygls.lsp.types import Range
-from pytest_lsp import check
 from pytest_lsp import Client
+from pytest_lsp import check
 
 
 @pytest.mark.asyncio

--- a/lib/esbonio/tests/sphinx-extensions/test_se_sphinx_codeblocks.py
+++ b/lib/esbonio/tests/sphinx-extensions/test_se_sphinx_codeblocks.py
@@ -1,8 +1,8 @@
 import itertools
 
 import pytest
-from pytest_lsp import check
 from pytest_lsp import Client
+from pytest_lsp import check
 
 from esbonio.lsp.testing import completion_request
 from esbonio.lsp.testing import directive_argument_patterns

--- a/lib/esbonio/tests/sphinx-extensions/test_se_sphinx_domains.py
+++ b/lib/esbonio/tests/sphinx-extensions/test_se_sphinx_domains.py
@@ -1,8 +1,8 @@
 import itertools
 
 import pytest
-from pytest_lsp import check
 from pytest_lsp import Client
+from pytest_lsp import check
 
 from esbonio.lsp.testing import completion_request
 from esbonio.lsp.testing import intersphinx_target_patterns

--- a/lib/esbonio/tests/sphinx-extensions/test_se_sphinx_roles.py
+++ b/lib/esbonio/tests/sphinx-extensions/test_se_sphinx_roles.py
@@ -1,8 +1,8 @@
 import itertools
 
 import pytest
-from pytest_lsp import check
 from pytest_lsp import Client
+from pytest_lsp import check
 
 from esbonio.lsp.testing import completion_request
 from esbonio.lsp.testing import role_target_patterns

--- a/lib/esbonio/tests/sphinx-extensions/workspace/sphinx-extensions/conf.py
+++ b/lib/esbonio/tests/sphinx-extensions/workspace/sphinx-extensions/conf.py
@@ -15,7 +15,6 @@ sys.path.insert(0, os.path.abspath("../code"))
 # -- Project information -----------------------------------------------------
 from sphinx.directives.code import CodeBlock
 
-
 project = "Defaults"
 copyright = "2020, Sphinx"
 author = "Sphinx"

--- a/lib/esbonio/tests/unit_tests/test_rst.py
+++ b/lib/esbonio/tests/unit_tests/test_rst.py
@@ -1,8 +1,8 @@
 import pytest
 
 from esbonio.lsp.roles import Roles
-from esbonio.lsp.rst import _get_setup_arguments
 from esbonio.lsp.rst import RstLanguageServer
+from esbonio.lsp.rst import _get_setup_arguments
 from esbonio.lsp.sphinx import SphinxLanguageServer
 
 

--- a/scripts/generate_docutils_documentation.py
+++ b/scripts/generate_docutils_documentation.py
@@ -17,7 +17,6 @@ from docutils.parsers.rst import roles
 from docutils.utils import new_document
 from docutils.writers import Writer
 
-
 logger = logging.getLogger(__name__)
 
 


### PR DESCRIPTION
The `Directives` language feature should now be extended by registering
`DirectiveLanguageFeatures`.

The existing `ArgumentCompletion`, `ArgumentDefinition` and
`ArgumentLink` extension points have been deprecated and will be removed
in ``v1.0``