### PR TITLE
Intersphinx: support external/external+ roles

### DIFF
--- a/lib/esbonio/esbonio/lsp/directives.py
+++ b/lib/esbonio/esbonio/lsp/directives.py
@@ -391,7 +391,7 @@ class Directives(LanguageFeature):
            A list of strings for the directive's main documentation.
 
         ``options``,
-           A dictionary, with a field for the documentaton of each of the directive's
+           A dictionary, with a field for the documentation of each of the directive's
            options.
 
         ``is_markdown``

--- a/lib/esbonio/esbonio/lsp/rst/roles.py
+++ b/lib/esbonio/esbonio/lsp/rst/roles.py
@@ -34,12 +34,6 @@ class Docutils(RoleLanguageFeature):
 
         return self._roles
 
-    def get_implementation(self, role: str, domain: str):
-        if domain:
-            return None
-
-        return self.roles.get(role, None)
-
     def index_roles(self) -> Dict[str, Any]:
         return self.roles
 

--- a/lib/esbonio/esbonio/lsp/spelling.py
+++ b/lib/esbonio/esbonio/lsp/spelling.py
@@ -48,7 +48,7 @@ class Spelling(LanguageFeature):
             if len(ranges) > 0 and diagnostic.range not in ranges:
                 continue
 
-            for fix in self.lang.candidates(error.text):
+            for fix in self.lang.candidates(error.text) or []:
                 actions.append(
                     CodeAction(
                         title=f"Correct '{error.text}' -> '{fix}'",

--- a/lib/esbonio/esbonio/lsp/sphinx/domains.py
+++ b/lib/esbonio/esbonio/lsp/sphinx/domains.py
@@ -596,8 +596,8 @@ class Intersphinx(RoleLanguageFeature):
         Parameters
         ----------
         project
-           The project to return targets from.
-           If None, all targets are returned.
+           The project to return targets from. If None, all targets
+           from the unnamed inventory are returned.
 
         name
            The name of the role
@@ -707,13 +707,13 @@ class Intersphinx(RoleLanguageFeature):
         self, role: str, implementation: str
     ) -> Optional[Dict[str, Any]]:
         if not role.startswith("external"):
-            return
+            return None
         # Remove the "external" part.
         role = role.split(":", maxsplit=1)[-1]
 
         feature = self.rst.get_feature(Roles)
         if not feature:
-            return
+            return None
 
         key = f"{role}({implementation})"
         documentation = feature._documentation.get(key)
@@ -722,6 +722,7 @@ class Intersphinx(RoleLanguageFeature):
                 "description": documentation.get("description"),
                 "is_markdown": True,
             }
+        return None
 
 
 def intersphinx_target_to_completion_item(

--- a/lib/esbonio/esbonio/lsp/sphinx/roles.py
+++ b/lib/esbonio/esbonio/lsp/sphinx/roles.py
@@ -1,14 +1,17 @@
 """Extra support for roles added by sphinx."""
 import json
 import os.path
-from typing import Dict, List, Any
+from typing import Any
+from typing import Dict
+from typing import List
 from typing import Optional
 
 import pkg_resources
 import pygls.uris as Uri
 from pygls.lsp.types import CompletionItem
 
-from esbonio.lsp.roles import RoleLanguageFeature, Roles
+from esbonio.lsp.roles import RoleLanguageFeature
+from esbonio.lsp.roles import Roles
 from esbonio.lsp.rst import CompletionContext
 from esbonio.lsp.sphinx import SphinxLanguageServer
 from esbonio.lsp.util.filepaths import complete_sphinx_filepaths

--- a/lib/esbonio/esbonio/lsp/sphinx/roles.py
+++ b/lib/esbonio/esbonio/lsp/sphinx/roles.py
@@ -23,11 +23,11 @@ class SphinxRoles(RoleLanguageFeature):
         self, role: str, implementation: str
     ) -> Optional[Dict[str, Any]]:
         if not self.rst.app:
-            return
+            return None
 
         feature = self.rst.get_feature(Roles)
         if not feature:
-            return
+            return None
 
         # Try with the primary domain.
         primary_domain = self.rst.app.config.primary_domain

--- a/lib/esbonio/esbonio/lsp/sphinx/roles.py
+++ b/lib/esbonio/esbonio/lsp/sphinx/roles.py
@@ -1,18 +1,45 @@
 """Extra support for roles added by sphinx."""
 import json
 import os.path
