### PR TITLE
Add initial sphinx support to the web extension

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -45,6 +45,21 @@
             }
         },
         {
+            "name": "VSCode Web Extension",
+            "type": "extensionHost",
+            "debugWebWorkerHost": true,
+            "request": "launch",
+            "args": [
+                "--extensionDevelopmentPath=${workspaceRoot}/code",
+                "--extensionDevelopmentKind=web",
+                "--folder-uri=${workspaceRoot}/${input:workspace}"
+            ],
+            "outFiles": [
+                "${workspaceRoot}/code/dist/browser/**/*.js"
+            ],
+            "preLaunchTask": "${defaultBuildTask}",
+        },
+        {
             "name": "Language Server",
             "type": "python",
             "request": "launch",

--- a/code/changes/548.feature.rst
+++ b/code/changes/548.feature.rst
@@ -1,0 +1,5 @@
+It should now be possible to run the Sphinx based language server in https://vscode.dev!
+
+Note, that this functionality, is still **experimental**.
+To try it out, you will need to explicity set the ``esbonio.sphinx.confDir`` option to ``/<github-user>/<github-repo>/<path>/``.
+For example, this project would need it to be set to `/swyddfa/esbonio/docs/`.

--- a/code/src/browser/core/log.ts
+++ b/code/src/browser/core/log.ts
@@ -1,0 +1,53 @@
+
+export enum LogLevel {
+  DEBUG = 0,
+  INFO = 1,
+  ERROR = 2
+}
+
+export abstract class Logger {
+
+  public level: LogLevel
+
+  constructor() {
+    this.level = LogLevel.ERROR
+  }
+
+  info(message: string): void {
+    if (this.level <= LogLevel.INFO) {
+      this.log(message)
+    }
+  }
+
+  debug(message: string): void {
+    if (this.level <= LogLevel.DEBUG) {
+      this.log(message)
+    }
+  }
+
+  error(message: string): void {
+    if (this.level <= LogLevel.ERROR) {
+      this.log(message)
+    }
+  }
+
+  abstract log(message: string): void
+
+  setLevel(level: string): void {
+    let logLevel: LogLevel
+
+    switch (level) {
+      case 'debug':
+        logLevel = LogLevel.DEBUG
+        break
+      case 'info':
+        logLevel = LogLevel.INFO
+        break
+      default:
+        logLevel = LogLevel.ERROR
+        break
+    }
+
+    this.level = logLevel
+  }
+}

--- a/code/src/browser/lsp/client.ts
+++ b/code/src/browser/lsp/client.ts
@@ -1,0 +1,387 @@
+import * as vscode from 'vscode'
+import { LanguageClient, LanguageClientOptions } from "vscode-languageclient/browser";
+
+import { Logger } from "../core/log";
+
+
+/**
+ * Represents the current sphinx configuration / configuration options
+ * that should be passed to sphinx on creation.
+ */
+export interface SphinxConfig {
+
+  /**
+   * The directory where Sphinx's build output should be stored.
+   */
+  buildDir?: string
+
+  /**
+   * The name of the builder to use.
+   */
+  builderName?: string
+
+  /**
+   * The directory containing the project's 'conf.py' file.
+   */
+  confDir?: string
+
+  /**
+   * Any overriden conf.py options.
+   */
+  configOverrides?: object,
+
+  /**
+   * The directory in which to store Sphinx's doctree cache
+   */
+  doctreeDir?: string,
+
+  /**
+   * Flag to force a full build of the documentation on startup.
+   */
+  forceFullBuild?: boolean
+
+  /**
+   * Flag to continue building when errors generated from warnings are encountered.
+   */
+  keepGoing?: boolean
+
+  /**
+   * Flag controlling if the server should behave like `sphinx-build -M ...`
+   */
+  makeMode?: boolean
+
+  /**
+   * The number of parallel jobs to use
+   */
+  numJobs?: number | string
+
+  /**
+   * Hide standard Sphinx output messages.
+   */
+  quiet?: boolean
+
+  /**
+   * Hide all Sphinx output.
+   */
+  silent?: boolean
+
+  /**
+   * The source dir containing the *.rst files for the project.
+   */
+  srcDir?: string
+
+  /**
+   * Tags to enable during a build.
+   */
+  tags?: string[]
+
+  /**
+   * The verbosity of Sphinx's output.
+   */
+  verbosity?: number
+
+  /**
+   * Treat any warnings as errors.
+   */
+  warningIsError?: boolean
+}
+
+export interface SphinxInfo extends SphinxConfig {
+
+  /**
+   * The equivalent `sphinx-build` command for the current configuration
+   */
+  command?: string[]
+
+  /**
+   * Sphinx's version number.
+   */
+  version?: string
+}
+
+/**
+ * Configuration options related to completions.
+ */
+export interface ServerCompletionConfig {
+
+  /**
+   * Indicates how the user would prefer completion items to behave
+   */
+  preferredInsertBehavior: string
+}
+
+/**
+ * Represents configuration options that should be passed to the server.
+ */
+export interface ServerConfig {
+
+  /**
+   * Used to set the logging level of the server.
+   */
+  logLevel: string
+
+  /**
+   * A list of logger names to suppress output from.
+   */
+  logFilter?: string[]
+
+  /**
+   * A flag to indicate if Sphinx build output should be omitted from the log.
+   */
+  hideSphinxOutput: boolean
+
+  /**
+   * A flag to enable showing deprecation warnings.
+   */
+  showDeprecationWarnings: boolean
+
+  /**
+   * Server completion settings
+   */
+  completion: ServerCompletionConfig
+}
+
+/**
+ * The initialization options we pass to the server on startup.
+ */
+export interface InitOptions {
+
+  /**
+   * Language server specific options
+   */
+  server: ServerConfig
+
+  /**
+   * Sphinx specific options
+   */
+  sphinx: SphinxConfig
+}
+
+export interface BuildCompleteResult {
+  /**
+   * The options representing the server's config.
+   */
+  config: { server: ServerConfig, sphinx: SphinxInfo },
+
+  /**
+   * Flag indicating if the previous build resulted in an error.
+   */
+  error: boolean,
+
+  /**
+   * The number of warnings emitted in the previous build.
+   */
+  warnings: number,
+}
+
+/**
+ * While the ServerManager is responsible for installation and updates of the
+ * Python package containing the server. The EsbonioClient is responsible for
+ * creating the LanguageClient instance that utilmately starts the server
+ * running.
+ */
+export class EsbonioClient {
+
+  /**
+   * If present, this represents the current configuration of the Sphinx instance
+   * managed by the Language server.
+   */
+  public sphinxInfo?: SphinxInfo
+
+  private client: LanguageClient
+  private worker: Worker
+
+  private clientStartedCallbacks: Array<(params: void) => void> = []
+  private clientErrorCallbacks: Array<(params: void) => void> = []
+  private buildStartCallbacks: Array<(params: void) => void> = []
+  private buildCompleteCallbacks: Array<(params: BuildCompleteResult) => void> = []
+
+  constructor(
+    private serverUri: vscode.Uri,
+    private logger: Logger,
+    private channel: vscode.OutputChannel,
+  ) { }
+
+  async stop() {
+
+    if (this.client) {
+      await this.client.stop()
+    }
+
+    return
+  }
+
+  /**
+   * Start the language client.
+   */
+  async start(): Promise<void> {
+
+    this.client = this.getClient()
+    if (!this.client) {
+      return
+    }
+
+    // HACK: Expose the files in the current workspace to the server.
+    if (vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders.length > 0) {
+      let rootUri = vscode.workspace.workspaceFolders[0].uri
+      await this.syncFiles(rootUri)
+    }
+
+    try {
+      this.logger.info("Starting Language Server")
+      this.configureHandlers()
+
+      await this.client.start()
+      this.clientStartedCallbacks.forEach(fn => fn())
+
+    } catch (err) {
+      this.clientErrorCallbacks.forEach(fn => fn(err))
+      this.logger.error(err)
+    }
+  }
+
+  /**
+   * This is... kind of a hack.
+   *
+   * We use the `vscode.workspace.fs` API to walk all the files in the workspace and
+   * copy their contents into the WASM filesystem provided by pyodide.
+   *
+   * This requires the LS worker to have speicial support for our custom messages
+   * so that it does not try and handle them as proper LSP messages.
+   *
+   * TODO: Investigate WASM + WASI.
+   *
+   */
+  private async syncFiles(uri: vscode.Uri) {
+    this.logger.debug(`Walking dir: ${uri}`)
+
+    for (let [path, kind] of await vscode.workspace.fs.readDirectory(uri)) {
+      if (kind === vscode.FileType.Directory) {
+        await this.syncFiles(vscode.Uri.joinPath(uri, path))
+        continue
+      }
+
+      let fileUri = vscode.Uri.joinPath(uri, path)
+      let contents = await vscode.workspace.fs.readFile(fileUri)
+
+      this.logger.debug(`Syncing file: ${fileUri}`)
+      this.worker.postMessage({
+        op: "writeFile",
+        fileUri: fileUri,
+        parentUri: uri,
+        content: contents
+      })
+    }
+  }
+
+
+  /**
+   * Restart the language server.
+   */
+  async restartServer() {
+    let config = vscode.workspace.getConfiguration("esbonio.server")
+    if (config.get("enabled")) {
+      this.logger.info("==================== RESTARTING SERVER =====================")
+      await this.stop()
+      await this.start()
+    }
+  }
+
+  private configureHandlers() {
+
+    this.client.onNotification("esbonio/buildStart", params => {
+      this.logger.debug("Build start.")
+      this.buildStartCallbacks.forEach(fn => fn())
+    })
+
+    this.client.onNotification("esbonio/buildComplete", (result: BuildCompleteResult) => {
+      this.logger.debug(`Build complete ${JSON.stringify(result, null, 2)}`)
+      this.sphinxInfo = result.config.sphinx
+      this.buildCompleteCallbacks.forEach(fn => {
+        fn(result)
+      })
+    })
+  }
+
+  private getClient(): LanguageClient {
+    const config = vscode.workspace.getConfiguration("esbonio")
+    this.worker = new Worker(this.serverUri.toString())
+    const clientOptions = this.getLanguageClientOptions(config)
+
+    return new LanguageClient("esbonio", "Esbonio", clientOptions, this.worker)
+  }
+
+  /**
+   * Returns the LanguageClient options that are common to both modes of
+   * transport.
+   */
+  private getLanguageClientOptions(config: vscode.WorkspaceConfiguration): LanguageClientOptions {
+
+    let initOptions: InitOptions = {
+      sphinx: this.getSphinxOptions(config),
+      server: {
+        logLevel: config.get<string>('server.logLevel'),
+        logFilter: config.get<string[]>('server.logFilter'),
+        hideSphinxOutput: config.get<boolean>('server.hideSphinxOutput'),
+        showDeprecationWarnings: config.get<boolean>('server.showDeprecationWarnings'),
+        completion: {
+          preferredInsertBehavior: config.get<string>('server.completion.preferredInsertBehavior')
+        }
+      }
+    }
+
+    let documentSelector = [
+      { language: 'restructuredtext' },
+    ]
+
+    if (config.get<boolean>('server.enabledInPyFiles')) {
+      documentSelector.push(
+        { language: 'python' }
+      )
+    }
+
+    let clientOptions: LanguageClientOptions = {
+      documentSelector: documentSelector,
+      initializationOptions: initOptions,
+      outputChannel: this.channel
+    }
+    this.logger.debug(`LanguageClientOptions: ${JSON.stringify(clientOptions, null, 2)}`)
+    return clientOptions
+  }
+
+  private getSphinxOptions(config: vscode.WorkspaceConfiguration): SphinxConfig {
+    return {
+      buildDir: config.get<string>('sphinx.buildDir'),
+      builderName: config.get<string>('sphinx.builderName'),
+      confDir: config.get<string>('sphinx.confDir'),
+      // configOverrides: config.get<object>('sphinx.configOverrides'),
+      doctreeDir: config.get<string>('sphinx.doctreeDir'),
+      forceFullBuild: config.get<boolean>('sphinx.forceFullBuild'),
+      keepGoing: config.get<boolean>('sphinx.keepGoing'),
+      makeMode: config.get<boolean>('sphinx.makeMode'),
+      numJobs: 1, // threading/multiprocessing not available in WASM.
+      quiet: config.get<boolean>('sphinx.quiet'),
+      silent: config.get<boolean>('sphinx.silent'),
+      srcDir: config.get<string>("sphinx.srcDir"),
+      tags: config.get<string[]>('sphinx.tags'),
+      verbosity: config.get<number>('sphinx.verbosity'),
+      warningIsError: config.get<boolean>('sphinx.warningIsError')
+    };
+  }
+
+  onClientStart(callback: (_: void) => void) {
+    this.clientStartedCallbacks.push(callback)
+  }
+
+  onClientError(callback: (_: void) => void) {
+    this.clientErrorCallbacks.push(callback)
+  }
+
+  onBuildComplete(callback: (result: BuildCompleteResult) => void) {
+    this.buildCompleteCallbacks.push(callback)
+  }
+
+  onBuildStart(callback: (_: void) => void) {
+    this.buildStartCallbacks.push(callback)
+  }
+}

--- a/code/src/browser/lsp/server.py
+++ b/code/src/browser/lsp/server.py
@@ -1,6 +1,11 @@
-from docutils import __version__
-from pygls.lsp.types import InitializedParams
+from typing import Literal
+from typing import Union
 
+from docutils import __version__ as __docutils_version__
+from lsprotocol.types import InitializedParams
+from pygls.protocol import default_converter
+
+from esbonio.lsp import __version__
 from esbonio.lsp import create_language_server
 from esbonio.lsp.rst import DEFAULT_MODULES
 from esbonio.lsp.rst import LanguageFeature
@@ -12,13 +17,26 @@ class DocutilsVersion(LanguageFeature):
 
     def initialized(self, params: InitializedParams) -> None:
         self.rst.send_notification(
-            "esbonio/buildComplete", {"docutils": {"version": __version__}}
+            "esbonio/buildComplete", {"docutils": {"version": __docutils_version__}}
         )
+
+
+def esbonio_converter():
+    converter = default_converter()
+    converter.register_structure_hook(Union[Literal["auto"], int], lambda obj, _: obj)
+
+    return converter
 
 
 # For now, let's just try the basic rst language server.
 # Eventually... it should be possible to create one of these per entry
 # point and have the web extension switch between them.
-server = create_language_server(RstLanguageServer, DEFAULT_MODULES)
+server = create_language_server(
+    RstLanguageServer,
+    DEFAULT_MODULES,
+    name="esbonio",
+    version=__version__,
+    converter_factory=esbonio_converter,
+)
 server.add_feature(DocutilsVersion(server))
 server.start_pyodide()

--- a/code/src/browser/lsp/server.py
+++ b/code/src/browser/lsp/server.py
@@ -1,24 +1,12 @@
 from typing import Literal
 from typing import Union
 
-from docutils import __version__ as __docutils_version__
-from lsprotocol.types import InitializedParams
 from pygls.protocol import default_converter
 
 from esbonio.lsp import __version__
 from esbonio.lsp import create_language_server
-from esbonio.lsp.rst import DEFAULT_MODULES
-from esbonio.lsp.rst import LanguageFeature
-from esbonio.lsp.rst import RstLanguageServer
-
-
-class DocutilsVersion(LanguageFeature):
-    """Quick hack to get the version number into the client."""
-
-    def initialized(self, params: InitializedParams) -> None:
-        self.rst.send_notification(
-            "esbonio/buildComplete", {"docutils": {"version": __docutils_version__}}
-        )
+from esbonio.lsp.sphinx import DEFAULT_MODULES
+from esbonio.lsp.sphinx import SphinxLanguageServer
 
 
 def esbonio_converter():
@@ -28,15 +16,11 @@ def esbonio_converter():
     return converter
 
 
-# For now, let's just try the basic rst language server.
-# Eventually... it should be possible to create one of these per entry
-# point and have the web extension switch between them.
 server = create_language_server(
-    RstLanguageServer,
+    SphinxLanguageServer,
     DEFAULT_MODULES,
     name="esbonio",
     version=__version__,
     converter_factory=esbonio_converter,
 )
-server.add_feature(DocutilsVersion(server))
 server.start_pyodide()

--- a/code/src/browser/lsp/worker.ts
+++ b/code/src/browser/lsp/worker.ts
@@ -1,5 +1,7 @@
 importScripts("https://cdn.jsdelivr.net/pyodide/v0.22.1/full/pyodide.js")
 
+import * as path from 'path';
+
 /* @ts-ignore */
 import * as languageServer from "./server.py"
 
@@ -8,9 +10,10 @@ function patchedStdout(data) {
     return
   }
 
-  // Uncomment to see messages sent from the language server
-  // console.log(data)
-  postMessage(JSON.parse(data))
+  const message = JSON.parse(data)
+
+  console.debug(message)
+  postMessage(message)
 }
 
 async function initPyodide() {
@@ -21,39 +24,110 @@ async function initPyodide() {
     indexURL: "https://cdn.jsdelivr.net/pyodide/v0.22.1/full/"
   })
 
