### PR TITLE
Refactoring directives support

### DIFF
--- a/docs/lsp/extending.rst
+++ b/docs/lsp/extending.rst
@@ -7,9 +7,10 @@ In order to support the extensible nature of reStructuredText and Sphinx, Esboni
 This section of the documentation outlines the server's architecture and how you can write your own extensions.
 
 .. toctree::
-   :hidden:
+   :maxdepth: 1
 
-   api-reference
+   extending/directives
+   extending/api-reference
 
 .. _lsp_architecture:
 
@@ -58,19 +59,6 @@ Architecture
       Ordinary Python modules are used to group related functionality together.
       Taking inspiration from how Sphinx is architected, language servers are assembled by passing the list of modules to load to the :func:`~esbonio.lsp.create_language_server`.
       This assembly process calls any functions with the name ``esbonio_setup`` allowing for ``LanguageFeatures`` to be configured and loaded into the server.
-
-      Here is an example of such a setup function.
-
-      .. literalinclude:: ../../lib/esbonio/esbonio/lsp/directives.py
-         :language: python
-         :start-at: def esbonio_setup
-
-   Provider
-      Being a Python class ``LanguageFeatures`` can do whatever you like.
-
-      However, a pattern commonly used in Esbonio is allowing multiple "providers" to be registered with a ``LanguageFeature``, extending its functionality in some way.
-      The API that a provider must implement varies and is defined by the language feature that uses it. An example of such a provider it the :class:`~esbonio.lsp.directives.ArgumentCompletion`
-      provider which allows extensions to provide completion suggestions for directive arguments.
 
    Startup Module
       As mentioned above, language servers are assembled and this is done inside a startup module.

--- a/docs/lsp/extending/api-reference.rst
+++ b/docs/lsp/extending/api-reference.rst
@@ -60,28 +60,6 @@ Language Features
 .. autoclass:: esbonio.lsp.DocumentLinkContext
    :members:
 
-Directives
-^^^^^^^^^^
-
-.. currentmodule:: esbonio.lsp.directives
-
-.. autodata:: DIRECTIVE
-   :annotation: = re.compile(...)
-
-.. autodata:: DIRECTIVE_OPTION
-   :annotation: = re.compile(...)
-
-.. autoclass:: ArgumentCompletion
-   :members:
-
-.. autoclass:: ArgumentDefinition
-   :members:
-
-.. autoclass:: ArgumentLink
-   :members:
-
-.. autoclass:: Directives
-   :members: add_argument_completion_provider, add_argument_definition_provider, add_argument_link_provider, add_documentation
 
 Roles
 ^^^^^

