### PR TITLE
Refactor Roles Support

### DIFF
--- a/docs/lsp/extending.rst
+++ b/docs/lsp/extending.rst
@@ -10,6 +10,7 @@ This section of the documentation outlines the server's architecture and how you
    :maxdepth: 1
 
    extending/directives
+   extending/roles
    extending/api-reference
 
 .. _lsp_architecture:

--- a/docs/lsp/extending/api-reference.rst
+++ b/docs/lsp/extending/api-reference.rst
@@ -61,29 +61,6 @@ Language Features
    :members:
 
 
-Roles
-^^^^^
-
-.. currentmodule:: esbonio.lsp.roles
-
-.. autodata:: ROLE
-   :annotation: = re.compile(...)
-
-.. autodata:: DEFAULT_ROLE
-   :annotation: = re.compile(...)
-
-.. autoclass:: Roles
-   :members: add_documentation, add_target_definition_provider, add_target_completion_provider, add_target_link_provider
-
-.. autoclass:: TargetCompletion
-   :members:
-
-.. autoclass:: TargetDefinition
-   :members:
-
-.. autoclass:: TargetLink
-   :members:
-
 Testing
 -------
 

--- a/docs/lsp/extending/roles.rst
+++ b/docs/lsp/extending/roles.rst
@@ -1,0 +1,49 @@
+Roles
+=====
+
+How To Guides
+-------------
+
+The following guides outlne how to extens the language server to add support for your custom roles.
+
+.. toctree::
+   :glob:
+   :maxdepth: 1
+
+   roles/*
+
+API Reference
+-------------
+
+.. currentmodule:: esbonio.lsp.roles
+
+.. autoclass:: Roles
+   :members: add_documentation,
+             add_feature,
+             add_target_completion_provider,
+             add_target_definition_provider,
+             add_target_link_provider,
+             get_documentation,
+             get_implementation,
+             get_roles,
+             resolve_target_link,
+             suggest_roles,
+             suggest_targets
+
+.. autoclass:: RoleLanguageFeature
+   :members:
+
+.. autodata:: esbonio.lsp.util.patterns.ROLE
+   :no-value:
+
+.. autodata:: esbonio.lsp.util.patterns.DEFAULT_ROLE
+   :no-value:
+
+.. autoclass:: TargetDefinition
+   :members:
+
+.. autoclass:: TargetCompletion
+   :members:
+
+.. autoclass:: TargetLink
+   :members:

--- a/docs/lsp/extending/roles/role-registry.rst
+++ b/docs/lsp/extending/roles/role-registry.rst
@@ -1,0 +1,123 @@
+Supporting Custom Role Registries
+=================================
+
+.. currentmodule:: esbonio.lsp.roles
+
+This guide walks through the process of teaching the language server how to discover roles stored in a custom registry.
+Once complete, the following LSP features should start working with your roles.
+
+- Basic role completions i.e. ``:role-name:`` but no target completions.
+- Documentation hovers (assuming you've provided documentation)
+- Goto Implementation
+
+.. note::
+
+   You may not need this guide.
+
+   If you're registering your role directly with
+   `docutils <https://docutils.sourceforge.io/docs/howto/rst-roles.html#register-the-role>`__ or
+   `sphinx <https://www.sphinx-doc.org/en/master/extdev/appapi.html#sphinx.application.Sphinx.add_role>`__,
+   or using a `custom domain <https://www.sphinx-doc.org/en/master/extdev/domainapi.html>`__
+   then you should find that the language server already has basic support for your custom roles out of the box.
+
+   This guide is indended for adding support for roles that are not registered in a standard location.
+
+Still here? Great! Let's get started.
+
+Indexing Roles
+--------------
+
+As an example, we'll walk through the steps required to add (basic) support for Sphinx domains to the language server.
+
+.. note::
+
+   For the sake of brevity, some details have been omitted from the code examples below.
+
+   If you're interested, you can find the actual implementation of the ``DomainRoles`` class
+   `here <https://github.com/swyddfa/esbonio/blob/release/lib/esbonio/esbonio/lsp/sphinx/domains.py>`__.
+
+So that the server can discover the available roles, we have to provide a :class:`RoleLanguageFeature` that implements the :meth:`~RoleLanguageFeature.index_roles` method.
+This method should return a dictionary where the keys are the canonical name of the role which map to the function that implements it::
+
+   class DomainRoles(RoleLanguageFeature):
+       def __init__(self, app: Sphinx):
+           self.app = app   # Sphinx application instance.
+
+       def index_roles(self) -> Dict[str, Any]:
+           roles = {}
+           for prefix, domain in self.app.domains.items():
+               for name, role in domain.roles.items():
+                   roles[f"{prefix}:{name}"] = role
+
+           return roles
+
+In the case of Sphinx domains a role's canonical name is of the form ``<domain>:<role>`` e.g. ``py:func`` or ``c:macro``.
+
+This is the bare minimum required to make the language server aware of your custom roles, in fact if you were to try the above implementation you would already find completions being offered for domain based roles.
+However, you would also notice that the short form of roles (e.g. ``func``) in the :ref:`standard <sphinx:domains-std>` and :confval:`primary <sphinx:primary_domain>` domains are not included in the list of completions - despite being valid.
+
+To remedy this, you might be tempted to start adding multiple entries to the dictionary, one for each valid name **do not do this.**
+Instead you can implement the :meth:`~RoleLanguageFeature.suggest_roles` method which solves this exact use case.
+
+.. tip::
+
+   If you want to play around with your own version of the ``DomainRoles`` class you can disable the built in version by:
+
+   - Passing the ``--exclude esbonio.lsp.sphinx.domains`` cli option, or
+   - If you're using VSCode adding ``esbonio.lsp.sphinx.domains`` to the :confval:`esbonio.server.excludedModules (string[])` option.
+
+(Optional) Suggesting Roles
+---------------------------
+
+The :meth:`~RoleLanguageFeature.suggest_roles` method is called each time the server is generating role completions.
+It can be used to tailor the list of roles that are offered to the user, depending on the current context.
+Each ``RoleLanguageFeature`` has a default implementation, which may be sufficient depending on your use case::
+
+   def suggest_roles(self, context: CompletionContext) -> Iterable[Tuple[str, Any]]:
+       """Suggest roles that may be used, given a completion context."""
+       return self.index_roles().items()
+
+However, in the case of Sphinx domains, we need to modify this to also include the short form of the roles in the standard and primary domains::
+
+   def suggest_roles(self, context: CompletionContext) -> Iterable[Tuple[str, Any]]:
+       roles = self.index_roles()
+       primary_domain = self.app.config.primary_domain
+
+       for key, role in roles.items():
+
+           if key.startswith("std:"):
+               roles[key.replace("std:", "")] = role
+
+           if primary_domain and key.startswith(f"{primary_domain}:"):
+               roles[key.replace(f"{primary_domain}:", "")] = role
+
+      return roles.items()
+
+Now if you were to try this version, the short forms of the relevant directives would be offered as completion suggestions, but you would also notice that features like documentation hovers still don't work.
+This is due to the language server not knowing which class implements these short form directives.
+
+(Optional) Implementation Lookups
+---------------------------------
+
+The :meth:`~RoleLanguageFeature.get_implementation` method is used by the language server to take a role's name and lookup its implementation.
+This powers features such as documentation hovers and goto implementation.
+As with ``suggest_roles``, each ``RoleLanguageFeature`` has a default implementation which may be sufficient for your use case::
+
+    def get_implementation(self, role: str, domain: Optional[str]) -> Optional[Any]:
+        """Return the implementation for the given role name."""
+        return self.index_roles().get(role, None)
+
+In the case of Sphinx domains, if we see a directive without a domain prefix we need to see if it belongs to the standard or primary domains::
+
+    def get_implementation(self, role: str, domain: Optional[str]) -> Optional[Any]:
+        roles = self.index_roles()
+
+        if domain is not None:
+            return roles.get(f"{domain}:{role}", None)
+
+        primary_domain = self.app.config.primary_domain
+        impl = roles.get(f"{primary_domain}:{role}", None)
+        if impl is not None:
+            return impl
+
+        return roles.get(f"std:{role}", None)

--- a/lib/esbonio/changes/416.enhancement.rst
+++ b/lib/esbonio/changes/416.enhancement.rst
@@ -1,0 +1,1 @@
+Completion suggestions will now also be generated for the long form (``:py:func:``) of roles and directives in the primary and standard Sphinx domains.

--- a/lib/esbonio/changes/495.api.rst
+++ b/lib/esbonio/changes/495.api.rst
@@ -1,0 +1,11 @@
+``RoleLanguageFeatures`` have been introduced as the preferred method of extending role support going forward.
+Subclasses can be implement any of the following methods
+
+- ``complete_targets`` called when generating role target completion items
+- ``find_target_definitions`` used to implement goto definition for role targets
+- ``get_implementation`` used to get the implementation of a role given its name
+- ``index_roles`` used to tell the language server which roles exist
+- ``resolve_target_link`` used to implement document links for role targets
+- ``suggest_roles`` called when generating role completion suggestions
+
+and are registered using the new ``Roles.add_feature()`` method.

--- a/lib/esbonio/changes/495.deprecated.rst
+++ b/lib/esbonio/changes/495.deprecated.rst
@@ -1,0 +1,20 @@
+The following protocols have been deprecated and will be removed in ``v1.0``
+
+- ``TargetDefinition``
+- ``TargetCompletion``
+- ``TargetLink``
+
+The following methods have been deprecated and will be removed in ``v1.0``
+
+- ``Roles.add_target_definition_provider``
+- ``Roles.add_target_link_provider``
+- ``Roles.add_target_completion_provider``
+- ``RstLanguageServer.get_roles()``
+- ``SphinxLanguageServer.get_domain()``
+- ``SphinxLanguageServer.get_domains()``
+- ``SphinxLanguageServer.get_roles()``
+- ``SphinxLanguageServer.get_role_target_types()``
+- ``SphinxLanguageServer.get_role_targets()``
+- ``SphinxLanguageServer.get_intersphinx_targets()``
+- ``SphinxLanguageServer.has_intersphinx_targets()``
+- ``SphinxLanguageServer.get_intersphinx_projects()``

--- a/lib/esbonio/esbonio/lsp/roles.py
+++ b/lib/esbonio/esbonio/lsp/roles.py
@@ -1,7 +1,9 @@
 """Role support."""
 import typing
+import warnings
 from typing import Any
 from typing import Dict
+from typing import Iterable
 from typing import List
 from typing import Optional
 from typing import Tuple
@@ -31,8 +33,98 @@ from esbonio.lsp.util.patterns import DIRECTIVE
 from esbonio.lsp.util.patterns import ROLE
 
 
+class RoleLanguageFeature:
+    """Base class for role language features."""
+
+    def complete_targets(
+        self, context: CompletionContext, name: str, domain: str
+    ) -> List[CompletionItem]:
+        """Return a list of completion items representing valid targets for the given
+        role.
+
+        Parameters
+        ----------
+        context
+           The completion context
+
+        name
+           The name of the role to generate completion suggestions for.
+
+        domain
+           The name of the domain the role is a member of
+        """
+        return []
+
+    def find_target_definitions(
+        self, context: DefinitionContext, name: str, domain: str, label: str
+    ) -> List[Location]:
+        """Return a list of locations representing the definition of the given role
+        target.
+
+        Parameters
+        ----------
+        doc:
+           The document containing the match
+        match:
+           The match object that triggered the definition request
+        name:
+           The name of the role
+        domain:
+           The domain the role is part of, if applicable.
+        """
+        return []
+
+    def get_implementation(self, role: str, domain: str) -> Optional[Any]:
+        """Return the implementation for the given role name.
+
+        Parameters
+        ----------
+        role
+           The name of the role
+
+        domain
+           The domain the role belongs to, if any
+        """
+        return self.index_roles().get(role, None)
+
+    def index_roles(self) -> Dict[str, Any]:
+        """Return all known roles."""
+        return dict()
+
+    def resolve_target_link(
+        self, context: DocumentLinkContext, name: str, domain: Optional[str], label: str
+    ) -> Tuple[Optional[str], Optional[str]]:
+        """Return a link corresponding to the given target.
+
+        Parameters
+        ----------
+        context
+           The document link context
+
+        domain
+           The name (if applicable) of the domain the role is a member of
+
+        name
+           The name of the role to generate completion suggestions for.
+
+        label
+           The label of the target to provide the link for
+        """
+        return None, None
+
+    def suggest_roles(self, context: CompletionContext) -> Iterable[Tuple[str, Any]]:
+        """Suggest roles that may be used, given a completion context."""
+        return self.index_roles().items()
+
+
 class TargetDefinition(Protocol):
-    """A definition provider for role targets"""
+    """A definition provider for role targets.
+
+    .. deprecated:: xxx
+
+       This will be removed in ``v1.0``, use a subclass of
+       :class:`~esbonio.lsp.roles.RoleLanguageFeature` instead.
+    """
 
     def find_definitions(
         self, context: DefinitionContext, name: str, domain: Optional[str]
@@ -54,7 +146,13 @@ class TargetDefinition(Protocol):
 
 
 class TargetCompletion(Protocol):
-    """A completion provider for role targets"""
+    """A completion provider for role targets.
+
+    .. deprecated:: xxx
+
+       This will be removed in ``v1.0``, use a subclass of
+       :class:`~esbonio.lsp.roles.RoleLanguageFeature` instead.
+    """
 
     def complete_targets(
         self, context: CompletionContext, name: str, domain: Optional[str]
@@ -74,7 +172,13 @@ class TargetCompletion(Protocol):
 
 
 class TargetLink(Protocol):
-    """A document link provider for role targets"""
+    """A document link provider for role targets.
+
+    .. deprecated:: xxx
+
+       This will be removed in ``v1.0``, use a subclass of
+       :class:`~esbonio.lsp.roles.RoleLanguageFeature` instead.
+    """
 
     def resolve_link(
         self, context: DocumentLinkContext, name: str, domain: Optional[str], label: str
@@ -106,45 +210,126 @@ class Roles(LanguageFeature):
         self._documentation: Dict[str, Dict[str, str]] = {}
         """Cache for documentation."""
 
-        self._target_definition_providers: List[TargetDefinition] = []
-        """A list of providers that locate the definition for the given role target."""
+        self._features: Dict[str, RoleLanguageFeature] = {}
+        """Collection of registered features"""
 
-        self._target_link_providers: List[TargetLink] = []
-        """A list of providers that resolve document links for role targets."""
+    def add_feature(self, feature: RoleLanguageFeature):
+        """Register a role language feature
 
-        self._target_completion_providers: List[TargetCompletion] = []
-        """A list of providers that give completion suggestions for role target
-        objects."""
+        Parameters
+        ----------
+        feature
+           The role language feature
+        """
+        key = f"{feature.__module__}.{feature.__class__.__name__}"
+
+        # Create a unique key for this instance.
+        if key in self._features:
+            key += f".{len([k for k in self._features.keys() if k.startswith(key)])}"
+
+        self._features[key] = feature
 
     def add_target_definition_provider(self, provider: TargetDefinition) -> None:
         """Register a :class:`~esbonio.lsp.roles.TargetDefinition` provider.
 
+        .. deprecated:: xxx
+
+           This will be removed in ``v1.0`` use
+           :meth:`~esbonio.lsp.roles.Roles.add_feature` with a
+           :class:`~esbonio.lsp.roles.RoleLanguageFeature` subclass instead.
+
         Parameters
         ----------
         provider
            The provider to register
         """
-        self._target_definition_providers.append(provider)
+
+        warnings.warn(
+            "TargetDefinition providers are deprecated in favour of "
+            "RoleLanguageFeatures, this method will be removed in v1.0",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
+        name = provider.__class__.__name__
+        key = f"{provider.__module__}.{name}.definition"
+
+        def find_target_definitions(self, context, name, domain, label):
+            return provider.find_definitions(context, name, domain)
+
+        feature = type(
+            f"{name}TargetDefinitionProvider",
+            (RoleLanguageFeature,),
+            {"find_target_definitions": find_target_definitions},
+        )()
+
+        self._features[key] = feature
 
     def add_target_link_provider(self, provider: TargetLink) -> None:
         """Register a :class:`~esbonio.lsp.roles.TargetLink` provider.
 
+        .. deprecated:: xxx
+
+           This will be removed in ``v1.0`` use
+           :meth:`~esbonio.lsp.roles.Roles.add_feature` with a
+           :class:`~esbonio.lsp.roles.RoleLanguageFeature` subclass instead.
+
         Parameters
         ----------
         provider
            The provider to register
         """
-        self._target_link_providers.append(provider)
+
+        warnings.warn(
+            "TargetLink providers are deprecated in favour of "
+            "RoleLanguageFeatures, this method will be removed in v1.0",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
+        name = provider.__class__.__name__
+        key = f"{provider.__module__}.{name}.link"
+
+        feature = type(
+            f"{name}TargetLinkProvider",
+            (RoleLanguageFeature,),
+            {"resolve_target_link": provider.resolve_link},
+        )()
+
+        self._features[key] = feature
 
     def add_target_completion_provider(self, provider: TargetCompletion) -> None:
         """Register a :class:`~esbonio.lsp.roles.TargetCompletion` provider.
 
+        .. deprecated:: xxx
+
+           This will be removed in ``v1.0`` use
+           :meth:`~esbonio.lsp.roles.Roles.add_feature` with a
+           :class:`~esbonio.lsp.roles.RoleLanguageFeature` subclass instead.
+
         Parameters
         ----------
         provider
            The provider to register
         """
-        self._target_completion_providers.append(provider)
+
+        warnings.warn(
+            "TargetCompletion providers are deprecated in favour of "
+            "RoleLanguageFeatures, this method will be removed in v1.0",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
+        name = provider.__class__.__name__
+        key = f"{provider.__module__}.{name}.completion"
+
+        feature = type(
+            f"{name}TargetCompletionProvider",
+            (RoleLanguageFeature,),
+            {"complete_targets": provider.complete_targets},
+        )()
+
+        self._features[key] = feature
 
     def add_documentation(self, documentation: Dict[str, Dict[str, Any]]) -> None:
         """Register role documentation.
@@ -222,13 +407,36 @@ class Roles(LanguageFeature):
 
     def definition(self, context: DefinitionContext) -> List[Location]:
 
-        domain = context.match.group("domain") or None
+        domain = context.match.group("domain") or ""
         name = context.match.group("name")
+        label = context.match.group("label")
+
+        # Be sure to only match complete roles
+        if not label or not context.match.group(0).endswith("`"):
+            return []
+
+        return self.find_target_definitions(context, name, domain, label)
+
+    def find_target_definitions(
+        self, context: DefinitionContext, name: str, domain: str, label: str
+    ) -> List[Location]:
 
         definitions = []
 
-        for provide in self._target_definition_providers:
-            definitions += provide.find_definitions(context, name, domain) or []
+        for feature_name, feature in self._features.items():
+            try:
+                definitions += feature.find_target_definitions(
+                    context, name, domain, label
+                )
+            except Exception:
+                self.logger.error(
+                    "Unable to find definitions of '%s' for role ':%s:', "
+                    "error in feature: '%s'",
+                    label,
+                    f"{domain}:{name}" if domain else name,
+                    feature_name,
+                    exc_info=True,
+                )
 
         return definitions
 
@@ -247,15 +455,7 @@ class Roles(LanguageFeature):
                 domain = match.group("domain")
                 name = match.group("name")
 
-                target = None
-                tooltip = None
-                for provider in self._target_link_providers:
-                    target, tooltip = provider.resolve_link(
-                        context, name, domain, label
-                    )
-                    if target:
-                        break
-
+                target, tooltip = self.resolve_target_link(context, name, domain, label)
                 if not target:
                     continue
 
@@ -263,18 +463,43 @@ class Roles(LanguageFeature):
                 start = match.start() + idx
                 end = start + len(label)
 
-                links.append(
-                    DocumentLink(
-                        target=target,
-                        tooltip=tooltip if context.tooltip_support else None,
-                        range=Range(
-                            start=Position(line=line, character=start),
-                            end=Position(line=line, character=end),
-                        ),
-                    )
+                link = DocumentLink(
+                    target=target,
+                    tooltip=tooltip if context.tooltip_support else None,
+                    range=Range(
+                        start=Position(line=line, character=start),
+                        end=Position(line=line, character=end),
+                    ),
                 )
 
+                links.append(link)
+
         return links
+
+    def resolve_target_link(
+        self, context: DocumentLinkContext, name: str, domain: str, label: str
+    ) -> Tuple[Optional[str], Optional[str]]:
+        """Resolve a given document link."""
+
+        for feature_name, feature in self._features.items():
+            try:
+                target, tooltip = feature.resolve_target_link(
+                    context, name, domain, label
+                )
+
+                if target:
+                    return target, tooltip
+            except Exception:
+                self.logger.error(
+                    "Unable to resolve target link '%s' for role ':%s:', "
+                    "error in feature: '%s'",
+                    label,
+                    f"{domain}:{name}" if domain else name,
+                    feature_name,
+                    exc_info=True,
+                )
+
+        return None, None
 
     def complete(self, context: CompletionContext) -> List[CompletionItem]:
         """Generate completion suggestions relevant to the current context.
@@ -348,6 +573,24 @@ class Roles(LanguageFeature):
 
         return item
 
+    def suggest_roles(self, context: CompletionContext) -> Iterable[Tuple[str, Any]]:
+        """Suggest roles that may be used, given a completion context.
+
+        Parameters
+        ----------
+        context
+           The completion context
+        """
+        for name, feature in self._features.items():
+            try:
+                yield from feature.suggest_roles(context)
+            except Exception:
+                self.logger.error(
+                    "Unable to suggest roles, error in feature: '%s'",
+                    name,
+                    exc_info=True,
+                )
+
     def complete_roles(self, context: CompletionContext) -> List[CompletionItem]:
 
         match = context.match
@@ -364,7 +607,7 @@ class Roles(LanguageFeature):
             end=Position(line=context.position.line, character=end),
         )
 
-        for name, role in self.rst.get_roles().items():
+        for name, role in self.suggest_roles(context):
 
             if not name.startswith(domain):
                 continue
@@ -404,6 +647,25 @@ class Roles(LanguageFeature):
 
         item.documentation = MarkupContent(kind=kind, value=description)
         return item
+
+    def suggest_targets(
+        self, context: CompletionContext, name: str, domain: str
+    ) -> List[CompletionItem]:
+
+        targets = []
+
+        for feature_name, feature in self._features.items():
+            try:
+                targets += feature.complete_targets(context, name, domain)
+            except Exception:
+                self.logger.error(
+                    "Unable to suggest targets for role ':%s:', error in feature: '%s'",
+                    f"{domain}:{name}" if domain else name,
+                    feature_name,
+                    exc_info=True,
+                )
+
+        return targets
 
     def complete_targets(self, context: CompletionContext) -> List[CompletionItem]:
         """Generate the list of role target completion suggestions."""
@@ -446,30 +708,27 @@ class Roles(LanguageFeature):
         prefix = context.match.group(0)[start:]
         modifier = groups["modifier"] or ""
 
-        for provide in self._target_completion_providers:
-            candidates = provide.complete_targets(context, name, domain) or []
+        for candidate in self.suggest_targets(context, name, domain):
 
-            for candidate in candidates:
+            # Don't interfere with items that already carry a `text_edit`, allowing
+            # some providers (like filepaths) to do something special.
+            if not candidate.text_edit:
+                new_text = candidate.insert_text or candidate.label
 
-                # Don't interfere with items that already carry a `text_edit`, allowing
-                # some providers (like filepaths) to do something special.
-                if not candidate.text_edit:
-                    new_text = candidate.insert_text or candidate.label
+                # This is rather annoying, but `filter_text` needs to start with
+                # the text we are going to replace, otherwise VSCode won't show our
+                # suggestions!
+                candidate.filter_text = f"{prefix}{new_text}"
 
-                    # This is rather annoying, but `filter_text` needs to start with
-                    # the text we are going to replace, otherwise VSCode won't show our
-                    # suggestions!
-                    candidate.filter_text = f"{prefix}{new_text}"
+                candidate.text_edit = TextEdit(
+                    range=range_, new_text=f"{modifier}{new_text}"
+                )
+                candidate.insert_text = None
 
-                    candidate.text_edit = TextEdit(
-                        range=range_, new_text=f"{modifier}{new_text}"
-                    )
-                    candidate.insert_text = None
+            if not candidate.text_edit.new_text.endswith(endchars):
+                candidate.text_edit.new_text += endchars
 
-                if not candidate.text_edit.new_text.endswith(endchars):
-                    candidate.text_edit.new_text += endchars
-
-                targets.append(candidate)
+            targets.append(candidate)
 
         return targets
 
@@ -490,12 +749,10 @@ class Roles(LanguageFeature):
 
         return self.hover_role(context, name, domain)
 
-    def hover_role(
-        self, context: HoverContext, name: str, domain: Optional[str]
-    ) -> str:
+    def hover_role(self, context: HoverContext, name: str, domain: str) -> str:
 
         label = f"{domain}:{name}" if domain else name
-        role = self.rst.get_roles().get(label, None)
+        role = self.get_implementation(name, domain)
         if not role:
             return ""
 
@@ -516,6 +773,55 @@ class Roles(LanguageFeature):
         # TODO: Add extension point for providers to contribute hovers for a target.
         return ""
 
+    def get_roles(self) -> Dict[str, Any]:
+        """Return a dictionary of all known roles."""
+
+        roles = {}
+
+        for name, feature in self._features.items():
+            self.logger.debug("calling '%s'", name)
+            try:
+                roles.update(feature.index_roles())
+            except Exception:
+                self.logger.error(
+                    "Unable to index roles, error in feature '%s'", name, exc_info=True
+                )
+
+        return roles
+
+    def get_implementation(self, role: str, domain: str) -> Optional[Any]:
+        """Return the implementation of a role given its name
+
+        Parameters
+        ----------
+        role
+           The name of the role.
+
+        domain
+           The domain of the role, if applicable.
+        """
+
+        if domain:
+            name = f"{domain}:{role}"
+        else:
+            name = role
+
+        for feature_name, feature in self._features.items():
+            try:
+                impl = feature.get_implementation(role, domain)
+                if impl is not None:
+                    return impl
+            except Exception:
+                self.logger.error(
+                    "Unable to get implementation for ':%s:', error in feature: '%s'\n%s",
+                    name,
+                    feature_name,
+                    exc_info=True,
+                )
+
+        self.logger.debug("Unable to get implementation for ':%s:', unknown role", name)
+        return None
+
     def implementation(self, context: ImplementationContext) -> List[Location]:
 
         region = context.match.group("role")
@@ -534,18 +840,13 @@ class Roles(LanguageFeature):
         return []
 
     def find_role_implementation(
-        self, context: ImplementationContext, name: str, domain: Optional[str]
+        self, context: ImplementationContext, name: str, domain: str
     ) -> List[Location]:
 
-        roles = self.rst.get_roles()
-        key = f"{domain}:{name}" if domain is not None else name
-        self.logger.debug("Key is: '%s'", key)
-
-        impl = roles.get(key, None)
+        impl = self.get_implementation(name, domain)
         if impl is None:
             return []
 
-        self.logger.debug("Getting implementation of '%s' (%s)", key, impl)
         location = get_object_location(impl, self.logger)
         if location is not None:
             return [location]

--- a/lib/esbonio/esbonio/lsp/rst/__init__.py
+++ b/lib/esbonio/esbonio/lsp/rst/__init__.py
@@ -15,7 +15,6 @@ from typing import Tuple
 from typing import Type
 from typing import TypeVar
 
-import docutils.parsers.rst.roles as docutils_roles
 import pygls.uris as Uri
 from docutils.parsers.rst import Directive
 from pydantic import BaseModel
@@ -429,12 +428,6 @@ class RstLanguageServer(LanguageServer):
         self._features: Dict[str, LanguageFeature] = {}
         """The collection of language features registered with the server."""
 
-        self._directives: Optional[Dict[str, Directive]] = None
-        """Cache for known directives."""
-
-        self._roles: Optional[Dict[str, Any]] = None
-        """Cache for known roles."""
-
     @property
     def configuration(self) -> Dict[str, Any]:
         """Return the server's actual configuration."""
@@ -647,20 +640,27 @@ class RstLanguageServer(LanguageServer):
         return directive.option_spec or {}
 
     def get_roles(self) -> Dict[str, Any]:
-        """Return a dictionary of known roles."""
+        """Return a dictionary of known roles.
 
-        if self._roles is not None:
-            return self._roles
+        .. deprecated:: xxx
 
-        found_roles = {**docutils_roles._roles, **docutils_roles._role_registry}
+           This will be removed in ``v1.0``.
+           Use the :meth:`~esbonio.lsp.roles.Roles.get_roles` method instead.
+        """
+        clsname = self.__class__.__name__
+        warnings.warn(
+            f"{clsname}.get_roles() is deprecated and will be removed in v1.0. "
+            "Instead call the get_roles() method on the Roles language "
+            "feature.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
 
-        self._roles = {
-            k: v
-            for k, v in found_roles.items()
-            if v != docutils_roles.unimplemented_role
-        }
+        feature = self.get_feature("esbonio.lsp.roles.Roles")
+        if feature is None:
+            return {}
 
-        return self._roles
+        return feature.get_roles()  # type: ignore
 
     def get_default_role(self) -> Tuple[Optional[str], Optional[str]]:
         """Return the default role for the project."""

--- a/lib/esbonio/esbonio/lsp/rst/roles.py
+++ b/lib/esbonio/esbonio/lsp/rst/roles.py
@@ -1,11 +1,51 @@
 import json
+from typing import Any
+from typing import Dict
+from typing import Optional
 
+import docutils.parsers.rst.roles as docutils_roles
 import pkg_resources
 
+from esbonio.lsp.roles import RoleLanguageFeature
 from esbonio.lsp.roles import Roles
 from esbonio.lsp.rst import RstLanguageServer
 
 
+class Docutils(RoleLanguageFeature):
+    """Support for docutils' built-in roles."""
+
+    def __init__(self) -> None:
+
+        self._roles: Optional[Dict[str, Any]] = None
+        """Cache for known roles."""
+
+    @property
+    def roles(self) -> Dict[str, Any]:
+        if self._roles is not None:
+            return self._roles
+
+        found_roles = {**docutils_roles._roles, **docutils_roles._role_registry}
+
+        self._roles = {
+            k: v
+            for k, v in found_roles.items()
+            if v != docutils_roles.unimplemented_role
+        }
+
+        return self._roles
+
+    def get_implementation(self, role: str, domain: str):
+        if domain:
+            return None
+
+        return self.roles.get(role, None)
+
+    def index_roles(self) -> Dict[str, Any]:
+        return self.roles
+
+
 def esbonio_setup(rst: RstLanguageServer, roles: Roles):
-    docutils_docs = pkg_resources.resource_string("esbonio.lsp.rst", "roles.json")
-    roles.add_documentation(json.loads(docutils_docs.decode("utf8")))
+    documentation = pkg_resources.resource_string("esbonio.lsp.rst", "roles.json")
+
+    roles.add_documentation(json.loads(documentation.decode("utf8")))
+    roles.add_feature(Docutils())

--- a/lib/esbonio/esbonio/lsp/sphinx/__init__.py
+++ b/lib/esbonio/esbonio/lsp/sphinx/__init__.py
@@ -477,6 +477,10 @@ class SphinxLanguageServer(RstLanguageServer):
     def get_domain(self, name: str) -> Optional[Domain]:
         """Return the domain with the given name.
 
+        .. deprecated:: xxx
+
+           This will be removed in ``v1.0``
+
         If a domain with the given name cannot be found, this method will return None.
 
         Parameters
@@ -484,6 +488,13 @@ class SphinxLanguageServer(RstLanguageServer):
         name:
            The name of the domain
         """
+
+        clsname = self.__class__.__name__
+        warnings.warn(
+            f"{clsname}.get_domains() is deprecated and will be removed in v1.0.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
 
         if self.app is None or self.app.env is None:
             return None
@@ -494,6 +505,10 @@ class SphinxLanguageServer(RstLanguageServer):
     def get_domains(self) -> Iterator[Tuple[str, Domain]]:
         """Get all the domains registered with an applications.
 
+        .. deprecated:: xxx
+
+           This will be removed in ``v1.0``
+
         Returns a generator that iterates through all of an application's domains,
         taking into account configuration variables such as ``primary_domain``.
         Yielded values will be a tuple of the form ``(prefix, domain)`` where
@@ -503,6 +518,13 @@ class SphinxLanguageServer(RstLanguageServer):
         - ``domain`` is the domain object itself.
 
         """
+
+        clsname = self.__class__.__name__
+        warnings.warn(
+            f"{clsname}.get_domains() is deprecated and will be removed in v1.0.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
 
         if self.app is None or self.app.env is None:
             return []
@@ -553,23 +575,6 @@ class SphinxLanguageServer(RstLanguageServer):
 
         return options or {}
 
-    def get_roles(self) -> Dict[str, Any]:
-        """Return a dictionary of known roles."""
-
-        if self._roles is not None:
-            return self._roles
-
-        self._roles = super().get_roles()
-
-        for prefix, domain in self.get_domains():
-            fmt = "{prefix}:{name}" if prefix else "{name}"
-
-            for name, role in domain.roles.items():
-                key = fmt.format(name=name, prefix=prefix)
-                self._roles[key] = role
-
-        return self._roles
-
     def get_default_role(self) -> Tuple[Optional[str], Optional[str]]:
         """Return the project's default role"""
 
@@ -594,6 +599,10 @@ class SphinxLanguageServer(RstLanguageServer):
         """Return a map indicating which object types a role is capable of linking
         with.
 
+        .. deprecated:: xxx
+
+           This will be removed in ``v1.0``
+
         For example
 
         .. code-block:: python
@@ -603,6 +612,14 @@ class SphinxLanguageServer(RstLanguageServer):
                "class": ["class", "exception"]
            }
         """
+
+        clsname = self.__class__.__name__
+        warnings.warn(
+            f"{clsname}.get_role_target_types() is deprecated and will be removed in "
+            "v1.0.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
 
         key = f"{domain_name}:{name}" if domain_name else name
 
@@ -638,6 +655,14 @@ class SphinxLanguageServer(RstLanguageServer):
            The domain the role is a part of, if applicable.
         """
 
+        clsname = self.__class__.__name__
+        warnings.warn(
+            f"{clsname}.get_role_targets() is deprecated and will be removed in "
+            "v1.0.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
         targets: List[tuple] = []
         domain_obj: Optional[Domain] = None
 
@@ -664,7 +689,20 @@ class SphinxLanguageServer(RstLanguageServer):
         return targets
 
     def get_intersphinx_projects(self) -> List[str]:
-        """Return the list of configured intersphinx project names."""
+        """Return the list of configured intersphinx project names.
+
+        .. deprecated:: xxx
+
+           This will be removed in ``v.1.0``
+        """
+
+        clsname = self.__class__.__name__
+        warnings.warn(
+            f"{clsname}.get_intersphinx_projects() is deprecated and will be removed in "
+            "v1.0.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
 
         if self.app is None:
             return []
@@ -678,6 +716,10 @@ class SphinxLanguageServer(RstLanguageServer):
         """Return ``True`` if the given intersphinx project has targets targeted by the
         given role.
 
+        .. deprecated:: xxx
+
+           This will be removed in ``v1.0``
+
         Parameters
         ----------
         project:
@@ -687,6 +729,14 @@ class SphinxLanguageServer(RstLanguageServer):
         domain:
            The domain the role is a part of, if applicable.
         """
+
+        clsname = self.__class__.__name__
+        warnings.warn(
+            f"{clsname}.has_intersphinx_targets() is deprecated and will be removed in "
+            "v1.0.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
 
         targets = self.get_intersphinx_targets(project, name, domain)
 
@@ -700,6 +750,10 @@ class SphinxLanguageServer(RstLanguageServer):
     ) -> Dict[str, Dict[str, tuple]]:
         """Return the intersphinx objects targeted by the given role.
 
+        .. deprecated:: xxx
+
+           This will be removed in ``v1.0``
+
         Parameters
         ----------
         project:
@@ -709,6 +763,14 @@ class SphinxLanguageServer(RstLanguageServer):
         domain:
            The domain the role is a part of, if applicable.
         """
+
+        clsname = self.__class__.__name__
+        warnings.warn(
+            f"{clsname}.get_intersphinx_targets() is deprecated and will be removed in "
+            "v1.0.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
 
         if self.app is None:
             return {}

--- a/lib/esbonio/esbonio/lsp/sphinx/domains.py
+++ b/lib/esbonio/esbonio/lsp/sphinx/domains.py
@@ -1,5 +1,6 @@
 """Support for Sphinx domains."""
 import pathlib
+from typing import Any
 from typing import Dict
 from typing import Iterable
 from typing import List
@@ -23,6 +24,7 @@ from esbonio.lsp import DefinitionContext
 from esbonio.lsp import DocumentLinkContext
 from esbonio.lsp.directives import DirectiveLanguageFeature
 from esbonio.lsp.directives import Directives
+from esbonio.lsp.roles import RoleLanguageFeature
 from esbonio.lsp.roles import Roles
 from esbonio.lsp.sphinx import SphinxLanguageServer
 
@@ -38,14 +40,10 @@ TARGET_KINDS = {
 }
 
 
-class DomainDirectives(DirectiveLanguageFeature):
-    """Support for directives coming from Sphinx's domains."""
+class DomainHelpers:
+    """Common methods that work on domains."""
 
-    def __init__(self, rst: SphinxLanguageServer):
-        self.rst = rst
-
-        self._directives: Optional[Dict[str, Directive]] = None
-        """Cache for known directives."""
+    rst: SphinxLanguageServer
 
     @property
     def domains(self) -> Dict[str, Domain]:
@@ -55,6 +53,25 @@ class DomainDirectives(DirectiveLanguageFeature):
             return dict()
 
         return self.rst.app.env.domains  # type: ignore
+
+    def get_default_domain(self, uri: str) -> Optional[str]:
+        """Return the default domain for the given uri."""
+
+        # TODO: Add support for .. default-domain::
+        if self.rst.app is not None:
+            return self.rst.app.config.primary_domain
+
+        return None
+
+
+class DomainDirectives(DirectiveLanguageFeature, DomainHelpers):
+    """Support for directives coming from Sphinx's domains."""
+
+    def __init__(self, rst: SphinxLanguageServer):
+        self.rst = rst
+
+        self._directives: Optional[Dict[str, Directive]] = None
+        """Cache for known directives."""
 
     @property
     def directives(self) -> Dict[str, Directive]:
@@ -69,15 +86,6 @@ class DomainDirectives(DirectiveLanguageFeature):
 
         self._directives = directives
         return self._directives
-
-    def get_default_domain(self, uri: str) -> Optional[str]:
-        """Return the default domain for the given uri."""
-
-        # TODO: Add support for .. default-domain::
-        if self.rst.app is not None:
-            return self.rst.app.config.primary_domain
-
-        return None
 
     def get_implementation(
         self, directive: str, domain: Optional[str]
@@ -132,71 +140,183 @@ class DomainDirectives(DirectiveLanguageFeature):
         return impl.option_spec.keys()
 
 
-class DomainFeatures:
+class DomainRoles(RoleLanguageFeature, DomainHelpers):
+    """Support for roles coming from Sphinx's domains."""
+
     def __init__(self, rst: SphinxLanguageServer):
         self.rst = rst
-        self.logger = rst.logger.getChild(self.__class__.__name__)
+
+        self._roles: Optional[Dict[str, Any]] = None
+        """Cache for known roles."""
+
+        self._role_target_types: Optional[Dict[str, List[str]]] = None
+        """Cache for role target types."""
+
+    @property
+    def roles(self) -> Dict[str, Any]:
+
+        if self._roles is not None:
+            return self._roles
+
+        roles = {}
+        for prefix, domain in self.domains.items():
+            for name, role in domain.roles.items():
+                roles[f"{prefix}:{name}"] = role
+
+        self._roles = roles
+        return self._roles
+
+    @property
+    def role_target_types(self) -> Dict[str, List[str]]:
+
+        if self._role_target_types is not None:
+            return self._role_target_types
+
+        self._role_target_types = {}
+
+        for prefix, domain in self.domains.items():
+            fmt = "{prefix}:{name}" if prefix else "{name}"
+
+            for name, item_type in domain.object_types.items():
+                for role in item_type.roles:
+                    role_key = fmt.format(name=role, prefix=prefix)
+                    target_types = self._role_target_types.get(role_key, list())
+                    target_types.append(name)
+
+                    self._role_target_types[role_key] = target_types
+
+        return self._role_target_types
+
+    def _get_role_target_types(self, name: str, domain: str = "") -> List[str]:
+        """Return a list indicating which object types a role is capable of linking
+        with.
+        """
+
+        if domain:
+            return self.role_target_types.get(f"{domain}:{name}", [])
+
+        # Try the primary domain
+        if self.rst.app and self.rst.app.config.primary_domain:
+            key = f"{self.rst.app.config.primary_domain}:{name}"
+
+            if key in self.role_target_types:
+                return self.role_target_types[key]
+
+        # Finally try the standard domain
+        return self.role_target_types.get(f"std:{name}", [])
+
+    def _get_role_targets(self, name: str, domain: str = "") -> List[tuple]:
+        """Return a list of objects targeted by the given role.
+
+        Parameters
+        ----------
+        name:
+           The name of the role
+        domain:
+           The domain the role is a part of, if applicable.
+        """
+
+        targets: List[tuple] = []
+        domain_obj: Optional[Domain] = None
+
+        if domain:
+            domain_obj = self.domains.get(domain, None)
+        else:
+            std = self.domains.get("std", None)
+            if std and name in std.roles:
+                domain_obj = std
+
+            elif self.rst.app and self.rst.app.config.primary_domain:
+                domain_obj = self.domains.get(self.rst.app.config.primary_domain, None)
+
+        target_types = set(self._get_role_target_types(name, domain))
+
+        if not domain_obj:
+            self.rst.logger.debug(
+                "Unable to find domain for role '%s:%s'", domain, name
+            )
+            return []
+
+        for obj in domain_obj.get_objects():
+            if obj[2] in target_types:
+                targets.append(obj)
+
+        return targets
+
+    def get_implementation(
+        self, role: str, domain: Optional[str]
+    ) -> Optional[Directive]:
+
+        if domain is not None:
+            return self.roles.get(f"{domain}:{role}", None)
+
+        if self.rst.app is None:
+            return None
+
+        # Try the default domain
+        primary_domain = self.rst.app.config.primary_domain
+        impl = self.roles.get(f"{primary_domain}:{role}", None)
+        if impl is not None:
+            return impl
+
+        # Try the std domain
+        return self.roles.get(f"std:{role}", None)
+
+    def index_roles(self) -> Dict[str, Any]:
+        return self.roles
+
+    def suggest_roles(self, context: CompletionContext) -> Iterable[Tuple[str, Any]]:
+
+        # In addition to providing each role fully qulaified, we should provide a
+        # suggestion for directives in the std and primary domains without the prefix.
+        items = self.roles.copy()
+        primary_domain = self.get_default_domain(context.doc.uri)
+
+        for key, role in self.roles.items():
+
+            if key.startswith("std:"):
+                items[key.replace("std:", "")] = role
+                continue
+
+            if primary_domain and key.startswith(f"{primary_domain}:"):
+                items[key.replace(f"{primary_domain}:", "")] = role
+
+        return items.items()
 
     def complete_targets(
-        self, context: CompletionContext, name: str, domain: Optional[str]
+        self, context: CompletionContext, name: str, domain: str
     ) -> List[CompletionItem]:
 
-        groups = context.match.groupdict()
-        domain = domain or ""
-        label = groups["label"]
+        label = context.match.group("label")
 
+        # Intersphinx targets contain ':' characters.
         if ":" in label:
-            return self.complete_intersphinx_targets(name, domain, label)
+            return []
 
-        items = [
-            object_to_completion_item(o)
-            for o in self.rst.get_role_targets(name, domain)
+        return [
+            object_to_completion_item(obj)
+            for obj in self._get_role_targets(name, domain)
         ]
 
-        for project in self.rst.get_intersphinx_projects():
-            if self.rst.has_intersphinx_targets(project, name, domain):
-                items.append(project_to_completion_item(project))
-
-        return items
-
-    def complete_intersphinx_targets(
-        self, name: str, domain: str, label: str
-    ) -> List[CompletionItem]:
-        items = []
-        project, *_ = label.split(":")
-        intersphinx_targets = self.rst.get_intersphinx_targets(project, name, domain)
-
-        for type_, targets in intersphinx_targets.items():
-            items += [
-                intersphinx_target_to_completion_item(project, label, target, type_)
-                for label, target in targets.items()
-            ]
-
-        return items
-
-    def resolve_link(
+    def resolve_target_link(
         self, context: DocumentLinkContext, name: str, domain: Optional[str], label: str
     ) -> Tuple[Optional[str], Optional[str]]:
         """``textDocument/documentLink`` support"""
 
-        # We can support intersphinx links.
+        # Ignore intersphinx references.
         if ":" in label:
-            return self.resolve_intersphinx(name, domain, label)
-
-        # We can also support local `:doc:` roles.
-        if not domain and name == "doc":
-            return self.resolve_doc(context.doc, label), None
+            return None, None
 
         # Other roles like :ref: do not make sense as the ``textDocument/documentLink``
         # api doesn't support specific locations like goto definition does.
+        if (domain is not None and domain != "std") or name != "doc":
+            return None, None
 
-        return None, None
+        return self.resolve_doc(context.doc, label), None
 
-    def find_definitions(
-        self, context: DefinitionContext, name: str, domain: Optional[str]
+    def find_target_definitions(
+        self, context: DefinitionContext, name: str, domain: str, label: str
     ) -> List[Location]:
-
-        label = context.match.group("label")
 
         if not domain and name == "ref":
             return self.ref_definition(label)
@@ -205,6 +325,23 @@ class DomainFeatures:
             return self.doc_definition(context.doc, label)
 
         return []
+
+    def resolve_doc(self, doc: Document, label: str) -> Optional[str]:
+        if self.rst.app is None:
+            return None
+
+        srcdir = self.rst.app.srcdir
+        currentdir = pathlib.Path(Uri.to_fs_path(doc.uri)).parent
+
+        if label.startswith("/"):
+            path = pathlib.Path(srcdir, label[1:] + ".rst")
+        else:
+            path = pathlib.Path(currentdir, label + ".rst")
+
+        if not path.exists():
+            return None
+
+        return Uri.from_fs_path(str(path))
 
     def doc_definition(self, doc: Document, label: str) -> List[Location]:
         """Goto definition implementation for ``:doc:`` targets"""
@@ -229,8 +366,8 @@ class DomainFeatures:
         if not self.rst.app or not self.rst.app.env:
             return []
 
-        types = set(self.rst.get_role_target_types("ref"))
-        std = self.rst.get_domain("std")
+        types = set(self._get_role_target_types("ref"))
+        std = self.domains["std"]
         if std is None:
             return []
 
@@ -271,46 +408,6 @@ class DomainFeatures:
             )
         ]
 
-    def resolve_doc(self, doc: Document, label: str) -> Optional[str]:
-
-        if self.rst.app is None:
-            return None
-
-        srcdir = self.rst.app.srcdir
-        currentdir = pathlib.Path(Uri.to_fs_path(doc.uri)).parent
-
-        if label.startswith("/"):
-            path = pathlib.Path(srcdir, label[1:] + ".rst")
-        else:
-            path = pathlib.Path(currentdir, label + ".rst")
-
-        if not path.exists():
-            return None
-
-        return Uri.from_fs_path(str(path))
-
-    def resolve_intersphinx(
-        self, name: str, domain: Optional[str], label: str
-    ) -> Tuple[Optional[str], Optional[str]]:
-        """Resolve an intersphinx reference to a URL"""
-
-        if not self.rst.app:
-            return None, None
-
-        project, *parts = label.split(":")
-        label = ":".join(parts)
-        targets = self.rst.get_intersphinx_targets(project, name, domain or "")
-
-        for _, items in targets.items():
-            if label in items:
-                source, version, url, display = items[label]
-                name = label if display == "-" else display
-                tooltip = f"{name} - {source} v{version}"
-
-                return url, tooltip
-
-        return None, None
-
     def find_docname_for_label(
         self, label: str, domain: Domain, types: Optional[Set[str]] = None
     ) -> Optional[str]:
@@ -319,11 +416,13 @@ class DomainFeatures:
 
         Parameters
         ----------
-        label:
+        label
            The label to search for
-        domain:
+
+        domain
            The domain to search within
-        types:
+
+        types
            A collection of object types that the label chould have.
         """
 
@@ -340,6 +439,155 @@ class DomainFeatures:
                 break
 
         return docname
+
+
+class Intersphinx(RoleLanguageFeature):
+    def __init__(self, rst: SphinxLanguageServer, domain: DomainRoles):
+        self.rst = rst
+        self.domain = domain
+
+    def complete_targets(
+        self, context: CompletionContext, name: str, domain: str
+    ) -> List[CompletionItem]:
+
+        label = context.match.group("label")
+
+        # Intersphinx targets contain ':' characters.
+        if ":" in label:
+            return self.complete_intersphinx_targets(name, domain, label)
+
+        return self.complete_intersphinx_projects(name, domain)
+
+    def complete_intersphinx_projects(
+        self, name: str, domain: str
+    ) -> List[CompletionItem]:
+
+        items = []
+        for project in self.get_intersphinx_projects():
+            if not self.has_intersphinx_targets(project, name, domain):
+                continue
+
+            items.append(
+                CompletionItem(
+                    label=project, detail="intersphinx", kind=CompletionItemKind.Module
+                )
+            )
+
+        return items
+
+    def complete_intersphinx_targets(
+        self, name: str, domain: str, label: str
+    ) -> List[CompletionItem]:
+        items = []
+        project, *_ = label.split(":")
+        intersphinx_targets = self.get_intersphinx_targets(project, name, domain)
+
+        for type_, targets in intersphinx_targets.items():
+            items += [
+                intersphinx_target_to_completion_item(project, label, target, type_)
+                for label, target in targets.items()
+            ]
+
+        return items
+
+    def resolve_target_link(
+        self, context: DocumentLinkContext, name: str, domain: Optional[str], label: str
+    ) -> Tuple[Optional[str], Optional[str]]:
+
+        if not self.rst.app:
+            return None, None
+
+        project, *parts = label.split(":")
+        label = ":".join(parts)
+        targets = self.get_intersphinx_targets(project, name, domain or "")
+
+        for _, items in targets.items():
+            if label in items:
+                source, version, url, display = items[label]
+                name = label if display == "-" else display
+                tooltip = f"{name} - {source} v{version}"
+
+                return url, tooltip
+
+        return None, None
+
+    def get_intersphinx_projects(self) -> List[str]:
+        """Return the list of configured intersphinx project names."""
+
+        if self.rst.app is None:
+            return []
+
+        inv = getattr(self.rst.app.env, "intersphinx_named_inventory", {})
+        return list(inv.keys())
+
+    def has_intersphinx_targets(
+        self, project: str, name: str, domain: str = ""
+    ) -> bool:
+        """Return ``True`` if the given intersphinx project has targets targeted by the
+        given role.
+
+        Parameters
+        ----------
+        project
+           The project to check
+
+        name
+           The name of the role
+
+        domain
+           The domain the role is a part of, if applicable.
+        """
+        targets = self.get_intersphinx_targets(project, name, domain)
+
+        if len(targets) == 0:
+            return False
+
+        return any([len(items) > 0 for items in targets.values()])
+
+    def get_intersphinx_targets(
+        self, project: str, name: str, domain: str = ""
+    ) -> Dict[str, Dict[str, tuple]]:
+        """Return the intersphinx objects targeted by the given role.
+
+        Parameters
+        ----------
+        project
+           The project to return targets from
+
+        name
+           The name of the role
+
+        domain
+           The domain the role is a part of, if applicable.
+        """
+
+        if self.rst.app is None:
+            return {}
+
+        inv = getattr(self.rst.app.env, "intersphinx_named_inventory", {})
+        if project not in inv:
+            return {}
+
+        targets = {}
+        inv = inv[project]
+
+        for target_type in self.domain._get_role_target_types(name, domain):
+
+            explicit_domain = f"{domain}:{target_type}"
+            if explicit_domain in inv:
+                targets[target_type] = inv[explicit_domain]
+                continue
+
+            primary_domain = f'{self.rst.app.config.primary_domain or ""}:{target_type}'
+            if primary_domain in inv:
+                targets[target_type] = inv[primary_domain]
+                continue
+
+            std_domain = f"std:{target_type}"
+            if std_domain in inv:
+                targets[target_type] = inv[std_domain]
+
+        return targets
 
 
 def intersphinx_target_to_completion_item(
@@ -390,17 +638,11 @@ def object_to_completion_item(object_: tuple) -> CompletionItem:
     )
 
 
-def project_to_completion_item(project: str) -> CompletionItem:
-    return CompletionItem(
-        label=project, detail="intersphinx", kind=CompletionItemKind.Module
-    )
-
-
-def esbonio_setup(rst: SphinxLanguageServer, roles: Roles, directives: Directives):
-    domains = DomainFeatures(rst)
-
-    roles.add_target_definition_provider(domains)
-    roles.add_target_completion_provider(domains)
-    roles.add_target_link_provider(domains)
-
+def esbonio_setup(rst: SphinxLanguageServer, directives: Directives, roles: Roles):
     directives.add_feature(DomainDirectives(rst))
+
+    domain_roles = DomainRoles(rst)
+    intersphinx = Intersphinx(rst, domain_roles)
+
+    roles.add_feature(domain_roles)
+    roles.add_feature(intersphinx)

--- a/lib/esbonio/tests/sphinx-default/test_sd_roles.py
+++ b/lib/esbonio/tests/sphinx-default/test_sd_roles.py
@@ -17,10 +17,10 @@ from esbonio.lsp.testing import role_patterns
 from esbonio.lsp.testing import sphinx_version
 
 C_EXPECTED = {"c:func", "c:macro"}
-C_UNEXPECTED = {"py:func", "py:mod"}
+C_UNEXPECTED = {"restructuredtext-unimplemented-role"}
 
 EXPECTED = {"doc", "func", "mod", "ref", "c:func"}
-UNEXPECTED = {"py:func", "py:mod", "restructuredtext-unimplemented-role"}
+UNEXPECTED = {"restructuredtext-unimplemented-role"}
 
 
 @pytest.mark.asyncio

--- a/lib/esbonio/tests/sphinx-default/test_sd_sphinx_domains.py
+++ b/lib/esbonio/tests/sphinx-default/test_sd_sphinx_domains.py
@@ -93,8 +93,8 @@ from esbonio.lsp.testing import role_target_patterns
             role_target_patterns("py:func"),
             [
                 (
-                    None,
                     {"pythagoras.calc_hypotenuse", "pythagoras.calc_side"},
+                    None,
                 ),
             ],
         ),
@@ -116,7 +116,7 @@ from esbonio.lsp.testing import role_target_patterns
         *itertools.product(
             role_target_patterns("py:meth"),
             [
-                (None, {"pythagoras.Triangle.is_right_angled"}),
+                ({"pythagoras.Triangle.is_right_angled"}, None),
             ],
         ),
         *itertools.product(
@@ -143,7 +143,6 @@ from esbonio.lsp.testing import role_target_patterns
             role_target_patterns("py:obj"),
             [
                 (
-                    None,
                     {
                         "pythagoras",
                         "pythagoras.PI",
@@ -156,6 +155,7 @@ from esbonio.lsp.testing import role_target_patterns
                         "pythagoras.calc_hypotenuse",
                         "pythagoras.calc_side",
                     },
+                    None,
                 ),
             ],
         ),

--- a/lib/esbonio/tests/sphinx-extensions/test_se_roles.py
+++ b/lib/esbonio/tests/sphinx-extensions/test_se_roles.py
@@ -10,11 +10,8 @@ from pytest_lsp import check
 from esbonio.lsp.testing import completion_request
 from esbonio.lsp.testing import role_patterns
 
-EXPECTED = {"doc", "py:func", "py:mod", "ref", "func"}
-UNEXPECTED = {"c:func", "c:macro", "restructuredtext-unimplemented-role"}
-
-PY_EXPECTED = {"py:func", "py:mod"}
-PY_UNEXPECTED = {"c:func", "c:macro"}
+EXPECTED = {"doc", "py:func", "py:mod", "ref", "func", "c:func", "c:macro"}
+UNEXPECTED = {"restructuredtext-unimplemented-role"}
 
 
 @pytest.mark.asyncio
@@ -31,7 +28,7 @@ PY_UNEXPECTED = {"c:func", "c:macro"}
         ),
         *itertools.product(
             role_patterns(":py:"),
-            [(PY_EXPECTED, PY_UNEXPECTED)],
+            [(EXPECTED, UNEXPECTED)],
         ),
         *itertools.product(
             role_patterns(":c:"),

--- a/lib/esbonio/tests/unit_tests/test_roles.py
+++ b/lib/esbonio/tests/unit_tests/test_roles.py
@@ -1,7 +1,311 @@
-import pytest
+import logging
+import sys
+from typing import Any
+from typing import Dict
+from typing import List
+from typing import Optional
+from typing import Tuple
 
+import pytest
+from pygls.lsp.types import CompletionItem
+from pygls.lsp.types import Location
+from pygls.lsp.types import Position
+from pygls.lsp.types import Range
+
+from esbonio.lsp import CompletionContext
+from esbonio.lsp import DefinitionContext
+from esbonio.lsp import DocumentLinkContext
 from esbonio.lsp.roles import DEFAULT_ROLE
 from esbonio.lsp.roles import ROLE
+from esbonio.lsp.roles import RoleLanguageFeature
+from esbonio.lsp.roles import Roles
+
+if sys.version_info.minor < 8:
+    from mock import Mock
+else:
+    from unittest.mock import Mock
+
+
+logger = logging.getLogger(__name__)
+
+
+class Simple(RoleLanguageFeature):
+    """A simple role language feature for use in tests."""
+
+    def __init__(self, names: List[str]):
+        self.roles = {name: lambda x: x for name in names}
+
+    def index_roles(self) -> Dict[str, Any]:
+        """Return all known roles."""
+        return self.roles
+
+    def complete_targets(
+        self, context: CompletionContext, name: str, domain: Optional[str]
+    ) -> List[CompletionItem]:
+        if name not in self.roles:
+            return []
+
+        return [CompletionItem(label=f"{r}-{name}") for r in self.roles]
+
+    def find_target_definitions(
+        self, context: DefinitionContext, name: str, domain: str, label: str
+    ) -> List[Location]:
+
+        if name not in self.roles:
+            return []
+
+        return [
+            Location(
+                uri=f"file:///{name}.rst",
+                range=Range(
+                    start=Position(line=1, character=0),
+                    end=Position(line=2, character=0),
+                ),
+            )
+        ]
+
+    def resolve_target_link(
+        self, context: DocumentLinkContext, name: str, domain: Optional[str], label: str
+    ) -> Tuple[Optional[str], Optional[str]]:
+
+        if name not in self.roles:
+            return None, None
+
+        return f"file:///{name}.rst", None
+
+    # The default `suggest_roles` implementation should be sufficient.
+    # The default `get_implementation` implementation should be sufficient.
+
+
+class Broken(RoleLanguageFeature):
+    """A role language feature that only throws exceptions."""
+
+    def index_roles(self) -> Dict[str, Any]:
+        """Return all known roles."""
+        raise NotImplementedError()
+
+    def complete_targets(
+        self, context: CompletionContext, name: str, domain: Optional[str]
+    ) -> List[CompletionItem]:
+        raise NotImplementedError()
+
+    def find_target_definitions(
+        self, context: DefinitionContext, name: str, domain: str, label: str
+    ) -> List[Location]:
+        raise NotImplementedError()
+
+    def resolve_target_link(
+        self, context: DocumentLinkContext, name: str, domain: Optional[str], label: str
+    ) -> Tuple[Optional[str], Optional[str]]:
+        raise NotImplementedError()
+
+    # The default `suggest_roles` implementation should be sufficient.
+    # The default `get_implementation` implementation should be sufficient.
+
+
+@pytest.fixture()
+def simple():
+    """A simple functional instance of the roles language feature"""
+
+    f1 = Simple(["one", "two"])
+    f2 = Simple(["three", "four"])
+
+    roles = Roles(Mock())
+    roles.add_feature(f1)
+    roles.add_feature(f2)
+
+    return roles
+
+
+@pytest.fixture()
+def broken():
+    """An instance of the roles language feature with sub features that will throw
+    errors."""
+
+    f1 = Simple(["one", "two"])
+    f2 = Broken()
+    f3 = Simple(["three", "four"])
+
+    roles = Roles(Mock())
+    roles.add_feature(f1)
+    roles.add_feature(f2)
+    roles.add_feature(f3)
+
+    return roles
+
+
+def test_get_roles(simple: Roles):
+    """Ensure that we can correctly combine roles from multiple sources."""
+
+    items = simple.get_roles()
+    assert list(items.keys()) == ["one", "two", "three", "four"]
+
+    # All should be well
+    simple.logger.error.assert_not_called()
+
+
+def test_get_roles_error(broken: Roles):
+    """Ensure that we can gracefully handle errors in role langauge features."""
+
+    items = broken.get_roles()
+    assert list(items.keys()) == ["one", "two", "three", "four"]
+
+    # The error should have been logged.
+    broken.logger.error.assert_called_once()
+    args = broken.logger.error.call_args.args
+    assert args[0].startswith("Unable to index roles")
+
+
+def test_get_implementation(simple: Roles):
+    """Ensure that we can correctly look up roles from multiple sources."""
+
+    impl = simple.get_implementation("one", None)
+    assert callable(impl)
+
+    impl = simple.get_implementation("four", None)
+    assert callable(impl)
+
+    # All should be well
+    simple.logger.error.assert_not_called()
+
+
+def test_get_implementation_error(broken: Roles):
+    """Ensure that we can gracefully handle errors in role language features."""
+
+    impl = broken.get_implementation("four", None)
+    assert callable(impl)
+
+    # The error should've been logged
+    broken.logger.error.assert_called_once()
+    args = broken.logger.error.call_args.args
+    assert args[0].startswith("Unable to get implementation for")
+
+
+def test_suggest_roles(simple: Roles):
+    """Ensure that we can correctly combine roles from multiple sources."""
+
+    context = CompletionContext(
+        doc=Mock(), location="rst", match=Mock(), position=Mock(), capabilities=Mock()
+    )
+
+    items = simple.suggest_roles(context)
+    assert [i[0] for i in items] == ["one", "two", "three", "four"]
+    assert all([callable(i[1]) for i in items])
+
+    # All should be well
+    simple.logger.error.assert_not_called()
+
+
+def test_suggest_roles_error(broken: Roles):
+    """Ensure that we can gracefully handle errors in role language features."""
+
+    context = CompletionContext(
+        doc=Mock(), location="rst", match=Mock(), position=Mock(), capabilities=Mock()
+    )
+
+    items = broken.suggest_roles(context)
+    assert [i[0] for i in items] == ["one", "two", "three", "four"]
+    assert all([callable(i[1]) for i in items])
+
+    # The error should've been logged
+    broken.logger.error.assert_called_once()
+    args = broken.logger.error.call_args.args
+    assert args[0].startswith("Unable to suggest roles")
+
+
+def test_find_target_definitions(simple: Roles):
+    """Ensure that we can find target definitions using multiple sources."""
+
+    context = DefinitionContext(
+        doc=Mock(), location="rst", match=Mock(), position=Mock()
+    )
+
+    locations = simple.find_target_definitions(context, "one", "", "example")
+    assert locations[0].uri == "file:///one.rst"
+
+    locations = simple.find_target_definitions(context, "four", "", "example")
+    assert locations[0].uri == "file:///four.rst"
+
+    # All should be well
+    simple.logger.error.assert_not_called()
+
+
+def test_find_target_definitions_error(broken: Roles):
+    """Ensure that we can gracefully handle errors in role language features."""
+
+    context = DefinitionContext(
+        doc=Mock(), location="rst", match=Mock(), position=Mock()
+    )
+
+    locations = broken.find_target_definitions(context, "four", "", "example")
+    assert locations[0].uri == "file:///four.rst"
+
+    # The error should've been logged
+    broken.logger.error.assert_called_once()
+    args = broken.logger.error.call_args.args
+    assert args[0].startswith("Unable to find definitions")
+
+
+def test_resolve_target_link(simple: Roles):
+    """Ensure that we can resolve links using multiple sources."""
+
+    context = DocumentLinkContext(doc=Mock(), capabilities=Mock())
+
+    target, _ = simple.resolve_target_link(context, "one", "", "example")
+    assert target == "file:///one.rst"
+
+    target, _ = simple.resolve_target_link(context, "four", "", "example")
+    assert target == "file:///four.rst"
+
+    # All should be well
+    simple.logger.error.assert_not_called()
+
+
+def test_resolve_target_link_error(broken: Roles):
+    """Ensure that we can gracefully handle errors in role language features."""
+
+    context = DocumentLinkContext(doc=Mock(), capabilities=Mock())
+
+    target, _ = broken.resolve_target_link(context, "four", "", "example")
+    assert target == "file:///four.rst"
+
+    # The error should've been logged
+    broken.logger.error.assert_called_once()
+    args = broken.logger.error.call_args.args
+    assert args[0].startswith("Unable to resolve target link")
+
+
+def test_suggest_targets(simple: Roles):
+    """Ensure that we can collect target completions from multiple sources."""
+
+    context = CompletionContext(
+        doc=Mock(), location="rst", match=Mock(), position=Mock(), capabilities=Mock()
+    )
+
+    items = simple.suggest_targets(context, "one", "")
+    assert [i.label for i in items] == ["one-one", "two-one"]
+
+    items = simple.suggest_targets(context, "four", "")
+    assert [i.label for i in items] == ["three-four", "four-four"]
+
+    # All should be well
+    simple.logger.error.assert_not_called()
+
+
+def test_suggest_targets_error(broken: Roles):
+    """Ensure that we can gracefully handle errors in role language features."""
+
+    context = CompletionContext(
+        doc=Mock(), location="rst", match=Mock(), position=Mock(), capabilities=Mock()
+    )
+
+    items = broken.suggest_targets(context, "four", "")
+    assert [i.label for i in items] == ["three-four", "four-four"]
+
+    # The error should've been logged
+    broken.logger.error.assert_called_once()
+    args = broken.logger.error.call_args.args
+    assert args[0].startswith("Unable to suggest targets for")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Similar to #444 and #453, this introduces `RoleLanguageFeatures` as the preferred method of extending role support moving forward. The following methods are currently supported

- `complete_targets` called when generating role target completion items
- `find_target_definitions` used to implement goto definition for role targets
- `get_implementation` used to get the implementation of a role given its name
- `index_roles` used to tell the language server which roles exist
- `resolve_target_link` used to implement document links for role targets
- `suggest_roles` called when generating role completion suggestions

This should allow for features like #464 to be implemented

As a result the following methods/protocols have been deprecated and will be removed in ``v1.0``

- `TargetDefinition`
- `TargetCompletion`
- `TargetLink`
- `Roles.add_target_definition_provider()`
- `Roles.add_target_link_provider()`
- `Roles.add_target_completion_provider()`
- `RstLanguageServer.get_roles()`
- `SphinxLanguageServer.get_domain()`
- `SphinxLanguageServer.get_domains()`
- `SphinxLanguageServer.get_roles()`
- `SphinxLanguageServer.get_role_target_types()`
- `SphinxLanguageServer.get_role_targets()`
- `SphinxLanguageServer.get_intersphinx_targets()`
- `SphinxLanguageServer.has_intersphinx_targets()`
- `SphinxLanguageServer.get_intersphinx_projects()`

Closes #416 