### PR TITLE
Fix handling of substitutions in `textDocument/documentSymbol` requests

### DIFF
--- a/lib/esbonio/changes/448.fix.rst
+++ b/lib/esbonio/changes/448.fix.rst
@@ -1,0 +1,1 @@
+``textDocument/documentSymbol`` requests should no longer fail on substitution definitions.

--- a/lib/esbonio/esbonio/lsp/util/patterns.py
+++ b/lib/esbonio/esbonio/lsp/util/patterns.py
@@ -7,6 +7,10 @@ DIRECTIVE = re.compile(
     (?P<directive>
       \.\.                            # directives start with a comment
       [ ]?                            # followed by a space
+      (?P<substitution>\|             # this could be a substitution definition
+        (?P<substitution_text>[^|]+)?
+      \|?)?
+      [ ]?
       ((?P<domain>[\w]+):(?!:))?      # directives may include a domain
       (?P<name>([\w-]|:(?!:))+)?      # directives have a name
       (::)?                           # directives end with '::'

--- a/lib/esbonio/tests/sphinx-default/workspace/theorems/pythagoras.rst
+++ b/lib/esbonio/tests/sphinx-default/workspace/theorems/pythagoras.rst
@@ -68,3 +68,5 @@ length of a missing side of a right angled triangle when the other two are known
    :param float b: The length of the side labelled ``b``
    :return: Then length of the side ``a``
    :rtype: float
+
+.. |rhs| replace:: right hand side

--- a/lib/esbonio/tests/unit_tests/test_directives.py
+++ b/lib/esbonio/tests/unit_tests/test_directives.py
@@ -1,10 +1,10 @@
-import py.test
+import pytest
 
 from esbonio.lsp.directives import DIRECTIVE
 from esbonio.lsp.directives import DIRECTIVE_OPTION
 
 
-@py.test.mark.parametrize(
+@pytest.mark.parametrize(
     "string, expected",
     [
         (".", None),
@@ -12,6 +12,46 @@ from esbonio.lsp.directives import DIRECTIVE_OPTION
         (".. d", {"directive": ".. d"}),
         (".. image::", {"name": "image", "directive": ".. image::"}),
         (".. c:", {"domain": "c", "directive": ".. c:"}),
+        (".. |", {"directive": ".. |", "substitution": "|"}),
+        (
+            ".. |e",
+            {"directive": ".. |e", "substitution": "|e", "substitution_text": "e"},
+        ),
+        (
+            ".. |example",
+            {
+                "directive": ".. |example",
+                "substitution": "|example",
+                "substitution_text": "example",
+            },
+        ),
+        (
+            ".. |example|",
+            {
+                "directive": ".. |example|",
+                "substitution": "|example|",
+                "substitution_text": "example",
+            },
+        ),
+        (
+            ".. |example| replace::",
+            {
+                "directive": ".. |example| replace::",
+                "substitution": "|example|",
+                "substitution_text": "example",
+                "name": "replace",
+            },
+        ),
+        (
+            ".. |example| replace:: some text here",
+            {
+                "directive": ".. |example| replace::",
+                "substitution": "|example|",
+                "substitution_text": "example",
+                "name": "replace",
+                "argument": "some text here",
+            },
+        ),
         (
             ".. c:function::",
             {"name": "function", "domain": "c", "directive": ".. c:function::"},
@@ -105,10 +145,10 @@ def test_directive_regex(string, expected):
         assert match is not None
 
         for name, value in expected.items():
-            assert match.groupdict().get(name, None) == value
+            assert match.groupdict().get(name, None) == value, name
 
 
-@py.test.mark.parametrize(
+@pytest.mark.parametrize(
     "string, expected",
     [
         (":", None),


### PR DESCRIPTION
Closes #448  