### PR TITLE
Update workflow definitions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,61 @@
+name: Documentation
+on:
+  pull_request:
+    branches:
+    - release
+    - develop
+    paths:
+    - 'docs/**'
+    - 'lib/esbonio/**'
+    - 'lib/esbonio-extensions/**'
+  push:
+    branches:
+    - release
+    - develop
+    paths:
+    - 'docs/**'
+    - 'lib/esbonio/**'
+    - 'lib/esbonio-extensions/**'
+
+jobs:
+  docs:
+    name: Documentation
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - uses: actions/setup-python@v4
+      with:
+        python-version: "3.10"
+
+    - run: |
+        set -e
+
+        python --version
+        python -m pip install --upgrade pip
+        python -m pip install -r docs/requirements.txt
+
+      name: Setup Environment
+
+    - id: build
+      run: |
+        set -e
+
+        cd docs
+        make html
+      name: Build Docs
+
+    - name: 'Upload Aritfact'
+      uses: actions/upload-artifact@v3
+      with:
+        name: 'docs'
+        path: 'docs/_build/${{ steps.build.outputs.version }}'
+
+    - name: 'Publish Docs'
+      uses: JamesIves/github-pages-deploy-action@v4
+      with:
+        branch: gh-pages
+        folder: docs/_build/${{ steps.build.outputs.version }}
+        target-folder: docs/${{ steps.build.outputs.version }}
+        clean: true
+      if: success() && ( startsWith(github.ref, 'refs/heads/release') || startsWith(github.ref, 'refs/heads/develop') )

--- a/.github/workflows/lsp-pr.yml
+++ b/.github/workflows/lsp-pr.yml
@@ -1,0 +1,80 @@
+name: Language Server PR
+on:
+  pull_request:
+    branches:
+    - develop
+    - release
+    paths:
+    - 'lib/esbonio/**'
+
+jobs:
+  lsp:
+    name: "Python v${{ matrix.python-version }} -- ${{ matrix.os }}"
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        os: [ubuntu-latest, windows-latest, macos-latest]
+
+        # Python 3.6 is not available on Windows or MacOS runners
+        exclude:
+        - os: macos-latest
+          python-version: "3.6"
+
+        - os: windows-latest
+          python-version: "3.6"
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Setup Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - run: |
+        python --version
+        python -m pip install --upgrade pip
+        python -m pip install --upgrade tox bump2version
+      name: Setup Environment
+
+    - run: |
+        set -e
+
+        # Despite the script's name, this is only used to obtain a
+        # dev version number e.g. v1.2.3-dev4
+        ./scripts/make-release.sh lsp
+      name: Set Version
+      if: matrix.python-version == '3.10' && matrix.os == 'ubuntu-latest'
+
+    - run: |
+        cd lib/esbonio
+
+        version=$(echo ${{ matrix.python-version }} | tr -d .)
+        python -m tox -e `tox -l | grep $version | tr '\n' ','`
+      name: Run Tests (when not on Windows)
+      if: matrix.os != 'windows-latest'
+
+    - run: |
+        cd lib/esbonio
+
+        $version=$(echo "${{ matrix.python-version }}" | tr -d ".")
+        $envs=$(tox -l | grep $version)
+
+        echo $($envs -join ",")
+        python -m tox -e $($envs -join ",")
+      name: Run Tests (when on Windows)
+      if: matrix.os == 'windows-latest'
+
+    - name: Package
+      run: |
+        cd lib/esbonio
+        python -m tox -e pkg
+      if: always() && matrix.python-version == '3.10' && matrix.os == 'ubuntu-latest'
+
+    - name: 'Upload Artifact'
+      uses: actions/upload-artifact@v3
+      with:
+        name: 'dist'
+        path: lib/esbonio/dist
+      if: always() && matrix.python-version == '3.10' && matrix.os == 'ubuntu-latest'

--- a/.github/workflows/lsp-pr.yml
+++ b/.github/workflows/lsp-pr.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
         os: [ubuntu-latest, windows-latest, macos-latest]
 
         # Python 3.6 is not available on Windows or MacOS runners

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -138,21 +138,16 @@ jobs:
       if: success() && startsWith(github.ref, 'refs/heads/release')
 
   extensions:
