### PR TITLE
lsp: Ensure that our `source-read` handler is called first

### DIFF
--- a/lib/esbonio/changes/539.fix.rst
+++ b/lib/esbonio/changes/539.fix.rst
@@ -1,0 +1,1 @@
+With live previews enabled, ``esbonio`` should no longer conflict with Sphinx extensions that register their own ``source-read`` handlers.

--- a/lib/esbonio/esbonio/lsp/sphinx/__init__.py
+++ b/lib/esbonio/esbonio/lsp/sphinx/__init__.py
@@ -339,7 +339,7 @@ class SphinxLanguageServer(RstLanguageServer):
         app.connect("env-before-read-docs", self.cb_env_before_read_docs)
 
         if self.user_config.server.enable_live_preview:  # type: ignore
-            app.connect("source-read", self.cb_source_read)
+            app.connect("source-read", self.cb_source_read, priority=0)
             app.connect("build-finished", self.cb_build_finished)
 
         return app


### PR DESCRIPTION
This should prevent `esbonio` from conflicting with Sphinx extensions that register their own custom `source-read` handlers.

Closes #539 