### PR TITLE
Fix error handling for `DirectiveLanguageFeatures`

### DIFF
--- a/.github/workflows/lsp-pr.yml
+++ b/.github/workflows/lsp-pr.yml
@@ -13,16 +13,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
         os: [ubuntu-latest, windows-latest, macos-latest]
 
-        # Python 3.6 is not available on Windows or MacOS runners
-        exclude:
-        - os: macos-latest
+        include:
+        - os: ubuntu-20.04
           python-version: "3.6"
 
-        - os: windows-latest
-          python-version: "3.6"
 
     steps:
     - uses: actions/checkout@v3

--- a/lib/esbonio/changes/506.enhancement.rst
+++ b/lib/esbonio/changes/506.enhancement.rst
@@ -1,0 +1,1 @@
+The language server now recognises and returns ``DocumentLinks`` for ``image::`` and ``figure::`` directives that use ``http://`` or ``https://`` references for images.

--- a/lib/esbonio/changes/506.fix.rst
+++ b/lib/esbonio/changes/506.fix.rst
@@ -1,0 +1,1 @@
+Errors thrown by ``DirectiveLanguageFeatures`` during ``textDocument/documentLink`` or ``textDocument/definition`` requests are now caught and no longer result in frustrating error banners in clients

--- a/lib/esbonio/changes/506.fix.rst
+++ b/lib/esbonio/changes/506.fix.rst
@@ -1,1 +1,3 @@
-Errors thrown by ``DirectiveLanguageFeatures`` during ``textDocument/documentLink`` or ``textDocument/definition`` requests are now caught and no longer result in frustrating error banners in clients
+Errors thrown by ``DirectiveLanguageFeatures`` during ``textDocument/documentLink`` or ``textDocument/definition`` requests are now caught and no longer result in frustrating error banners in clients.
+
+The ``textDocument/documentLink`` handler for ``image::`` and ``figure::`` should no longer throw exceptions for invalid paths on Windows.

--- a/lib/esbonio/esbonio/lsp/sphinx/images.py
+++ b/lib/esbonio/esbonio/lsp/sphinx/images.py
@@ -78,6 +78,9 @@ class Images:
         if domain or directive not in {"figure", "image"}:
             return None, None
 
+        if argument.startswith("https://") or argument.startswith("http://"):
+            return argument, None
+
         return self.resolve_path(context.doc, argument), None
 
     def resolve_path(self, doc: Document, argument: str) -> Optional[str]:
@@ -95,11 +98,16 @@ class Images:
         else:
             basedir = pathlib.Path(Uri.to_fs_path(doc.uri)).parent
 
-        fpath = (basedir / argument).resolve()
-        if not fpath.exists():
-            return None
+        try:
+            fullpath = basedir / argument
+            fpath = fullpath.resolve()
 
-        return Uri.from_fs_path(str(fpath))
+            if fpath.exists():
+                return Uri.from_fs_path(str(fpath))
+        except Exception:
+            self.logger.debug("Unable to resolve filepath '%s'", fullpath)
+
+        return None
 
 
 def esbonio_setup(rst: SphinxLanguageServer, directives: Directives):

--- a/lib/esbonio/tests/sphinx-extensions/test_se_sphinx.py
+++ b/lib/esbonio/tests/sphinx-extensions/test_se_sphinx.py
@@ -39,6 +39,13 @@ from pytest_lsp import check
                         end=Position(line=9, character=47),
                     ),
                 ),
+                DocumentLink(
+                    target="https://www.python.org/static/img/python-logo.png",
+                    range=Range(
+                        start=Position(line=11, character=11),
+                        end=Position(line=11, character=60),
+                    ),
+                ),
             ],
         )
     ],
@@ -49,11 +56,16 @@ async def test_document_links(client: Client, uri: str, expected: List[DocumentL
     test_uri = client.root_uri + uri
     links = await client.document_link_request(test_uri)
 
-    assert len(links) == len(expected)
+    expected_links = {link.target: link for link in expected}
+    actual_links = {link.target: link for link in links}
 
-    for expected, actual in zip(expected, links):
-        assert expected.range == actual.range
-        assert expected.target == actual.target
+    for target in expected_links:
+        assert target in actual_links
+
+        actual = actual_links.pop(target)
+        assert expected_links[target].range == actual.range
+
+    assert len(actual_links) == 0, f"Unexpected links {', '.join(actual_links.keys())}"
 
     check.document_links(client, links)
 

--- a/lib/esbonio/tests/sphinx-extensions/workspace/sphinx-extensions/definitions.rst
+++ b/lib/esbonio/tests/sphinx-extensions/workspace/sphinx-extensions/definitions.rst
@@ -8,3 +8,5 @@ Here is a reference to :ref:`python:logging-basic-tutorial`
 One for :py:class:`python:logging.Filter`
 
 Another for :doc:`python:howto/logging-cookbook`
+
+.. image:: https://www.python.org/static/img/python-logo.png


### PR DESCRIPTION
- Errors thrown by `find_argument_definitions` and `resolve_argument_link` methods in `DirectiveLanguageFeature` instances should now be caught and logged.
- Enhance handling of `textDocument/documentLink` requests for `image::` and `figure::` directives

Closes #506 