-    name: "Sphinx Extensions -- Python v${{ matrix.python-version }}"
+    name: "Sphinx Extensions"
     needs: [trigger, lsp]
     if: always() && needs.trigger.outputs.extensions
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
-        os: [ubuntu-20.04]
+    runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
-    - name: Setup Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+    - uses: actions/setup-python@v4
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: 3.10
 
     - run: |
         sudo apt update
@@ -169,25 +164,17 @@ jobs:
         ./scripts/make-release.sh extensions
       name: Set Version
       id: info
-      if: matrix.python-version == '3.8'
-
-    - run: |
-        cd lib/esbonio-extensions
-        python -m tox -e py`echo ${{ matrix.python-version }} | tr -d .`
-      name: Test
 
     - name: Package
       run: |
         cd lib/esbonio-extensions
         python -m tox -e pkg
-      if: matrix.python-version == '3.8'
 
     - name: 'Upload Artifact'
-      uses: actions/upload-artifact@v1.0.0
+      uses: actions/upload-artifact@v3
       with:
         name: 'dist'
         path: lib/esbonio-extensions/dist
-      if: matrix.python-version == '3.8'
 
     - name: Publish
       id: assets
@@ -201,7 +188,7 @@ jobs:
 
         src=$(find dist/ -name '*.tar.gz' -exec basename {} \;)
         echo "::set-output name=SRC::$src"
-      if: success() && matrix.python-version == '3.8' && startsWith(github.ref, 'refs/heads/release')
+      if: success() && startsWith(github.ref, 'refs/heads/release')
 
     - name: Create Release
       id: release
@@ -213,7 +200,7 @@ jobs:
         draft: false
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      if: success() && matrix.python-version == '3.8' && startsWith(github.ref, 'refs/heads/release')
+      if: success() && startsWith(github.ref, 'refs/heads/release')
 
     - name: Upload Release Asset
       uses: actions/upload-release-asset@v1.0.1
@@ -224,7 +211,7 @@ jobs:
         asset_path: lib/esbonio-extensions/dist/${{ steps.assets.outputs.WHL }}
         asset_name: ${{ steps.assets.outputs.WHL }}
         asset_content_type: application/octet-stream
-      if: success() && matrix.python-version == '3.8' && startsWith(github.ref, 'refs/heads/release')
+      if: success() && startsWith(github.ref, 'refs/heads/release')
 
     - name: Upload Release Asset
       uses: actions/upload-release-asset@v1.0.1
@@ -235,7 +222,7 @@ jobs:
         asset_path: lib/esbonio-extensions/dist/${{ steps.assets.outputs.SRC }}
         asset_name: ${{ steps.assets.outputs.SRC }}
         asset_content_type: application/octet-stream
-      if: success() && matrix.python-version == '3.8' && startsWith(github.ref, 'refs/heads/release')
+      if: success() && startsWith(github.ref, 'refs/heads/release')
 
   lsp:
     name: Language Server

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,4 @@
-name: Esbonio
-
+name: Release
 on:
   pull_request:
     branches:
@@ -71,17 +70,17 @@ jobs:
     name: VSCode Extension
     needs: [trigger, extensions]
     if: always() && needs.trigger.outputs.vscode
-    runs-on: ubuntu-20.04 # TODO: Enable windows, macOS builds.
+    runs-on: ubuntu-latest
     steps:
-    - uses: 'actions/checkout@v2'
+    - uses: 'actions/checkout@v3'
 
-    - uses: 'actions/setup-node@v1'
+    - uses: 'actions/setup-node@v3'
       with:
-        node-version: 14.x
+        node-version: 16.x
 
-    - uses: 'actions/setup-python@v1'
+    - uses: 'actions/setup-python@v4'
       with:
-        python-version: 3.8
+        python-version: "3.10"
 
     - run: |
         sudo apt update
@@ -90,7 +89,6 @@ jobs:
         python --version
         python -m pip install --upgrade pip
         python -m pip install --upgrade tox bump2version towncrier==19.2 docutils
-
       name: Install Build Tools
 
     - run: |
@@ -102,27 +100,15 @@ jobs:
 
     - run: |
         cd code