+  return pyodide
+}
+
+let SERVER_STARTED = false
+async function startServer(pyodide) {
   console.debug("Installing dependencies.")
   await pyodide.loadPackage(["micropip"])
   await pyodide.runPythonAsync(`
-    import sys
-    import micropip
+  import sys
+  import micropip
 
-    await micropip.install('setuptools')
-    await micropip.install('esbonio')
+  await micropip.install('setuptools')
+  await micropip.install('esbonio')
   `)
 
-  console.debug("Loading lsp server.")
+  console.debug("Loading server.")
 
   pyodide.globals.get('sys').stdout.write = patchedStdout
   await pyodide.runPythonAsync(languageServer)
+  SERVER_STARTED = true
+}
 
-  return pyodide
+
+/**
+ * Write a file's contents into pyodide's in-memory filesystem.
+ *
+ * Since the VSCode api returns a Uint8 array, let's use lower level
+ * file system APIs to avoid round tripping the data to a string and
+ * back.
+ *
+ * It *should* also let us ignore annoying details like encodings :)
+ *
+ * @param pyodide The pyodide instance to use.
+ * @param message The message containing the file's contents
+ */
+async function writeFile(pyodide, message) {
+
+  const FS = pyodide.FS
+  const fpath = message.fileUri.path
+  const ppath = message.parentUri.path
+
+  mkdirs(FS, ppath)
+
+  let stream = FS.open(fpath, 'w+')
+  let data = message.content
+
+  console.debug(`Writing file: ${fpath}`)
+  FS.write(stream, data, 0, data.length, 0)
+  FS.close(stream)
+}
+
+function mkdirs(FS, dir: string) {
+
+  try {
+    FS.stat(dir)
+  } catch (err) {
+    // Dir does not exist
+    let parent = path.dirname(dir)
+
+    try {
+      FS.stat(parent)
+    } catch (err) {
+      mkdirs(FS, parent)
+    }
+
+    FS.mkdir(dir)
+  }
 }
 
 const pyodideReady = initPyodide()
 
 onmessage = async (event) => {
+  let message = event.data
+  console.debug(message)
+
   let pyodide = await pyodideReady
 
-  // Uncomment to see messages from the client
-  // console.log(event.data)
+  // Pass regular LSP messages to the language server.
+  if (message.jsonrpc) {
 
-  /* @ts-ignore */
-  self.client_message = JSON.stringify(event.data)
-  await pyodide.runPythonAsync(`
+    if (!SERVER_STARTED) {
+      await startServer(pyodide)
+    }
+
+    /* @ts-ignore */
+    self.client_message = JSON.stringify(message)
+    await pyodide.runPythonAsync(`
     import json
     from js import client_message
 
     message = json.loads(client_message, object_hook=server.lsp._deserialize_message)
     server.lsp._procedure_handler(message)
-  `)
+    `)
+
+    return
+  }
+
+  // Otherwise, handle out-of-spec messages here.
+  switch (message.op) {
+    case "writeFile":
+      await writeFile(pyodide, message)
+      break
+    default:
+      console.error(`Unknown operation: ${message.op}`)
+  }
+
 }

