### PR TITLE
Directive fixes

### DIFF
--- a/docs/lsp/extending/directives.rst
+++ b/docs/lsp/extending/directives.rst
@@ -24,6 +24,7 @@ API Reference
              add_documentation,
              add_feature,
              get_directives,
+             get_documentation,
              get_implementation,
              suggest_directives,
              suggest_options

--- a/docs/lsp/extending/directives/directive-registry.rst
+++ b/docs/lsp/extending/directives/directive-registry.rst
@@ -6,23 +6,24 @@ Supporting Custom Directive Registries
 This guide walks through the process of teaching the language server how to discover directives stored in a custom registry.
 Once complete, the following LSP features should start working with your directives.
 
-- Basic directive completions i.e. ``.. directive-name::`` but no argument or option completions.
-- Documentation hovers (assuming you've provided documentation)
-- Goto Implementation
+- Basic directive completions i.e. ``.. directive-name::`` but no argument completions.
+- Basic option key completions i.e. ``:option-name:`` assuming options are declared in a directive's ``option_spec``, but no option value completions.
+- Documentation hovers assuming you've provided documentation.
+- Goto Implementation.
 
 .. note::
 
    You may not need this guide.
 
    If you're registering your directive directly with
-   `docutils <https://docutils.sourceforge.io/docs/howto/rst-directives.html#toc-entry-4>`__ or
+   `docutils <https://docutils.sourceforge.io/docs/howto/rst-directives.html#register-the-directive>`__ or
    `sphinx <https://www.sphinx-doc.org/en/master/extdev/appapi.html#sphinx.application.Sphinx.add_directive>`__,
    or using a `custom domain <https://www.sphinx-doc.org/en/master/extdev/domainapi.html>`__
    then you should find that the language server already has basic support for your custom directives out of the box.
 
-   This guide is indended for tools that maintain their own set of directives in a separate store to the standard locations.
+   This guide is indended for adding support for directives that are not registered in a standard location.
 
-Still here? Great! Let's get started
+Still here? Great! Let's get started.
 
 Indexing Directives
 -------------------
@@ -61,7 +62,7 @@ Instead you can implement the :meth:`~DirectiveLanguageFeature.suggest_directive
 
 .. tip::
 
-   If you do want to play around with your own version of the ``DomainDirectives`` class you can disable the built in version by:
+   If you want to play around with your own version of the ``DomainDirectives`` class you can disable the built in version by:
 
    - Passing the ``--exclude esbonio.lsp.sphinx.domains`` cli option, or
    - If you're using VSCode adding ``esbonio.lsp.sphinx.domains`` to the :confval:`esbonio.server.excludedModules (string[])` option.
@@ -92,7 +93,7 @@ However, in the case of Sphinx domains, we need to modify this to also include t
 
         return directives.items()
 
-Now if you were to try this version, the short forms of the relevant directives would be offered as completion suggestions, but you would notice features like documentation hovers still don't work.
+Now if you were to try this version, the short forms of the relevant directives would be offered as completion suggestions, but you would also notice that features like documentation hovers still don't work.
 This is due to the language server not knowing which class implements these short form directives.
 
 (Optional) Implementation Lookups

--- a/lib/esbonio/changes/498.enhancement.rst
+++ b/lib/esbonio/changes/498.enhancement.rst
@@ -1,0 +1,1 @@
+The default ``suggest_options`` implementation for ``DirectiveLanguageFeatures`` should now be more useful in that it will return the keys from a directive's ``option_spec``

--- a/lib/esbonio/changes/498.fix.rst
+++ b/lib/esbonio/changes/498.fix.rst
@@ -1,1 +1,3 @@
 The language server should now correctly handle errors that occur while generating completion suggestions for a directive's options
+
+The language server should now show hovers for directives in the primary domain.

--- a/lib/esbonio/changes/498.fix.rst
+++ b/lib/esbonio/changes/498.fix.rst
@@ -1,0 +1,1 @@
+The language server should now correctly handle errors that occur while generating completion suggestions for a directive's options

--- a/lib/esbonio/esbonio/lsp/directives.py
+++ b/lib/esbonio/esbonio/lsp/directives.py
@@ -665,23 +665,22 @@ class Directives(LanguageFeature):
             end=Position(line=context.position.line, character=end),
         )
 
-        for feature in self._features.values():
-            for option in feature.suggest_options(context, name, domain):
-                insert_text = f":{option}:"
+        for option in self.suggest_options(context, name, domain):
+            insert_text = f":{option}:"
 
-                items.append(
-                    CompletionItem(
-                        label=option,
-                        detail=f"{impl_name}:{option}",
-                        kind=CompletionItemKind.Field,
-                        filter_text=insert_text,
-                        text_edit=TextEdit(range=range_, new_text=insert_text),
-                        data={
-                            "completion_type": "directive_option",
-                            "for_directive": name,
-                        },
-                    )
+            items.append(
+                CompletionItem(
+                    label=option,
+                    detail=f"{impl_name}:{option}",
+                    kind=CompletionItemKind.Field,
+                    filter_text=insert_text,
+                    text_edit=TextEdit(range=range_, new_text=insert_text),
+                    data={
+                        "completion_type": "directive_option",
+                        "for_directive": name,
+                    },
                 )
+            )
 
         return items
 

--- a/lib/esbonio/esbonio/lsp/directives.py
+++ b/lib/esbonio/esbonio/lsp/directives.py
@@ -825,7 +825,7 @@ class Directives(LanguageFeature):
         label = f"{domain}:{name}" if domain else name
         self.logger.debug("Calculating hover for directive '%s'", label)
 
-        directive = self.rst.get_directives().get(label, None)
+        directive = self.get_implementation(name, domain)
         if not directive:
             return ""
 

--- a/lib/esbonio/esbonio/lsp/directives.py
+++ b/lib/esbonio/esbonio/lsp/directives.py
@@ -436,12 +436,15 @@ class Directives(LanguageFeature):
     def get_implementation(
         self, directive: str, domain: Optional[str]
     ) -> Optional[Directive]:
-        """Suggest directives that may be used, given a completion context.
+        """Return the implementation of a directive given its name
 
         Parameters
         ----------
-        context
-           The CompletionContext.
+        directive
+           The name of the directive.
+
+        domain
+           The domain of the directive, if applicable.
         """
 
         if domain:

--- a/lib/esbonio/esbonio/lsp/directives.py
+++ b/lib/esbonio/esbonio/lsp/directives.py
@@ -75,8 +75,14 @@ class DirectiveLanguageFeature:
     def suggest_options(
         self, context: CompletionContext, directive: str, domain: Optional[str]
     ) -> Iterable[str]:
-        """Suggest directive options that may be used, given a completion context."""
-        return []
+        """Suggest options that may be used, given a completion context."""
+
+        impl = self.get_implementation(directive, domain)
+        if impl is None:
+            return []
+
+        option_spec = impl.option_spec or {}
+        return option_spec.keys()
 
     def resolve_argument_link(
         self,

--- a/lib/esbonio/esbonio/lsp/rst/directives.py
+++ b/lib/esbonio/esbonio/lsp/rst/directives.py
@@ -1,7 +1,6 @@
 import importlib
 import json
 from typing import Dict
-from typing import Iterable
 from typing import Optional
 from typing import Tuple
 from typing import Union
@@ -10,7 +9,6 @@ import pkg_resources
 from docutils.parsers.rst import Directive
 from docutils.parsers.rst import directives as docutils_directives
 
-from esbonio.lsp import CompletionContext
 from esbonio.lsp.directives import DirectiveLanguageFeature
 from esbonio.lsp.directives import Directives
 
@@ -50,17 +48,6 @@ class Docutils(DirectiveLanguageFeature):
 
     def index_directives(self) -> Dict[str, Directive]:
         return self.directives
-
-    def suggest_options(
-        self, context: CompletionContext, directive: str, domain: Optional[str]
-    ) -> Iterable[str]:
-
-        impl = self.directives.get(directive, None)
-        if impl is None:
-            return []
-
-        option_spec = impl.option_spec or {}
-        return option_spec.keys()
 
 
 def resolve_directive(directive: Union[Directive, Tuple[str, str]]) -> Directive:

--- a/lib/esbonio/tests/sphinx-default/test_sd_directives.py
+++ b/lib/esbonio/tests/sphinx-default/test_sd_directives.py
@@ -338,6 +338,16 @@ async def test_completion_suppression(client: Client, extension: str, setup):
             None,
         ),
         (
+            ".. function:: ",
+            Position(line=0, character=5),
+            "Describes a module-level function.",
+        ),
+        (
+            ".. py:function:: ",
+            Position(line=0, character=5),
+            "Describes a module-level function.",
+        ),
+        (
             ".. c:function:: ",
             Position(line=0, character=1),
             "Describes a C function",

--- a/lib/esbonio/tests/unit_tests/test_directives.py
+++ b/lib/esbonio/tests/unit_tests/test_directives.py
@@ -25,39 +25,31 @@ class Simple(DirectiveLanguageFeature):
     def __init__(self, names: List[str]):
         self.directives = {name: Directive for name in names}
 
-    def get_implementation(
-        self, directive: str, domain: Optional[str]
-    ) -> Optional[Directive]:
-        return self.directives.get(directive, None)
-
     def index_directives(self) -> Dict[str, Directive]:
         return self.directives
-
-    # The default `suggest_directives` implementation should be sufficient.
 
     def suggest_options(
         self, context: CompletionContext, directive: str, domain: Optional[str]
     ) -> Iterable[str]:
         return iter(directive) if directive in self.directives else []
 
+    # The default `suggest_directives` implementation should be sufficient.
+    # The default `get_implementation` implementation should be sufficient.
+
 
 class Broken(DirectiveLanguageFeature):
     """A directive language feature that only throws exceptions."""
 
-    def get_implementation(
-        self, directive: str, domain: Optional[str]
-    ) -> Optional[Directive]:
-        raise NotImplementedError()
-
     def index_directives(self) -> Dict[str, Directive]:
         raise NotImplementedError()
-
-    # The default `suggest_directives` implementation should be sufficient.
 
     def suggest_options(
         self, context: CompletionContext, directive: str, domain: Optional[str]
     ) -> Iterable[str]:
         raise NotImplementedError()
+
+    # The default `suggest_directives` implementation should be sufficient.
+    # The default `get_implementation` implementation should be sufficient.
 
 
 @pytest.fixture()
@@ -116,7 +108,7 @@ def test_get_directives_error(broken: Directives):
 
 
 def test_get_implementation(simple: Directives):
-    """Ensure that we can correctly combine directives from multiple sources."""
+    """Ensure that we can correctly look up directives from multiple sources."""
 
     impl = simple.get_implementation("one", None)
     assert impl == Directive


### PR DESCRIPTION
- By using `get_implementation` when constructing hovers the server should more accurately be able to find the appropriate documentation for a directive
- Improved the default implementation of `suggest_options` for `DirectiveLanguageFeatures` so that if the feature indexes a directive that declares all its options in the `option_spec` field, completion suggestions should now "just work"
- Ensure that completion requests for directive options don't fail when a `DirectiveLanguageFeature` misbehaves