-        npm install
-
-        mkdir dist
-        xvfb-run -a npm test
-      name: Test Extension
-
-    - run: |
-        cd code
         rm -r dist
         npm run package
-
-        vsix=$(find . -name '*.vsix' -exec basename {} \;)
-        echo "::set-output name=VSIX::$vsix"
-      id: assets
-      name: Package
+      name: Package Extension
 
     - name: 'Upload Artifact'
-      uses: actions/upload-artifact@v1.0.0
+      uses: actions/upload-artifact@v3
       with:
         name: 'vsix'
-        path: code/${{ steps.assets.outputs.VSIX }}
+        path: code/*.vsix
 
     - name: 'Publish Extension'
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
     - release
-    - develop
 
 jobs:
   # Simple job the checks to see which parts we actually have to build.
@@ -104,30 +103,15 @@ jobs:
         npm run deploy
       env:
         VSCE_PAT: ${{ secrets.VSCODE_PAT }}
-      if: success() && startsWith(github.ref, 'refs/heads/release')
 
     - name: Create Release
-      id: release
-      uses: actions/create-release@v1
-      with:
-        tag_name: ${{ steps.info.outputs.TAG }}
-        release_name: Esbonio VSCode Extension v${{ steps.info.outputs.VERSION  }} - ${{ steps.info.outputs.DATE }}
-        body_path: code/.changes.html
-        draft: false
+      run: |
+        gh release create "v${VERSION}" \
+          --title "Esbonio VSCode Extension v${VERSION} - ${RELEASE_DATE}" \
+          -F code/.changes.html \
+          ./code/*.vsix
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      if: success() && startsWith(github.ref, 'refs/heads/release')
-
-    - name: Upload Release Asset
-      uses: actions/upload-release-asset@v1.0.1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.release.outputs.upload_url }}
-        asset_path: code/${{ steps.assets.outputs.VSIX }}
-        asset_name: ${{ steps.assets.outputs.VSIX }}
-        asset_content_type: application/octet-stream
-      if: success() && startsWith(github.ref, 'refs/heads/release')
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   extensions:
     name: "Sphinx Extensions"
@@ -139,7 +123,7 @@ jobs:
 
     - uses: actions/setup-python@v4
       with:
-        python-version: 3.10
+        python-version: "3.10"
 
     - run: |
         sudo apt update
@@ -175,46 +159,14 @@ jobs:
         python -m pip install twine
         python -m twine upload dist/* -u alcarney -p ${{ secrets.PYPI_PASS }}
 
-        whl=$(find dist/ -name '*.whl' -exec basename {} \;)
-        echo "::set-output name=WHL::$whl"
-
-        src=$(find dist/ -name '*.tar.gz' -exec basename {} \;)
-        echo "::set-output name=SRC::$src"
-      if: success() && startsWith(github.ref, 'refs/heads/release')
-
     - name: Create Release
-      id: release
-      uses: actions/create-release@v1
-      with:
-        tag_name: ${{ steps.info.outputs.TAG }}
-        release_name: Esbonio Extensions v${{ steps.info.outputs.VERSION  }} - ${{ steps.info.outputs.DATE }}
-        body_path: lib/esbonio-extensions/.changes.html
-        draft: false
+      run: |
+        gh release create "v${VERSION}" \
+          --title "Esbonio Extensions v${VERSION} - ${RELEASE_DATE}" \
+          -F lib/esbonio-extensions/.changes.html \
+          ./lib/esbonio-extensions/dist/*
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      if: success() && startsWith(github.ref, 'refs/heads/release')
-
-    - name: Upload Release Asset
-      uses: actions/upload-release-asset@v1.0.1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.release.outputs.upload_url }}
-        asset_path: lib/esbonio-extensions/dist/${{ steps.assets.outputs.WHL }}
-        asset_name: ${{ steps.assets.outputs.WHL }}
-        asset_content_type: application/octet-stream
-      if: success() && startsWith(github.ref, 'refs/heads/release')
-
-    - name: Upload Release Asset
-      uses: actions/upload-release-asset@v1.0.1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.release.outputs.upload_url }}
-        asset_path: lib/esbonio-extensions/dist/${{ steps.assets.outputs.SRC }}
-        asset_name: ${{ steps.assets.outputs.SRC }}
-        asset_content_type: application/octet-stream
-      if: success() && startsWith(github.ref, 'refs/heads/release')
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   lsp:
     name: Language Server
@@ -258,49 +210,16 @@ jobs:
         path: lib/esbonio/dist
 
     - name: Publish
-      id: assets
       run: |
         cd lib/esbonio
         python -m pip install twine
         python -m twine upload dist/* -u alcarney -p ${{ secrets.PYPI_PASS }}
 
-        whl=$(find dist/ -name '*.whl' -exec basename {} \;)
-        echo "::set-output name=WHL::$whl"
-
-        src=$(find dist/ -name '*.tar.gz' -exec basename {} \;)
-        echo "::set-output name=SRC::$src"
-      if: startsWith(github.ref, 'refs/heads/release')
-
     - name: Create Release
-      id: release
-      uses: actions/create-release@v1
-      with:
-        tag_name: ${{ steps.info.outputs.TAG }}
-        release_name: Esbonio Language Server v${{ steps.info.outputs.VERSION  }} - ${{ steps.info.outputs.DATE }}
-        body_path: lib/esbonio/.changes.html
-        draft: false
+      run: |
+        gh release create "v${VERSION}" \
+          --title "Esbonio Language Server v${VERSION} - ${RELEASE_DATE}" \
+          -F lib/esbonio/.changes.html \
+          ./lib/esbonio/dist/*
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      if: success() && startsWith(github.ref, 'refs/heads/release')
-
-    - name: Upload Release Asset
-      uses: actions/upload-release-asset@v1.0.1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.release.outputs.upload_url }}
-        asset_path: lib/esbonio/dist/${{ steps.assets.outputs.WHL }}
-        asset_name: ${{ steps.assets.outputs.WHL }}
-        asset_content_type: application/octet-stream
-      if: success() && startsWith(github.ref, 'refs/heads/release')
-
-    - name: Upload Release Asset
-      uses: actions/upload-release-asset@v1.0.1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.release.outputs.upload_url }}
-        asset_path: lib/esbonio/dist/${{ steps.assets.outputs.SRC }}
-        asset_name: ${{ steps.assets.outputs.SRC }}
-        asset_content_type: application/octet-stream
-      if: success() && startsWith(github.ref, 'refs/heads/release')
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
       lsp: ${{steps.check-lsp.outputs.build}}
       vscode: ${{steps.check-vscode.outputs.build}}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0
 
@@ -84,7 +84,7 @@ jobs:
 
         python --version
         python -m pip install --upgrade pip
-        python -m pip install --upgrade tox bump2version towncrier==19.2 docutils
+        python -m pip install --upgrade tox bump2version towncrier docutils
       name: Install Build Tools
 
     - run: |
@@ -155,7 +155,7 @@ jobs:
 
         python --version
         python -m pip install --upgrade pip
-        python -m pip install --upgrade tox bump2version towncrier==19.2 docutils
+        python -m pip install --upgrade tox bump2version towncrier docutils
       name: Setup Environment
 
     - run: |
@@ -244,7 +244,7 @@ jobs:
 
         python --version
         python -m pip install --upgrade pip
-        python -m pip install --upgrade tox bump2version towncrier==19.2 docutils
+        python -m pip install --upgrade tox bump2version towncrier docutils
       name: Setup Environment
 
     - run: |
@@ -317,13 +317,13 @@ jobs:
     name: Documentation
     needs: [trigger, vscode]
     if: always() && needs.trigger.outputs.docs
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
-    - uses: 'actions/checkout@v2.3.1'
+    - uses: actions/checkout@v3
 
-    - uses: 'actions/setup-python@v1'
+    - uses: actions/setup-python@v4
       with:
-        python-version: 3.8
+        python-version: 3.10
 
     - run: |
         set -e
@@ -343,13 +343,13 @@ jobs:
       name: Build Docs
 
     - name: 'Upload Aritfact'
-      uses: 'actions/upload-artifact@v1.0.0'
+      uses: 'actions/upload-artifact@v3
       with:
         name: 'docs'
         path: 'docs/_build/${{ steps.build.outputs.version }}'
 
     - name: 'Publish Docs'
-      uses: JamesIves/github-pages-deploy-action@4.1.5
+      uses: JamesIves/github-pages-deploy-action@v4
       with:
         branch: gh-pages
         folder: docs/_build/${{ steps.build.outputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,5 @@
 name: Release
 on:
-  pull_request:
-    branches:
-    - release
-    - develop
   push:
     branches:
     - release
@@ -242,32 +238,23 @@ jobs:
       if: success() && matrix.python-version == '3.8' && startsWith(github.ref, 'refs/heads/release')
 
   lsp:
-    name: "Language Server -- Python v${{ matrix.python-version }} -- ${{ matrix.os }}"
+    name: Language Server
     needs: trigger
     if: always() && needs.trigger.outputs.lsp
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
-        os: [ubuntu-20.04, windows-latest, macos-latest]
-
-        # Python 3.6 is not available on Windows or MacOS runners
-        exclude:
-        - os: macos-latest
-          python-version: "3.6"
-
-        - os: windows-latest
-          python-version: "3.6"
+    runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
-    - name: Setup Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+    - uses: actions/setup-python@v4
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: "3.10"
 
     - run: |
+
+        sudo apt update
+        sudo apt install pandoc
+
         python --version
         python -m pip install --upgrade pip
         python -m pip install --upgrade tox bump2version towncrier==19.2 docutils
@@ -276,45 +263,20 @@ jobs:
     - run: |
         set -e
 
-        sudo apt update
-        sudo apt install pandoc
-
         ./scripts/make-release.sh lsp
       name: Set Version
       id: info
-      if: matrix.python-version == '3.8' && matrix.os == 'ubuntu-20.04'
-
-    - run: |
-        cd lib/esbonio
-
-        version=$(echo ${{ matrix.python-version }} | tr -d .)
-        python -m tox -e `tox -l | grep $version | tr '\n' ','`
-      name: Run Tests (when not on Windows)
-      if: matrix.os != 'windows-latest'
-
-    - run: |
-        cd lib/esbonio
-
-        $version=$(echo "${{ matrix.python-version }}" | tr -d ".")
-        $envs=$(tox -l | grep $version)
-
-        echo $($envs -join ",")
-        python -m tox -e $($envs -join ",")
-      name: Run Tests (when on Windows)
-      if: matrix.os == 'windows-latest'
 
     - name: Package
       run: |
         cd lib/esbonio
         python -m tox -e pkg
-      if: always() && matrix.python-version == '3.8' && matrix.os == 'ubuntu-20.04'
 
     - name: 'Upload Artifact'
-      uses: actions/upload-artifact@v1.0.0
+      uses: actions/upload-artifact@v3
       with:
         name: 'dist'
         path: lib/esbonio/dist
-      if: always() && matrix.python-version == '3.8' && matrix.os == 'ubuntu-20.04'
 
     - name: Publish
       id: assets
@@ -328,7 +290,7 @@ jobs:
 
         src=$(find dist/ -name '*.tar.gz' -exec basename {} \;)
         echo "::set-output name=SRC::$src"
-      if: success() && matrix.python-version == '3.8' && matrix.os == 'ubuntu-20.04' && startsWith(github.ref, 'refs/heads/release')
+      if: startsWith(github.ref, 'refs/heads/release')
 
     - name: Create Release
       id: release
@@ -340,7 +302,7 @@ jobs:
         draft: false
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      if: success() && matrix.python-version == '3.8' && matrix.os == 'ubuntu-20.04' && startsWith(github.ref, 'refs/heads/release')
+      if: success() && startsWith(github.ref, 'refs/heads/release')
 
     - name: Upload Release Asset
       uses: actions/upload-release-asset@v1.0.1
@@ -351,7 +313,7 @@ jobs:
         asset_path: lib/esbonio/dist/${{ steps.assets.outputs.WHL }}
         asset_name: ${{ steps.assets.outputs.WHL }}
         asset_content_type: application/octet-stream
-      if: success() && matrix.python-version == '3.8' && matrix.os == 'ubuntu-20.04' && startsWith(github.ref, 'refs/heads/release')
+      if: success() && startsWith(github.ref, 'refs/heads/release')
 
     - name: Upload Release Asset
       uses: actions/upload-release-asset@v1.0.1
@@ -362,7 +324,7 @@ jobs:
         asset_path: lib/esbonio/dist/${{ steps.assets.outputs.SRC }}
         asset_name: ${{ steps.assets.outputs.SRC }}
         asset_content_type: application/octet-stream
-      if: success() && matrix.python-version == '3.8' && matrix.os == 'ubuntu-20.04' && startsWith(github.ref, 'refs/heads/release')
+      if: success() && startsWith(github.ref, 'refs/heads/release')
 
   docs:
     name: Documentation

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,14 +54,6 @@ jobs:
         ./scripts/should-build.sh lsp
       name: "Build LSP?"
 
-    - id: check-docs
-      run: |
-        set -e
-        echo ${BASE}
-
-        ./scripts/should-build.sh docs
-      name: "Build Docs?"
-
   vscode:
     name: VSCode Extension
     needs: [trigger, extensions]
@@ -312,47 +304,3 @@ jobs:
         asset_name: ${{ steps.assets.outputs.SRC }}
         asset_content_type: application/octet-stream
       if: success() && startsWith(github.ref, 'refs/heads/release')
-
-  docs:
-    name: Documentation
-    needs: [trigger, vscode]
-    if: always() && needs.trigger.outputs.docs
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3
-
-    - uses: actions/setup-python@v4
-      with:
-        python-version: 3.10
-
-    - run: |
-        set -e
-
-        python --version
-        python -m pip install --upgrade pip
-        python -m pip install -r docs/requirements.txt
-
-      name: Setup Environment
-
-    - id: build
-      run: |
-        set -e
-
-        cd docs
-        make html
-      name: Build Docs
-
-    - name: 'Upload Aritfact'
-      uses: 'actions/upload-artifact@v3
-      with:
-        name: 'docs'
-        path: 'docs/_build/${{ steps.build.outputs.version }}'
-
-    - name: 'Publish Docs'
-      uses: JamesIves/github-pages-deploy-action@v4
-      with:
-        branch: gh-pages
-        folder: docs/_build/${{ steps.build.outputs.version }}
-        target-folder: docs/${{ steps.build.outputs.version }}
-        clean: true
-      if: success() && ( startsWith(github.ref, 'refs/heads/release') || startsWith(github.ref, 'refs/heads/develop') )

--- a/.github/workflows/sphinx-ext-pr.yml
+++ b/.github/workflows/sphinx-ext-pr.yml
@@ -1,0 +1,57 @@
+name: Sphinx Extensions PR
+on:
+  pull_request:
+    branches:
+    - develop
+    - release
+    paths:
+    - 'lib/esbonio-extensions/**'
+
+jobs:
+  sphinx-exts:
+    name: "Python v${{ matrix.python-version }}"
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Setup Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - run: |
+        python --version
+        python -m pip install --upgrade pip
+        python -m pip install --upgrade tox bump2version
+      name: Setup Environment
+
+    - run: |
+        set -e
+
+        # Despite the script's name, this is only used to obtain a
+        # dev version number e.g. v1.2.3-dev4
+        ./scripts/make-release.sh extensions
+      name: Set Version
+      id: info
+      if: matrix.python-version == '3.10'
+
+    - run: |
+        cd lib/esbonio-extensions
+        python -m tox -e py`echo ${{ matrix.python-version }} | tr -d .`
+      name: Test
+
+    - name: Package
+      run: |
+        cd lib/esbonio-extensions
+        python -m tox -e pkg
+      if: matrix.python-version == '3.10'
+
+    - name: 'Upload Artifact'
+      uses: actions/upload-artifact@v3
+      with:
+        name: 'dist'
+        path: lib/esbonio-extensions/dist
+      if: matrix.python-version == '3.10'

--- a/.github/workflows/vscode-pr.yml
+++ b/.github/workflows/vscode-pr.yml
@@ -1,0 +1,62 @@
+name: VSCode PR
+on:
+  pull_request:
+    branches:
+    - develop
+    - release
+    paths:
+    - 'code/**'
+jobs:
+  vscode:
+    name: Test Extension
+    runs-on: ubuntu-latest
+    steps:
+    - uses: 'actions/checkout@v3'
+
+    - uses: 'actions/setup-node@v3'
+      with:
+        node-version: 16.x
+
+    - uses: 'actions/setup-python@v4'
+      with:
+        python-version: "3.10"
+
+    - run: |
+        python --version
+        python -m pip install --upgrade pip
+        python -m pip install --upgrade bump2version
+
+      name: Install Build Tools
+
+    - run: |
+        set -e
+
+        # Despite the script's name, this is only used to obtain a
+        # dev version number e.g. v1.2.3-dev4
+        ./scripts/make-release.sh vscode
+      name: Set Version
+
+    - run: |
+        set -e
+
+        cd code
+        npm ci
+
+        mkdir dist
+        npm test
+      name: Test Extension
+
+    - run: |
+        set -e
+
+        cd code
+        rm -r dist
+        npm run package
+      id: assets
+      name: Package Extension
+
+    - name: 'Upload Artifact'
+      uses: actions/upload-artifact@v3
+      with:
+        name: 'vsix'
+        path: code/*.vsix

--- a/code/package.json
+++ b/code/package.json
@@ -24,7 +24,7 @@
         "watch": "webpack --mode development --watch",
         "test": "npm run compile-test && node ./dist/test/runUnitTests.js",
         "clean": "rm -r dist",
-        "deploy": "vsce publish --baseImagesUrl https://github.com/swyddfa/esbonio/raw/release/code/",
+        "deploy": "vsce publish -i *.vsix --baseImagesUrl https://github.com/swyddfa/esbonio/raw/release/code/",
         "package": "vsce package --baseImagesUrl https://github.com/swyddfa/esbonio/raw/release/code/",
         "vscode:prepublish": "webpack --mode production"
     },

--- a/lib/esbonio-extensions/changes/470.misc.rst
+++ b/lib/esbonio-extensions/changes/470.misc.rst
@@ -1,0 +1,1 @@
+Add Python 3.11 support

--- a/lib/esbonio-extensions/esbonio/tutorial.py
+++ b/lib/esbonio-extensions/esbonio/tutorial.py
@@ -28,7 +28,7 @@ logger = getLogger(__name__)
 CELL_TYPES = {"markdown": nbf.new_markdown_cell, "code": nbf.new_code_cell}
 REPL_PATTERN = re.compile(r"^(>>>|\.\.\.) ?", re.MULTILINE)
 
-CODE_LANGUAGES = {"default", "python", "pycon3"}
+CODE_LANGUAGES = {"default", "python", "pycon3", "pycon"}
 """The set of languages we support being exported as a notebook."""
 
 

--- a/lib/esbonio-extensions/pyproject.toml
+++ b/lib/esbonio-extensions/pyproject.toml
@@ -44,7 +44,7 @@ showcontent = true
 legacy_tox_ini = """
 [tox]
 isolated_build = True
-envlist = py{37,38,39,310}
+envlist = py{37,38,39,310,311}
 
 [testenv]
 deps =

--- a/lib/esbonio-extensions/setup.cfg
+++ b/lib/esbonio-extensions/setup.cfg
@@ -17,6 +17,7 @@ classifiers =
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     Topic :: Documentation
     Topic :: Documentation :: Sphinx
 platforms = any

--- a/lib/esbonio-extensions/tests/conftest.py
+++ b/lib/esbonio-extensions/tests/conftest.py
@@ -1,7 +1,7 @@
 import pathlib
 from unittest import mock
 
-import py.test
+import pytest
 from docutils.io import StringInput
 from docutils.parsers.rst import Parser
 from docutils.parsers.rst import directives
@@ -11,7 +11,7 @@ from sphinx.ext.doctest import DoctestDirective
 from esbonio.tutorial import Solution
 
 
-@py.test.fixture(scope="session")
+@pytest.fixture(scope="session")
 def testdata():
     """Given the name of a file in the data/ folder and return its contents.
 
@@ -32,7 +32,7 @@ def testdata():
     return loader
 
 
-@py.test.fixture(scope="session")
+@pytest.fixture(scope="session")
 def rst_mock_settings():
     """Return a mock that can pretend to be the settings object needed to parse rst
     sources.
@@ -71,7 +71,7 @@ def rst_mock_settings():
     return settings
 
 
-@py.test.fixture(scope="session")
+@pytest.fixture(scope="session")
 def parse_rst(rst_mock_settings):
     """A fixture that attempts to produce a doctree from rst source in a representative
     environment."""

--- a/lib/esbonio-extensions/tests/test_tutorial.py
+++ b/lib/esbonio-extensions/tests/test_tutorial.py
@@ -1,12 +1,12 @@
 import pathlib
 
 import nbformat.v4 as nbformat
-import py.test
+import pytest
 
 import esbonio.tutorial as tutorial
 
 
-@py.test.mark.parametrize(
+@pytest.mark.parametrize(
     "name",
     [
         "bare_link",

--- a/lib/esbonio/changes/470.misc.rst
+++ b/lib/esbonio/changes/470.misc.rst
@@ -1,0 +1,1 @@
+Add Python 3.11 support

--- a/lib/esbonio/pyproject.toml
+++ b/lib/esbonio/pyproject.toml
@@ -67,7 +67,7 @@ legacy_tox_ini = """
 [tox]
 isolated_build = True
 skip_missing_interpreters = true
-envlist = py{36,37,38,39}-sphinx{3,4,5}, py310-sphinx{4,5}
+envlist = py{36,37,38,39}-sphinx{3,4,5}, py{310,311}-sphinx{4,5}
 
 [testenv]
 deps =
@@ -80,7 +80,7 @@ deps =
 extras = test
 commands =
     python ../../scripts/check-sphinx-version.py
-    py{38,39,310}-sphinx5: mypy --namespace-packages --explicit-package-bases -p esbonio
+    py{38,39,310,311}-sphinx5: mypy --namespace-packages --explicit-package-bases -p esbonio
     pytest {posargs}
 
 [testenv:pkg]

--- a/lib/esbonio/setup.cfg
+++ b/lib/esbonio/setup.cfg
@@ -24,17 +24,20 @@ classifiers =
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     Topic :: Documentation
     Topic :: Documentation :: Sphinx
 platforms = any
 
 [options]
 packages = find_namespace:
+python_requires = >=3.6
 include_package_data = True
 install_requires =
     appdirs
     sphinx
-    pygls>=0.11.0,<1.0
+    pygls>=0.11.0,<1.0 ; python_version<"3.11"
+    pygls>=0.12.4,<1.0 ; python_version>="3.11"
     pyspellchecker
     typing-extensions
 

--- a/lib/esbonio/tests/sphinx-default/test_sd_symbols.py
+++ b/lib/esbonio/tests/sphinx-default/test_sd_symbols.py
@@ -1,7 +1,7 @@
 from typing import List
 from typing import Optional
 
-import py.test
+import pytest
 from pygls.lsp.types import DocumentSymbol
 from pygls.lsp.types import Position
 from pygls.lsp.types import Range
@@ -61,7 +61,7 @@ def symbol(
     )
 
 
-@py.test.mark.parametrize(
+@pytest.mark.parametrize(
     "filepath,expected",
     [
         ("conf.py", None),

--- a/scripts/make-release.sh
+++ b/scripts/make-release.sh
@@ -128,8 +128,6 @@ if [ "${GITHUB_REF}" = "refs/heads/release" ]; then
     pandoc CHANGES.rst -f rst -t gfm -o CHANGELOG.md
 
     # Export info that can be picked up in later steps.
-    echo "::set-output name=VERSION::${VERSION}"
-    echo "::set-output name=TAG::${TAG}"
-    echo "::set-output name=DATE::${DATE}"
-
+    echo "VERSION=${VERSION}" >> $GITHUB_ENV
+    echo "RELEASE_DATE::${RELEASE_DATE}" >> $GITHUB_ENV
 fi


### PR DESCRIPTION
This splits the monolithic `release.yml` workflow definition up into a number of smaller workflows
- `vscode-pr.yml`: for testing PRs against the VSCode extension
- `lsp-pr.yml`: for testing PRs against the language server
- `sphinx-ext-pr.yml` for testing PRs against the sphinx extensions.
- `docs.yml` for validating PRs and publishing changes made against the docs

`release.yml` still remains, but now is only for making releases.

Also, version numbers of actions used have been bumped where possible, unmaintained actions have been removed. Closes #462 