--- a/code/src/browser/lsp/worker.ts
+++ b/code/src/browser/lsp/worker.ts
@@ -1,4 +1,4 @@
-importScripts("https://cdn.jsdelivr.net/pyodide/v0.20.0/full/pyodide.js")
+importScripts("https://cdn.jsdelivr.net/pyodide/v0.22.1/full/pyodide.js")
 
 /* @ts-ignore */
 import * as languageServer from "./server.py"
@@ -18,7 +18,7 @@ async function initPyodide() {
 
   /* @ts-ignore */
   let pyodide = await loadPyodide({
-    indexURL: "https://cdn.jsdelivr.net/pyodide/v0.20.0/full/"
+    indexURL: "https://cdn.jsdelivr.net/pyodide/v0.22.1/full/"
   })
 
   console.debug("Installing dependencies.")
@@ -52,9 +52,8 @@ onmessage = async (event) => {
   await pyodide.runPythonAsync(`
     import json
     from js import client_message
-    from pygls.protocol import deserialize_message
 
-    message = json.loads(client_message, object_hook=deserialize_message)
+    message = json.loads(client_message, object_hook=server.lsp._deserialize_message)
     server.lsp._procedure_handler(message)
   `)
 }

--- a/code/webpack.config.js
+++ b/code/webpack.config.js
@@ -97,6 +97,9 @@ const lspWorkerConfig = {
   resolve: {
     extensions: ['.ts', '.js'],
     mainFields: ['module', 'main'],
+    fallback: {
+      path: require.resolve('path-browserify')
+    }
   },
   module: {
     rules: [


### PR DESCRIPTION
In order to expose the contents of the workspace to the pyodide runtime, the extension copies all the files into its in-memory filesystem - not ideal but good enough for now.