-from typing import List
+from typing import Dict, List, Any
 from typing import Optional
 
 import pkg_resources
 import pygls.uris as Uri
 from pygls.lsp.types import CompletionItem
 
-from esbonio.lsp.roles import Roles
+from esbonio.lsp.roles import RoleLanguageFeature, Roles
 from esbonio.lsp.rst import CompletionContext
 from esbonio.lsp.sphinx import SphinxLanguageServer
 from esbonio.lsp.util.filepaths import complete_sphinx_filepaths
 from esbonio.lsp.util.filepaths import path_to_completion_item
+
+
+class SphinxRoles(RoleLanguageFeature):
+    def __init__(self, rst: SphinxLanguageServer):
+        self.rst = rst
+
+    def get_role_documentation(
+        self, role: str, implementation: str
+    ) -> Optional[Dict[str, Any]]:
+        if not self.rst.app:
+            return
+
+        feature = self.rst.get_feature(Roles)
+        if not feature:
+            return
+
+        # Try with the primary domain.
+        primary_domain = self.rst.app.config.primary_domain
+        if primary_domain:
+            key = f"{primary_domain}:{role}({implementation})"
+            documentation = feature._documentation.get(key)
+            if documentation:
+                return documentation
+
+        # Try with the standard domain.
+        key = f"std:{role}({implementation})"
+        return feature._documentation.get(key)
 
 
 class Downloads:
@@ -42,4 +69,5 @@ def esbonio_setup(rst: SphinxLanguageServer, roles: Roles):
     sphinx_docs = pkg_resources.resource_string("esbonio.lsp.sphinx", "roles.json")
     roles.add_documentation(json.loads(sphinx_docs.decode("utf8")))
 
+    roles.add_feature(SphinxRoles(rst))
     roles.add_target_completion_provider(Downloads(rst))

--- a/lib/esbonio/esbonio/lsp/util/patterns.py
+++ b/lib/esbonio/esbonio/lsp/util/patterns.py
@@ -91,20 +91,20 @@ A number of named capture groups are available
 
 ROLE = re.compile(
     r"""
-    ([^\w:]|^\s*)                     # roles cannot be preceeded by letter chars
+    ([^\w:]|^\s*)                        # roles cannot be preceeded by letter chars
     (?P<role>
-      :                               # roles begin with a ':' character
-      (?!:)                           # the next character cannot be a ':'
-      ((?P<domain>[\w]+):(?=\w))?     # roles may include a domain (that must be followed by a word character)
-      ((?P<name>[\w-]+):?)?           # roles have a name
+      :                                  # roles begin with a ':' character
+      (?!:)                              # the next character cannot be a ':'
+      ((?P<domain>[\w+-]+):(?=\w))?      # roles may include a domain (that must be followed by a word character)
+      ((?P<name>([\w+-]+:)*[\w+-]+):?)?  # roles have a name
     )
     (?P<target>
-      `                               # targets begin with a '`' character
-      ((?P<alias>[^<`>]*?)<)?         # targets may specify an alias
-      (?P<modifier>[!~])?             # targets may have a modifier
-      (?P<label>[^<`>]*)?             # targets contain a label
-      >?                              # labels end with a '>' when there's an alias
-      `?                              # targets end with a '`' character
+      `                                  # targets begin with a '`' character
+      ((?P<alias>[^<`>]*?)<)?            # targets may specify an alias
+      (?P<modifier>[!~])?                # targets may have a modifier
+      (?P<label>[^<`>]*)?                # targets contain a label
+      >?                                 # labels end with a '>' when there's an alias
+      `?                                 # targets end with a '`' character
     )?
     """,
     re.VERBOSE,


### PR DESCRIPTION
- The current regex for roles wasn't taking into consideration `:foo:bar:baz:` roles (roles with more than two `:`)
- Add support for external roles into the InterSphinx feature (maybe subclassing? InterSphinxExternalRoles)
- Missing tests and fixing current ones
- The documentation/hover feature requires passing a static dictionary to the Role class, but maybe it should be part of the RoleLanguageFeature class, so we can do that dynamically, this is useful since the documentation for these new external roles is basically the same as normal roles `:external:doc:` == `:doc:`. Of course, this should already be possible with `add_documentation`, but having it in RoleLanguageFeature encapsulates all the logic there.

Closes https://github.com/swyddfa/esbonio/issues/464