--- a/docs/lsp/extending/directives.rst
+++ b/docs/lsp/extending/directives.rst
@@ -1,0 +1,47 @@
+Directives
+==========
+
+How To Guides
+-------------
+
+The following guides outline how to extend the language server to add support for your custom directives.
+
+.. toctree::
+   :glob:
+   :maxdepth: 1
+
+   directives/*
+
+API Reference
+-------------
+
+.. currentmodule:: esbonio.lsp.directives
+
+.. autoclass:: Directives
+   :members: add_argument_completion_provider,
+             add_argument_definition_provider,
+             add_argument_link_provider,
+             add_documentation,
+             add_feature,
+             get_directives,
+             get_implementation,
+             suggest_directives,
+             suggest_options
+
+.. autoclass:: DirectiveLanguageFeature
+   :members:
+
+.. autodata:: esbonio.lsp.util.patterns.DIRECTIVE
+   :no-value:
+
+.. autodata:: esbonio.lsp.util.patterns.DIRECTIVE_OPTION
+   :no-value:
+
+.. autoclass:: ArgumentCompletion
+   :members:
+
+.. autoclass:: ArgumentDefinition
+   :members:
+
+.. autoclass:: ArgumentLink
+   :members:

--- a/docs/lsp/extending/directives/directive-registry.rst
+++ b/docs/lsp/extending/directives/directive-registry.rst
@@ -1,0 +1,121 @@
+Supporting Custom Directive Registries
+======================================
+
+.. currentmodule:: esbonio.lsp.directives
+
+This guide walks through the process of teaching the language server how to discover directives stored in a custom registry.
+Once complete, the following LSP features should start working with your directives.
+
+- Basic directive completions i.e. ``.. directive-name::`` but no argument or option completions.
+- Documentation hovers (assuming you've provided documentation)
+- Goto Implementation
+
+.. note::
+
+   You may not need this guide.
+
+   If you're registering your directive directly with
+   `docutils <https://docutils.sourceforge.io/docs/howto/rst-directives.html#toc-entry-4>`__ or
+   `sphinx <https://www.sphinx-doc.org/en/master/extdev/appapi.html#sphinx.application.Sphinx.add_directive>`__,
+   or using a `custom domain <https://www.sphinx-doc.org/en/master/extdev/domainapi.html>`__
+   then you should find that the language server already has basic support for your custom directives out of the box.
+
+   This guide is indended for tools that maintain their own set of directives in a separate store to the standard locations.
+
+Still here? Great! Let's get started
+
+Indexing Directives
+-------------------
+
+As an example, we'll walk through the steps required to add (basic) support for Sphinx domains to the language server.
+
+.. note::
+
+   For the sake of brevity, some details have been omitted from the code examples below.
+
+   If you're interested, you can find the actual implementation of the ``DomainDirectives`` class
+   `here <https://github.com/swyddfa/esbonio/blob/release/lib/esbonio/esbonio/lsp/sphinx/domains.py>`__.
+
+So that the server can discover the available directives, we have to provide a :class:`DirectiveLanguageFeature` that implements the :meth:`~DirectiveLanguageFeature.index_directives` method.
+This method should return a dictionary where the keys are the canonical name of a directive which map to the class that implements it::
+
+   class DomainDirectives(DirectiveLanguageFeature):
+       def __init__(self, app: Sphinx):
+           self.app = app  # Sphinx application instance.
+
+       def index_directives(self) -> Dict[str, Directive]:
+           directives = {}
+           for prefix, domain in self.app.domains.items():
+               for name, directive in domain.directives.items():
+                   directives[f"{prefix}:{name}"] = directive
+
+           return directives
+
+In the case of Sphinx domains a directive's canonical name is of the form ``<domain>:<directive>`` e.g. ``py:function`` or ``c:macro``.
+
+This is the bare minimum required to make the language server aware of your custom directives, in fact if you were to try the above implementation you would already find completions being offered for domain based directives.
+However, you would also notice that the short form of directives (e.g. ``function``) in the :ref:`standard <sphinx:domains-std>` and :confval:`primary <sphinx:primary_domain>` domains are not included in the list of completions - despite being valid.
+
+To remedy this, you might be tempted to start adding multiple entries to the dictionary, one for each valid name **do not do this.**
+Instead you can implement the :meth:`~DirectiveLanguageFeature.suggest_directives` method which solves this exact use case.
+
+.. tip::
+
+   If you do want to play around with your own version of the ``DomainDirectives`` class you can disable the built in version by:
+
+   - Passing the ``--exclude esbonio.lsp.sphinx.domains`` cli option, or
+   - If you're using VSCode adding ``esbonio.lsp.sphinx.domains`` to the :confval:`esbonio.server.excludedModules (string[])` option.
+
+(Optional) Suggesting Directives
+--------------------------------
+
+The :meth:`~DirectiveLanguageFeature.suggest_directives` method is called each time the server is generating directive completions.
+It can be used to tailor the list of directives that are offered to the user, depending on the current context.
+Each ``DirectiveLanguageFeature`` has a default implementation, which may be sufficient depending on your use case::
+
+   def suggest_directives(self, context: CompletionContext) -> Iterable[Tuple[str, Directive]]:
+       return self.index_directives().items()
+
+However, in the case of Sphinx domains, we need to modify this to also include the short form of the directives in the standard and primary domains::
+
+   def suggest_directives(self, context: CompletionContext) -> Iterable[Tuple[str, Directive]]:
+       directives = self.index_directives()
+       primary_domain = self.app.config.primary_domain
+
+       for key, directive in directives.items():
+
+           if key.startswith("std:"):
+               directives[key.replace("std:", "")] = directive
+
+            if primary_domain and key.startswith(f"{primary_domain}:"):
+               directives[key.replace(f"{primary_domain}:", "")] = directive
+
+        return directives.items()
+
+Now if you were to try this version, the short forms of the relevant directives would be offered as completion suggestions, but you would notice features like documentation hovers still don't work.
+This is due to the language server not knowing which class implements these short form directives.
+
+(Optional) Implementation Lookups
+---------------------------------
+
+The :meth:`~DirectiveLanguageFeature.get_implementation` method is used by the language server to take a directive's name and lookup its implementation.
+This powers features such as documentation hovers and goto implementation.
+As with ``suggest_directives``, each ``DirectiveLanguageFeature`` has a default implementation which may be sufficient for your use case::
+
+   def get_implementation(self, directive: str, domain: Optional[str]) -> Optional[Directive]:
+       return self.index_directives().get(directive, None)
+
+In the case of Sphinx domains, if we see a directive without a domain prefix we need to see if it belongs to the standard or primary domains::
+
+   def get_implementation(self, directive: str, domain: Optional[str]) -> Optional[Directive]:
+       directives = self.index_directives()
+
+       if domain is not None:
+           return directives.get(f"{domain}:{directive}", None)
+
+       primary_domain = self.app.config.primary_domain
+       impl = directives.get(f"{primary_domain}:{directive}", None)
+       if impl is not None:
+           return impl
+
+       return directives.get(f"std:{directive}", None)

--- a/lib/esbonio/changes/453.api.rst
+++ b/lib/esbonio/changes/453.api.rst
@@ -1,0 +1,6 @@
+``DirectiveLanguageFeatures`` can now implement the following methods.
+
+- ``index_directives``: used to discover available directive implementations
+- ``suggest_directives``: used to determine which directive names can be suggested in the current completion context (``function`` vs ``py:function`` vs ``c:function`` etc.)
+- ``get_implementation``: used to go from a directive name (``function`` vs ``py:function``) to its implementation
+- ``suggest_options``: used to determine which directive options can be suggested in the current completion context

--- a/lib/esbonio/changes/453.deprecated.rst
+++ b/lib/esbonio/changes/453.deprecated.rst
@@ -1,0 +1,4 @@
+Calling the ``get_directives()`` method on the ``RstLanguageServer`` and ``SphinxLanguageServer`` objects is deprecated in favour of calling the ``get_directives()`` method on the ``Directives`` language feature.
+It will be removed in ``v1.0``
+
+Calling the ``get_directive_options()`` method on the ``RstLanguageServer`` and ``SphinxLanguageServer`` objects deprecated and will be removed in ``v1.0``.

--- a/lib/esbonio/esbonio/lsp/directives.py
+++ b/lib/esbonio/esbonio/lsp/directives.py
@@ -856,14 +856,15 @@ class Directives(LanguageFeature):
         self, context: ImplementationContext, name: str, domain: Optional[str]
     ) -> List[Location]:
 
-        directives = self.rst.get_directives()
-        key = f"{domain}:{name}" if domain is not None else name
-
-        impl = directives.get(key, None)
+        impl = self.get_implementation(name, domain)
         if impl is None:
             return []
 
-        self.logger.debug("Getting implementation of '%s' (%s)", key, impl)
+        self.logger.debug(
+            "Getting implementation of '%s' (%s)",
+            f"{domain}:{name}" if domain else name,
+            impl,
+        )
         location = get_object_location(impl, self.logger)
         if location is None:
             return []

--- a/lib/esbonio/esbonio/lsp/directives.py
+++ b/lib/esbonio/esbonio/lsp/directives.py
@@ -126,7 +126,7 @@ class DirectiveLanguageFeature:
 class ArgumentCompletion(Protocol):
     """A completion provider for directive arguments.
 
-    .. deprecated:: xxxx
+    .. deprecated:: 0.14.2
 
        This will be removed in ``v1.0``, use subclasses of
        :class:`~esbonio.lsp.directives.DirectiveLanguageFeature` instead.
@@ -152,7 +152,7 @@ class ArgumentCompletion(Protocol):
 class ArgumentDefinition(Protocol):
     """A definition provider for directive arguments.
 
-    .. deprecated:: xxxx
+    .. deprecated:: 0.14.2
 
        This will be removed in ``v1.0``, use subclasses of
        :class:`~esbonio.lsp.directives.DirectiveLanguageFeature` instead.
@@ -183,7 +183,7 @@ class ArgumentDefinition(Protocol):
 class ArgumentLink(Protocol):
     """A document link resolver for directive arguments.
 
-    .. deprecated:: xxxx
+    .. deprecated:: 0.14.2
 
        This will be removed in ``v1.0``, use subclasses of
        :class:`~esbonio.lsp.directives.DirectiveLanguageFeature` instead.
@@ -242,7 +242,7 @@ class Directives(LanguageFeature):
     def add_argument_completion_provider(self, provider: ArgumentCompletion) -> None:
         """Register an :class:`~esbonio.lsp.directives.ArgumentCompletion` provider.
 
-        .. deprecated:: xxxx
+        .. deprecated:: 0.14.2
 
            This will be removed in ``v1.0``, use
            :meth:`~esbonio.lsp.directives.Directives.add_feature` with a
@@ -275,7 +275,7 @@ class Directives(LanguageFeature):
     def add_argument_definition_provider(self, provider: ArgumentDefinition) -> None:
         """Register an :class:`~esbonio.lsp.directives.ArgumentDefinition` provider.
 
-        .. deprecated:: xxxx
+        .. deprecated:: 0.14.2
 
            This will be removed in ``v1.0``, use
            :meth:`~esbonio.lsp.directives.Directives.add_feature` with a
@@ -308,7 +308,7 @@ class Directives(LanguageFeature):
     def add_argument_link_provider(self, provider: ArgumentLink) -> None:
         """Register an :class:`~esbonio.lsp.directives.ArgumentLink` provider.
 
-        .. deprecated:: xxxx
+        .. deprecated:: 0.14.2
 
            This will be removed in ``v1.0``, use
            :meth:`~esbonio.lsp.directives.Directives.add_feature` with a

--- a/lib/esbonio/esbonio/lsp/directives.py
+++ b/lib/esbonio/esbonio/lsp/directives.py
@@ -245,8 +245,8 @@ class Directives(LanguageFeature):
         .. deprecated:: xxxx
 
            This will be removed in ``v1.0``, use
-           :meth:`esbonio.lsp.directives.Directives.add_feature` with a
-           :class:`esbonio.lsp.directives.DirectiveLanguageFeature` subclass instead.
+           :meth:`~esbonio.lsp.directives.Directives.add_feature` with a
+           :class:`~esbonio.lsp.directives.DirectiveLanguageFeature` subclass instead.
 
         Parameters
         ----------

--- a/lib/esbonio/esbonio/lsp/rst/__init__.py
+++ b/lib/esbonio/esbonio/lsp/rst/__init__.py
@@ -17,7 +17,6 @@ from typing import Type
 from typing import TypeVar
 from typing import Union
 
-import docutils.parsers.rst.directives as docutils_directives
 import docutils.parsers.rst.roles as docutils_roles
 import pygls.uris as Uri
 from docutils.parsers.rst import Directive
@@ -596,22 +595,20 @@ class RstLanguageServer(LanguageServer):
     def get_directives(self) -> Dict[str, Directive]:
         """Return a dictionary of the known directives"""
 
-        if self._directives is not None:
-            return self._directives
+        clsname = self.__class__.__name__
+        warnings.warn(
+            f"{clsname}.get_directives() is deprecated and will be removed in v1.0."
+            " Instead call the get_directives() method on the Directives language "
+            "feature.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
 
-        ignored_directives = ["restructuredtext-test-directive"]
-        found_directives = {
-            **docutils_directives._directive_registry,
-            **docutils_directives._directives,
-        }
+        feature = self.get_feature("esbonio.lsp.directives.Directives")
+        if feature is None:
+            return {}
 
-        self._directives = {
-            k: resolve_directive(v)
-            for k, v in found_directives.items()
-            if k not in ignored_directives
-        }
-
-        return self._directives
+        return feature.get_directives()  # type: ignore
 
     def get_directive_options(self, name: str) -> Dict[str, Any]:
         """Return the options specification for the given directive."""

--- a/lib/esbonio/esbonio/lsp/rst/__init__.py
+++ b/lib/esbonio/esbonio/lsp/rst/__init__.py
@@ -613,6 +613,14 @@ class RstLanguageServer(LanguageServer):
     def get_directive_options(self, name: str) -> Dict[str, Any]:
         """Return the options specification for the given directive."""
 
+        clsname = self.__class__.__name__
+        warnings.warn(
+            f"{clsname}.get_directive_options() is deprecated and will be removed in "
+            "v1.0.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
         directive = self.get_directives().get(name, None)
         if directive is None:
             return {}

--- a/lib/esbonio/esbonio/lsp/rst/__init__.py
+++ b/lib/esbonio/esbonio/lsp/rst/__init__.py
@@ -1,5 +1,4 @@
 import collections
-import importlib
 import inspect
 import logging
 import pathlib
@@ -15,7 +14,6 @@ from typing import Optional
 from typing import Tuple
 from typing import Type
 from typing import TypeVar
-from typing import Union
 
 import docutils.parsers.rst.roles as docutils_roles
 import pygls.uris as Uri
@@ -810,23 +808,6 @@ class RstLanguageServer(LanguageServer):
         """
         idx = doc.offset_at_position(position)
         return doc.source[:idx]
-
-
-def resolve_directive(directive: Union[Directive, Tuple[str, str]]) -> Directive:
-    """Return the directive based on the given reference.
-
-    'Core' docutils directives are returned as tuples ``(modulename, ClassName)``
-    so they need to be resolved manually.
-    """
-
-    if isinstance(directive, tuple):
-        mod, cls = directive
-
-        modulename = "docutils.parsers.rst.directives.{}".format(mod)
-        module = importlib.import_module(modulename)
-        return getattr(module, cls)
-
-    return directive
 
 
 def normalise_uri(uri: str) -> str:

--- a/lib/esbonio/esbonio/lsp/rst/__init__.py
+++ b/lib/esbonio/esbonio/lsp/rst/__init__.py
@@ -591,7 +591,14 @@ class RstLanguageServer(LanguageServer):
             return None
 
     def get_directives(self) -> Dict[str, Directive]:
-        """Return a dictionary of the known directives"""
+        """Return a dictionary of the known directives
+
+        .. deprecated:: 0.14.2
+
+           This will be removed in ``v1.0``.
+           Use the :meth:`~esbonio.lsp.directives.Directives.get_directives` method
+           instead.
+        """
 
         clsname = self.__class__.__name__
         warnings.warn(
@@ -609,7 +616,12 @@ class RstLanguageServer(LanguageServer):
         return feature.get_directives()  # type: ignore
 
     def get_directive_options(self, name: str) -> Dict[str, Any]:
-        """Return the options specification for the given directive."""
+        """Return the options specification for the given directive.
+
+        .. deprecated:: 0.14.2
+
+           This will be removed in ``v1.0``
+        """
 
         clsname = self.__class__.__name__
         warnings.warn(

--- a/lib/esbonio/esbonio/lsp/rst/directives.py
+++ b/lib/esbonio/esbonio/lsp/rst/directives.py
@@ -1,11 +1,87 @@
+import importlib
 import json
+from typing import Dict
+from typing import Iterable
+from typing import Optional
+from typing import Tuple
+from typing import Union
 
 import pkg_resources
+from docutils.parsers.rst import Directive
+from docutils.parsers.rst import directives as docutils_directives
 
+from esbonio.lsp import CompletionContext
+from esbonio.lsp.directives import DirectiveLanguageFeature
 from esbonio.lsp.directives import Directives
-from esbonio.lsp.rst import RstLanguageServer
 
 
-def esbonio_setup(rst: RstLanguageServer, directives: Directives):
-    docutils_docs = pkg_resources.resource_string("esbonio.lsp.rst", "directives.json")
-    directives.add_documentation(json.loads(docutils_docs.decode("utf8")))
+class Docutils(DirectiveLanguageFeature):
+    """Support for docutils' built-in directives."""
+
+    def __init__(self) -> None:
+
+        self._directives: Optional[Dict[str, Directive]] = None
+        """Cache for known directives."""
+
+    @property
+    def directives(self) -> Dict[str, Directive]:
+        if self._directives is not None:
+            return self._directives
+
+        ignored_directives = ["restructuredtext-test-directive"]
+        found_directives = {
+            **docutils_directives._directive_registry,
+            **docutils_directives._directives,
+        }
+
+        self._directives = {
+            k: resolve_directive(v)
+            for k, v in found_directives.items()
+            if k not in ignored_directives
+        }
+
+        return self._directives
+
+    def get_implementation(self, directive: str, domain: Optional[str]):
+        if domain:
+            return None
+
+        return self.directives.get(directive, None)
+
+    def index_directives(self) -> Dict[str, Directive]:
+        return self.directives
+
+    def suggest_options(
+        self, context: CompletionContext, directive: str, domain: Optional[str]
+    ) -> Iterable[str]:
+
+        impl = self.directives.get(directive, None)
+        if impl is None:
+            return []
+
+        option_spec = impl.option_spec or {}
+        return option_spec.keys()
+
+
+def resolve_directive(directive: Union[Directive, Tuple[str, str]]) -> Directive:
+    """Return the directive based on the given reference.
+
+    'Core' docutils directives are returned as tuples ``(modulename, ClassName)``
+    so they need to be resolved manually.
+    """
+
+    if isinstance(directive, tuple):
+        mod, cls = directive
+
+        modulename = "docutils.parsers.rst.directives.{}".format(mod)
+        module = importlib.import_module(modulename)
+        return getattr(module, cls)
+
+    return directive
+
+
+def esbonio_setup(directives: Directives):
+    documentation = pkg_resources.resource_string("esbonio.lsp.rst", "directives.json")
+
+    directives.add_documentation(json.loads(documentation.decode("utf8")))
+    directives.add_feature(Docutils())

--- a/lib/esbonio/esbonio/lsp/sphinx/__init__.py
+++ b/lib/esbonio/esbonio/lsp/sphinx/__init__.py
@@ -4,6 +4,7 @@ import pathlib
 import platform
 import traceback
 import typing
+import warnings
 from functools import partial
 from multiprocessing import Process
 from multiprocessing import Queue
@@ -455,7 +456,20 @@ class SphinxLanguageServer(RstLanguageServer):
             yield prefix, domain
 
     def get_directive_options(self, name: str) -> Dict[str, Any]:
-        """Return the options specification for the given directive."""
+        """Return the options specification for the given directive.
+
+        .. deprecated:: 0.14.2
+
+           This will be removed in ``v1.0``
+        """
+
+        clsname = self.__class__.__name__
+        warnings.warn(
+            f"{clsname}.get_directive_options() is deprecated and will be removed in "
+            "v1.0.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
 
         directive = self.get_directives().get(name, None)
         if directive is None:

--- a/lib/esbonio/esbonio/lsp/sphinx/__init__.py
+++ b/lib/esbonio/esbonio/lsp/sphinx/__init__.py
@@ -453,26 +453,6 @@ class SphinxLanguageServer(RstLanguageServer):
 
             yield prefix, domain
 
-    def get_directive_options(self, name: str) -> Dict[str, Any]:
-        """Return the options specification for the given directive."""
-
-        directive = self.get_directives().get(name, None)
-        if directive is None:
-            return {}
-
-        options = directive.option_spec
-
-        if name.startswith("auto") and self.app:
-            self.logger.debug("Processing options for '%s' directive", name)
-            name = name.replace("auto", "")
-
-            self.logger.debug("Documenter name is '%s'", name)
-            documenter = self.app.registry.documenters.get(name, None)
-
-            if documenter is not None:
-                options = documenter.option_spec
-
-        return options or {}
 
     def get_roles(self) -> Dict[str, Any]:
         """Return a dictionary of known roles."""

--- a/lib/esbonio/esbonio/lsp/sphinx/__init__.py
+++ b/lib/esbonio/esbonio/lsp/sphinx/__init__.py
@@ -60,14 +60,15 @@ IS_LINUX = platform.system() == "Linux"
 DEFAULT_MODULES = [
     "esbonio.lsp.directives",         # Generic directive support
     "esbonio.lsp.roles",              # Generic roles support
-    "esbonio.lsp.rst.directives",     # Specialised support for docutils directives
-    "esbonio.lsp.rst.roles",          # Specialised support for docutils roles
-    "esbonio.lsp.sphinx.codeblocks",  # Support for code-block, highlight, etc.
-    "esbonio.lsp.sphinx.domains",     # Support for Sphinx domains
-    "esbonio.lsp.sphinx.directives",  # Specialised support for Sphinx directives
-    "esbonio.lsp.sphinx.images",      # Support for image, figure etc
-    "esbonio.lsp.sphinx.includes",    # Support for include, literal-include etc.
-    "esbonio.lsp.sphinx.roles",       # Support for misc roles added by Sphinx e.g. :download:
+    "esbonio.lsp.rst.directives",     # docutils directives
+    "esbonio.lsp.rst.roles",          # docutils roles
+    "esbonio.lsp.sphinx.autodoc",     # automodule, autoclass, etc.
+    "esbonio.lsp.sphinx.codeblocks",  # code-block, highlight, etc.
+    "esbonio.lsp.sphinx.domains",     # Sphinx domains
+    "esbonio.lsp.sphinx.directives",  # Sphinx directives
+    "esbonio.lsp.sphinx.images",      # image, figure etc
+    "esbonio.lsp.sphinx.includes",    # include, literal-include etc.
+    "esbonio.lsp.sphinx.roles",       # misc roles added by Sphinx e.g. :download:
 ]
 """The modules to load in the default configuration of the server."""
 # fmt: on
@@ -453,6 +454,26 @@ class SphinxLanguageServer(RstLanguageServer):
 
             yield prefix, domain
 
+    def get_directive_options(self, name: str) -> Dict[str, Any]:
+        """Return the options specification for the given directive."""
+
+        directive = self.get_directives().get(name, None)
+        if directive is None:
+            return {}
+
+        options = directive.option_spec
+
+        if name.startswith("auto") and self.app:
+            self.logger.debug("Processing options for '%s' directive", name)
+            name = name.replace("auto", "")
+
+            self.logger.debug("Documenter name is '%s'", name)
+            documenter = self.app.registry.documenters.get(name, None)
+
+            if documenter is not None:
+                options = documenter.option_spec
+
+        return options or {}
 
     def get_roles(self) -> Dict[str, Any]:
         """Return a dictionary of known roles."""

--- a/lib/esbonio/esbonio/lsp/sphinx/__init__.py
+++ b/lib/esbonio/esbonio/lsp/sphinx/__init__.py
@@ -16,7 +16,6 @@ from typing import Optional
 from typing import Tuple
 
 import pygls.uris as Uri
-from docutils.parsers.rst import Directive
 from pygls.lsp.types import DeleteFilesParams
 from pygls.lsp.types import Diagnostic
 from pygls.lsp.types import DiagnosticSeverity
@@ -453,23 +452,6 @@ class SphinxLanguageServer(RstLanguageServer):
                 prefix = ""
 
             yield prefix, domain
-
-    def get_directives(self) -> Dict[str, Directive]:
-        """Return a dictionary of the known directives"""
-
-        if self._directives is not None:
-            return self._directives
-
-        self._directives = super().get_directives()
-
-        for prefix, domain in self.get_domains():
-            fmt = "{prefix}:{name}" if prefix else "{name}"
-
-            for name, directive in domain.directives.items():
-                key = fmt.format(name=name, prefix=prefix)
-                self._directives[key] = directive
-
-        return self._directives
 
     def get_directive_options(self, name: str) -> Dict[str, Any]:
         """Return the options specification for the given directive."""

--- a/lib/esbonio/esbonio/lsp/sphinx/autodoc.py
+++ b/lib/esbonio/esbonio/lsp/sphinx/autodoc.py
@@ -1,0 +1,36 @@
+from typing import Iterable
+from typing import Optional
+
+from esbonio.lsp import CompletionContext
+from esbonio.lsp.directives import DirectiveLanguageFeature
+from esbonio.lsp.directives import Directives
+from esbonio.lsp.sphinx import SphinxLanguageServer
+
+
+class AutoDoc(DirectiveLanguageFeature):
+    def __init__(self, rst: SphinxLanguageServer):
+        self.rst = rst
+
+    def suggest_options(
+        self, context: CompletionContext, directive: str, domain: Optional[str]
+    ) -> Iterable[str]:
+
+        if self.rst.app is None or not directive.startswith("auto"):
+            return []
+
+        # The autoxxxx set of directives need special support as their options are
+        # stored on "documenters" instead of the directive implementation itself.
+        name = directive.replace("auto", "")
+        documenter = self.rst.app.registry.documenters.get(name, None)
+
+        if documenter is None:
+            self.rst.logger.debug(
+                "Unable to find documenter for directive: '%s'", directive
+            )
+            return []
+
+        return documenter.option_spec.keys()
+
+
+def esbonio_setup(rst: SphinxLanguageServer, directives: Directives):
+    directives.add_feature(AutoDoc(rst))

--- a/lib/esbonio/esbonio/lsp/sphinx/domains.py
+++ b/lib/esbonio/esbonio/lsp/sphinx/domains.py
@@ -1,5 +1,7 @@
 """Support for Sphinx domains."""
 import pathlib
+from typing import Dict
+from typing import Iterable
 from typing import List
 from typing import Optional
 from typing import Set
@@ -7,6 +9,7 @@ from typing import Tuple
 
 import pygls.uris as Uri
 from docutils import nodes
+from docutils.parsers.rst import Directive
 from pygls.lsp.types import CompletionItem
 from pygls.lsp.types import CompletionItemKind
 from pygls.lsp.types import Location
@@ -15,10 +18,12 @@ from pygls.lsp.types import Range
 from pygls.workspace import Document
 from sphinx.domains import Domain
 
+from esbonio.lsp import CompletionContext
+from esbonio.lsp import DefinitionContext
+from esbonio.lsp import DocumentLinkContext
+from esbonio.lsp.directives import DirectiveLanguageFeature
+from esbonio.lsp.directives import Directives
 from esbonio.lsp.roles import Roles
-from esbonio.lsp.rst import CompletionContext
-from esbonio.lsp.rst import DefinitionContext
-from esbonio.lsp.rst import DocumentLinkContext
 from esbonio.lsp.sphinx import SphinxLanguageServer
 
 TARGET_KINDS = {
@@ -31,6 +36,100 @@ TARGET_KINDS = {
     "module": CompletionItemKind.Module,
     "term": CompletionItemKind.Text,
 }
+
+
+class DomainDirectives(DirectiveLanguageFeature):
+    """Support for directives coming from Sphinx's domains."""
+
+    def __init__(self, rst: SphinxLanguageServer):
+        self.rst = rst
+
+        self._directives: Optional[Dict[str, Directive]] = None
+        """Cache for known directives."""
+
+    @property
+    def domains(self) -> Dict[str, Domain]:
+        """Return a dictionary of known domains."""
+
+        if self.rst.app is None or self.rst.app.env is None:
+            return dict()
+
+        return self.rst.app.env.domains  # type: ignore
+
+    @property
+    def directives(self) -> Dict[str, Directive]:
+
+        if self._directives is not None:
+            return self._directives
+
+        directives = {}
+        for prefix, domain in self.domains.items():
+            for name, directive in domain.directives.items():
+                directives[f"{prefix}:{name}"] = directive
+
+        self._directives = directives
+        return self._directives
+
+    def get_default_domain(self, uri: str) -> Optional[str]:
+        """Return the default domain for the given uri."""
+
+        # TODO: Add support for .. default-domain::
+        if self.rst.app is not None:
+            return self.rst.app.config.primary_domain
+
+        return None
+
+    def get_implementation(
+        self, directive: str, domain: Optional[str]
+    ) -> Optional[Directive]:
+
+        if domain is not None:
+            return self.directives.get(f"{domain}:{directive}", None)
+
+        if self.rst.app is None:
+            return None
+
+        # Try the default domain
+        primary_domain = self.rst.app.config.primary_domain
+        impl = self.directives.get(f"{primary_domain}:{directive}", None)
+        if impl is not None:
+            return impl
+
+        # Try the std domain
+        return self.directives.get(f"std:{directive}", None)
+
+    def index_directives(self) -> Dict[str, Directive]:
+        return self.directives
+
+    def suggest_directives(
+        self, context: CompletionContext
+    ) -> Iterable[Tuple[str, Directive]]:
+
+        # In addition to providing each directive fully qualified, we should provide a
+        # suggestion for directives in the std and primary domains without the prefix.
+        items = self.directives.copy()
+        primary_domain = self.get_default_domain(context.doc.uri)
+
+        for key, directive in self.directives.items():
+
+            if key.startswith("std:"):
+                items[key.replace("std:", "")] = directive
+                continue
+
+            if primary_domain and key.startswith(f"{primary_domain}:"):
+                items[key.replace(f"{primary_domain}:", "")] = directive
+
+        return items.items()
+
+    def suggest_options(
+        self, context: CompletionContext, directive: str, domain: Optional[str]
+    ) -> Iterable[str]:
+
+        impl = self.get_implementation(directive, domain)
+        if impl is None:
+            return []
+
+        return impl.option_spec.keys()
 
 
 class DomainFeatures:
@@ -297,9 +396,11 @@ def project_to_completion_item(project: str) -> CompletionItem:
     )
 
 
-def esbonio_setup(rst: SphinxLanguageServer, roles: Roles):
+def esbonio_setup(rst: SphinxLanguageServer, roles: Roles, directives: Directives):
     domains = DomainFeatures(rst)
 
     roles.add_target_definition_provider(domains)
     roles.add_target_completion_provider(domains)
     roles.add_target_link_provider(domains)
+
+    directives.add_feature(DomainDirectives(rst))

--- a/lib/esbonio/esbonio/lsp/util/patterns.py
+++ b/lib/esbonio/esbonio/lsp/util/patterns.py
@@ -1,6 +1,6 @@
 import re
 
-DIRECTIVE = re.compile(
+DIRECTIVE: "re.Pattern" = re.compile(
     r"""
     (\s*)                             # directives can be indented
     (?P<directive>
@@ -21,18 +21,38 @@ DIRECTIVE = re.compile(
 """A regular expression to detect and parse partial and complete directives.
 
 This does **not** include any options or content that may be included underneath
-the initial declaration. The language server breaks a directive down into a number
-of parts::
+the initial declaration. A number of named capture groups are available.
 
-                   vvvvvv argument
-   .. c:function:: malloc
-   ^^^^^^^^^^^^^^^ directive
-        ^^^^^^^^ name
-      ^ domain (optional)
+``name``
+   The name of the directive, not including the domain prefix.
+
+``domain``
+   The domain prefix
+
+``directive``
+   Everything that makes up a directive, from the initial ``..`` up to and including the
+   ``::`` characters.
+
+``argument``
+   All argument text.
+
+``substitution``
+   If the directive is part of a substitution definition, this group will contain
+
+**Example**
+
+Here is an example with a "standard" directive
+
+.. include:: ../../../lib/esbonio/tests/doctests/example_directive_pattern.txt
+
+And here is an example with a substitution definition
+
+.. include:: ../../../lib/esbonio/tests/doctests/example_directive_substitution_pattern.txt
+
 """
 
 
-DIRECTIVE_OPTION = re.compile(
+DIRECTIVE_OPTION: "re.Pattern" = re.compile(
     r"""
     (?P<indent>\s+)       # directive options must be indented
     (?P<option>
@@ -48,14 +68,27 @@ DIRECTIVE_OPTION = re.compile(
 )
 """A regular expression used to detect and parse partial and complete directive options.
 
-The language server breaks an option down into a number of parts::
+A number of named capture groups are available
 
-               vvvvvv value
-   |   :align: center
-       ^^^^^^^ option
-        ^^^^^ name
-    ^^^ indent
+``name``
+   The name of the option
+
+``option``
+   The name of the option including the surrounding ``:`` characters.
+
+``indent``
+   The whitespace characters making preceeding the initial ``:`` character
+
+``value``
+   The value passed to the option
+
+**Example**
+
+.. include:: ../../../lib/esbonio/tests/doctests/example_directive_option_pattern.txt
+
 """
+
+
 ROLE = re.compile(
     r"""
     ([^\w:]|^\s*)                     # roles cannot be preceeded by letter chars

--- a/lib/esbonio/pyproject.toml
+++ b/lib/esbonio/pyproject.toml
@@ -8,6 +8,7 @@ known_first_party = ["esbonio"]
 profile = "black"
 
 [tool.pytest.ini_options]
+addopts = "--doctest-glob='*.txt'"
 asyncio_mode = "auto"
 filterwarnings = [
     "ignore:'contextfunction' is renamed to 'pass_context',*:DeprecationWarning",

--- a/lib/esbonio/setup.cfg
+++ b/lib/esbonio/setup.cfg
@@ -51,6 +51,7 @@ console_scripts =
 debug = lsp-devtools
 dev =
   black
+  mock; python_version<"3.8"
   mypy
   flake8
   lsp-devtools

--- a/lib/esbonio/tests/doctests/example_directive_option_pattern.txt
+++ b/lib/esbonio/tests/doctests/example_directive_option_pattern.txt
@@ -1,0 +1,14 @@
+>>> from esbonio.lsp.util.patterns import DIRECTIVE_OPTION
+>>> match = DIRECTIVE_OPTION.match("   :align: center")
+
+>>> match.group("name")
+'align'
+
+>>> match.group("option")
+':align:'
+
+>>> match.group("indent")
+'   '
+
+>>> match.group("value")
+'center'

--- a/lib/esbonio/tests/doctests/example_directive_pattern.txt
+++ b/lib/esbonio/tests/doctests/example_directive_pattern.txt
@@ -1,0 +1,14 @@
+>>> from esbonio.lsp.util.patterns import DIRECTIVE
+>>> match = DIRECTIVE.match(".. py:function:: print")
+
+>>> match.group("name")
+'function'
+
+>>> match.group("domain")
+'py'
+
+>>> match.group("directive")
+'.. py:function::'
+
+>>> match.group("argument")
+'print'

--- a/lib/esbonio/tests/doctests/example_directive_substitution_pattern.txt
+++ b/lib/esbonio/tests/doctests/example_directive_substitution_pattern.txt
@@ -1,0 +1,20 @@
+>>> from esbonio.lsp.util.patterns import DIRECTIVE
+>>> match = DIRECTIVE.match(".. |example| replace:: this is an example")
+
+>>> match.group("name")
+'replace'
+
+>>> match.group("domain") is None
+True
+
+>>> match.group("substitution")
+'|example|'
+
+>>> match.group("substitution_text")
+'example'
+
+>>> match.group("directive")
+'.. |example| replace::'
+
+>>> match.group("argument")
+'this is an example'

--- a/lib/esbonio/tests/sphinx-default/test_sd_directives.py
+++ b/lib/esbonio/tests/sphinx-default/test_sd_directives.py
@@ -22,15 +22,15 @@ EXPECTED = {
     "toctree",
     "c:macro",
     "c:function",
+    "py:function",
+    "py:module",
+    "std:program",
+    "std:option",
 }
 
 UNEXPECTED = {
     "autoclass",
     "automodule",
-    "py:function",
-    "py:module",
-    "std:program",
-    "std:option",
     "restructuredtext-test-directive",
 }
 
@@ -45,9 +45,15 @@ UNEXPECTED = {
         (".. d", EXPECTED, UNEXPECTED),
         (".. code-b", EXPECTED, UNEXPECTED),
         (".. codex-block:: ", None, None),
-        (".. py:", None, None),
-        (".. c:", {"c:macro", "c:function"}, {"function", "image", "toctree"}),
-        (".. _some_label:", None, None),
+        (".. c:", EXPECTED, UNEXPECTED),
+        pytest.param(
+            ".. _some_label:",
+            None,
+            None,
+            marks=pytest.mark.xfail(
+                reason="TODO: Is there a way not to offer directive suggestions here?"
+            ),
+        ),
         ("   .", None, None),
         ("   ..", EXPECTED, UNEXPECTED),
         ("   .. ", EXPECTED, UNEXPECTED),
@@ -55,9 +61,15 @@ UNEXPECTED = {
         ("   .. doctest:: ", None, None),
         ("   .. code-b", EXPECTED, UNEXPECTED),
         ("   .. codex-block:: ", None, None),
-        ("   .. py:", None, None),
-        ("   .. _some_label:", None, None),
-        ("   .. c:", {"c:macro", "c:function"}, {"function", "image", "toctree"}),
+        pytest.param(
+            "   .. _some_label:",
+            None,
+            None,
+            marks=pytest.mark.xfail(
+                reason="TODO: Is there a way not to offer directive suggestions here?"
+            ),
+        ),
+        ("   .. c:", EXPECTED, UNEXPECTED),
     ],
 )
 async def test_directive_completions(

--- a/lib/esbonio/tests/sphinx-default/test_sd_directives.py
+++ b/lib/esbonio/tests/sphinx-default/test_sd_directives.py
@@ -71,10 +71,13 @@ async def test_directive_completions(
     results = await completion_request(client, test_uri, text)
 
     items = {item.label for item in results.items}
-    expected = expected or set()
     unexpected = unexpected or set()
 
-    assert expected == items & expected
+    if expected is None:
+        assert items == set()
+    else:
+        assert expected == items & expected
+
     assert set() == items & unexpected
 
     check.completion_items(client, results.items)

--- a/lib/esbonio/tests/sphinx-extensions/test_se_directives.py
+++ b/lib/esbonio/tests/sphinx-extensions/test_se_directives.py
@@ -18,15 +18,15 @@ EXPECTED = {
     "image",
     "toctree",
     "macro",
+    "c:macro",
     "not-a-true-directive",  # Ensure the server doesn't crash on non-standard directives.
     "function",
+    "std:program",
+    "std:option",
 }
 
 UNEXPECTED = {
-    "c:macro",
     "module",
-    "std:program",
-    "std:option",
     "restructuredtext-test-directive",
 }
 
@@ -41,13 +41,7 @@ UNEXPECTED = {
         (".. d", EXPECTED, UNEXPECTED),
         (".. code-b", EXPECTED, UNEXPECTED),
         (".. codex-block:: ", None, None),
-        (".. _some_label:", None, None),
-        (
-            ".. py:",
-            {"py:function", "py:module"},
-            {"image", "toctree", "macro", "function"},
-        ),
-        (".. c:", None, None),
+        (".. py:", EXPECTED, UNEXPECTED),
         ("   .", None, None),
         ("   ..", EXPECTED, UNEXPECTED),
         ("   .. ", EXPECTED, UNEXPECTED),
@@ -55,13 +49,7 @@ UNEXPECTED = {
         ("   .. doctest:: ", None, None),
         ("   .. code-b", EXPECTED, UNEXPECTED),
         ("   .. codex-block:: ", None, None),
-        ("   .. _some_label:", None, None),
-        (
-            "   .. py:",
-            {"py:function", "py:module"},
-            {"image", "toctree", "macro", "function"},
-        ),
-        ("   .. c:", None, None),
+        ("   .. py:", EXPECTED, UNEXPECTED),
     ],
 )
 async def test_directive_completions(

--- a/lib/esbonio/tests/sphinx-extensions/test_se_directives.py
+++ b/lib/esbonio/tests/sphinx-extensions/test_se_directives.py
@@ -75,10 +75,13 @@ async def test_directive_completions(
     results = await completion_request(client, test_uri, text)
 
     items = {item.label for item in results.items}
-    expected = expected or set()
     unexpected = unexpected or set()
 
-    assert expected == items & expected
+    if expected is None:
+        assert items == set()
+    else:
+        assert expected == items & expected
+
     assert set() == items & unexpected
 
     check.completion_items(client, results.items)

--- a/lib/esbonio/tests/unit_tests/test_directives.py
+++ b/lib/esbonio/tests/unit_tests/test_directives.py
@@ -1,7 +1,123 @@
-import pytest
+from typing import Dict
+from typing import List
+from unittest.mock import Mock
 
+import pytest
+from docutils.parsers.rst import Directive
+
+from esbonio.lsp import CompletionContext
 from esbonio.lsp.directives import DIRECTIVE
 from esbonio.lsp.directives import DIRECTIVE_OPTION
+from esbonio.lsp.directives import DirectiveLanguageFeature
+from esbonio.lsp.directives import Directives
+
+
+class Simple(DirectiveLanguageFeature):
+    """A simple directive language feature for use in tests."""
+
+    def __init__(self, names: List[str]):
+        self.directives = {name: Directive for name in names}
+
+    def index_directives(self) -> Dict[str, Directive]:
+        return self.directives
+
+    # The default `suggest_directives` implementation should be sufficient.
+
+
+class Broken(DirectiveLanguageFeature):
+    """A directive language feature that only throws exceptions."""
+
+    def index_directives(self) -> Dict[str, Directive]:
+        raise NotImplementedError()
+
+    # The default `suggest_directives` implementation should be sufficient.
+
+
+@pytest.fixture()
+def simple():
+    """A simple functional instance of the directive language feature"""
+
+    f1 = Simple(["one", "two"])
+    f2 = Simple(["three", "four"])
+
+    directives = Directives(Mock())
+    directives.add_feature(f1)
+    directives.add_feature(f2)
+
+    return directives
+
+
+@pytest.fixture()
+def broken():
+    """A an instance of the directive language feature with sub features that will
+    throw errors."""
+
+    f1 = Simple(["one", "two"])
+    f2 = Broken()
+    f3 = Simple(["three", "four"])
+
+    directives = Directives(Mock())
+    directives.add_feature(f1)
+    directives.add_feature(f2)
+    directives.add_feature(f3)
+
+    return directives
+
+
+def test_get_directives(simple: Directives):
+    """Ensure that we can correctly combine directives from multiple sources."""
+
+    items = simple.get_directives()
+    assert list(items.keys()) == ["one", "two", "three", "four"]
+    assert all([cls == Directive for cls in items.values()])
+
+    # All should be well
+    simple.logger.error.assert_not_called()
+
+
+def test_get_directives_error(broken: Directives):
+    """Ensure we can gracefully handle errors in directive language features."""
+
+    items = broken.get_directives()
+    assert list(items.keys()) == ["one", "two", "three", "four"]
+    assert all([cls == Directive for cls in items.values()])
+
+    # The error should've been logged
+    broken.logger.error.assert_called_once()
+    args = broken.logger.error.call_args.args
+    assert args[0].startswith("Unable to index directives")
+
+
+def test_suggest_directives(simple: Directives):
+    """Ensure that we can correctly combine directives from multiple sources."""
+
+    context = CompletionContext(
+        doc=Mock(), location="rst", match=Mock(), position=Mock(), capabilities=Mock()
+    )
+    items = simple.suggest_directives(context)
+
+    assert [i[0] for i in items] == ["one", "two", "three", "four"]
+    assert all([i[1] == Directive for i in items])
+
+    # All should be well
+    simple.logger.error.assert_not_called()
+
+
+def test_suggest_directives_error(broken: Directives):
+    """Ensure that we can gracefully handle errors in directive language features."""
+
+    context = CompletionContext(
+        doc=Mock(), location="rst", match=Mock(), position=Mock(), capabilities=Mock()
+    )
+    items = broken.suggest_directives(context)
+
+    assert [i[0] for i in items] == ["one", "two", "three", "four"]
+    assert all([i[1] == Directive for i in items])
+
+    # The error should've been logged
+    broken.logger.error.assert_called_once()
+    args = broken.logger.error.call_args.args
+    assert args[0].startswith("Unable to suggest directives")
 
 
 @pytest.mark.parametrize(

--- a/lib/esbonio/tests/unit_tests/test_directives.py
+++ b/lib/esbonio/tests/unit_tests/test_directives.py
@@ -1,8 +1,8 @@
+import sys
 from typing import Dict
 from typing import Iterable
 from typing import List
 from typing import Optional
-from unittest.mock import Mock
 
 import pytest
 from docutils.parsers.rst import Directive
@@ -12,6 +12,11 @@ from esbonio.lsp.directives import DIRECTIVE
 from esbonio.lsp.directives import DIRECTIVE_OPTION
 from esbonio.lsp.directives import DirectiveLanguageFeature
 from esbonio.lsp.directives import Directives
+
+if sys.version_info.minor < 8:
+    from mock import Mock
+else:
+    from unittest.mock import Mock
 
 
 class Simple(DirectiveLanguageFeature):

--- a/lib/esbonio/tests/unit_tests/test_directives.py
+++ b/lib/esbonio/tests/unit_tests/test_directives.py
@@ -1,5 +1,7 @@
 from typing import Dict
+from typing import Iterable
 from typing import List
+from typing import Optional
 from unittest.mock import Mock
 
 import pytest
@@ -18,19 +20,39 @@ class Simple(DirectiveLanguageFeature):
     def __init__(self, names: List[str]):
         self.directives = {name: Directive for name in names}
 
+    def get_implementation(
+        self, directive: str, domain: Optional[str]
+    ) -> Optional[Directive]:
+        return self.directives.get(directive, None)
+
     def index_directives(self) -> Dict[str, Directive]:
         return self.directives
 
     # The default `suggest_directives` implementation should be sufficient.
 
+    def suggest_options(
+        self, context: CompletionContext, directive: str, domain: Optional[str]
+    ) -> Iterable[str]:
+        return iter(directive) if directive in self.directives else []
+
 
 class Broken(DirectiveLanguageFeature):
     """A directive language feature that only throws exceptions."""
+
+    def get_implementation(
+        self, directive: str, domain: Optional[str]
+    ) -> Optional[Directive]:
+        raise NotImplementedError()
 
     def index_directives(self) -> Dict[str, Directive]:
         raise NotImplementedError()
 
     # The default `suggest_directives` implementation should be sufficient.
+
+    def suggest_options(
+        self, context: CompletionContext, directive: str, domain: Optional[str]
+    ) -> Iterable[str]:
+        raise NotImplementedError()
 
 
 @pytest.fixture()
@@ -88,6 +110,31 @@ def test_get_directives_error(broken: Directives):
     assert args[0].startswith("Unable to index directives")
 
 
+def test_get_implementation(simple: Directives):
+    """Ensure that we can correctly combine directives from multiple sources."""
+
+    impl = simple.get_implementation("one", None)
+    assert impl == Directive
+
+    impl = simple.get_implementation("four", None)
+    assert impl == Directive
+
+    # All should be well
+    simple.logger.error.assert_not_called()
+
+
+def test_get_implementation_error(broken: Directives):
+    """Ensure we can gracefully handle errors in directive language features."""
+
+    impl = broken.get_implementation("four", None)
+    assert impl == Directive
+
+    # The error should've been logged
+    broken.logger.error.assert_called_once()
+    args = broken.logger.error.call_args.args
+    assert args[0].startswith("Unable to get implementation for")
+
+
 def test_suggest_directives(simple: Directives):
     """Ensure that we can correctly combine directives from multiple sources."""
 
@@ -118,6 +165,36 @@ def test_suggest_directives_error(broken: Directives):
     broken.logger.error.assert_called_once()
     args = broken.logger.error.call_args.args
     assert args[0].startswith("Unable to suggest directives")
+
+
+def test_suggest_options(simple: Directives):
+    """Ensure that we can correctly combine directives from multiple sources."""
+
+    context = CompletionContext(
+        doc=Mock(), location="rst", match=Mock(), position=Mock(), capabilities=Mock()
+    )
+
+    items = simple.suggest_options(context, "four", None)
+    assert list(items) == ["f", "o", "u", "r"]
+
+    # All should be well
+    simple.logger.error.assert_not_called()
+
+
+def test_suggest_options_error(broken: Directives):
+    """Ensure that we can gracefully handle errors in directive language features."""
+
+    context = CompletionContext(
+        doc=Mock(), location="rst", match=Mock(), position=Mock(), capabilities=Mock()
+    )
+
+    items = broken.suggest_options(context, "four", None)
+    assert list(items) == ["f", "o", "u", "r"]
+
+    # The error should've been logged
+    broken.logger.error.assert_called_once()
+    args = broken.logger.error.call_args.args
+    assert args[0].startswith("Unable to suggest options for ")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Building on the `DirectiveLanguageFeatures` introduced in #444, this PR introduces a number of new methods features can implement

- `index_directives`: used to discover available directive implementations
- `suggest_directives`: used to determine which directive names can be suggested in the current completion context (`function` vs `py:function` vs `c:function` etc.)
- `get_implementation`: used to go from a directive name (`function` vs `py:function`) to its implementation
- `suggest_options`: used to determine which directive options can be suggested in the current completion context

This should also enable implementing other features such as #105,  #312 , #414 etc.

Finally, both `<primary_domain>:function` and `function` are offered as completion suggestions as they are both valid. 
Working towards #416 

