### PR TITLE
Proof of concept `PreviewManager` feature

### DIFF
--- a/lib/esbonio/esbonio/server/cli.py
+++ b/lib/esbonio/esbonio/server/cli.py
@@ -67,7 +67,11 @@ def main(argv: Optional[Sequence[str]] = None):
     cli = build_parser()
     args = cli.parse_args(argv)
 
-    modules = ["esbonio.server.features.sphinx_manager"]
+    # Order matters!
+    modules = [
+        "esbonio.server.features.sphinx_manager",
+        "esbonio.server.features.preview_manager",
+    ]
 
     for mod in args.included_modules:
         modules.append(mod)

--- a/lib/esbonio/esbonio/server/features/preview_manager/__init__.py
+++ b/lib/esbonio/esbonio/server/features/preview_manager/__init__.py
@@ -1,0 +1,101 @@
+import asyncio
+import logging
+from http.server import HTTPServer
+from http.server import SimpleHTTPRequestHandler
+from typing import Any
+
+import pygls.uris as Uri
+
+from esbonio.server import EsbonioLanguageServer
+from esbonio.server.feature import LanguageFeature
+from esbonio.server.features.sphinx_manager import SphinxManager
+
+
+class RequestHandler(SimpleHTTPRequestHandler):
+    def __init__(self, *args, logger: logging.Logger, directory: str, **kwargs) -> None:
+        self.logger = logger
+        super().__init__(*args, directory=directory, **kwargs)
+
+    def translate_path(self, path: str) -> str:
+        result = super().translate_path(path)
+        self.logger.debug("Translate: '%s' -> '%s'", path, result)
+        return result
+
+    def log_message(self, format: str, *args: Any) -> None:
+        self.logger.debug(format, *args)
+
+
+class RequestHandlerFactory:
+    """Class for dynamically producing request handlers.
+
+    ``HTTPServer`` works by taking a "request handler" class and creating an instance of
+    it for every request it receives. By making this class callable, we can dynamically
+    produce a request handler based on the current situation.
+    """
+
+    def __init__(self, logger: logging.Logger, build_dir: str):
+        self.logger = logger
+        self.build_dir = build_dir
+
+    def __call__(self, *args, **kwargs):
+        return RequestHandler(
+            *args, logger=self.logger, directory=self.build_dir, **kwargs
+        )
+
+
+class PreviewManager(LanguageFeature):
+    """Language feature for managing previews."""
+
+    def __init__(self, server: EsbonioLanguageServer, sphinx: SphinxManager):
+        super().__init__(server)
+        self.sphinx = sphinx
+
+        logger = server.logger.getChild("PreviewServer")
+        self._request_handler_factory = RequestHandlerFactory(logger, "")
+        self._http_server = None
+        self._http_future = None
+
+    def get_http_server(self):
+        if self._http_server is not None:
+            return self._http_server
+
+        self._http_server = HTTPServer(("localhost", 0), self._request_handler_factory)
+
+        loop = asyncio.get_running_loop()
+        self._http_future = loop.run_in_executor(
+            self.server.thread_pool_executor,
+            self._http_server.serve_forever,
+        )
+
+        return self._http_server
+
+    async def preview_file(self, params):
+        src_uri = params["uri"]
+        self.logger.debug("Preview file called %s", src_uri)
+
+        client = await self.sphinx.get_client(src_uri)
+        if client is None or client.src_dir is None or client.build_dir is None:
+            return None
+
+        src_path = Uri.to_fs_path(src_uri)
+        if src_path is None:
+            return None
+
+        rst_path = src_path.replace(client.src_dir, "")
+        html_path = rst_path.replace(".rst", ".html")
+        self.logger.debug("'%s' -> '%s' -> '%s'", src_path, rst_path, html_path)
+
+        server = self.get_http_server()
+        self._request_handler_factory.build_dir = client.build_dir
+        self.logger.debug("Preview running on port: %s", server.server_port)
+
+        return {"uri": f"http://localhost:{server.server_port}{html_path}"}
+
+
+def esbonio_setup(server: EsbonioLanguageServer, sphinx: SphinxManager):
+    manager = PreviewManager(server, sphinx)
+    server.add_feature(manager)
+
+    @server.command("esbonio.server.previewFile")
+    async def preview_file(ls: EsbonioLanguageServer, *args):
+        return await manager.preview_file(args[0][0])

--- a/lib/esbonio/esbonio/server/features/sphinx_manager/client.py
+++ b/lib/esbonio/esbonio/server/features/sphinx_manager/client.py
@@ -2,8 +2,12 @@ from __future__ import annotations
 
 import asyncio
 import typing
+from typing import Optional
 
+import pygls.uris as Uri
 from pygls.client import Client
+
+from .config import SphinxConfig
 
 if typing.TYPE_CHECKING:
     from .manager import SphinxManager
@@ -18,12 +22,87 @@ class SphinxClient(Client):
         self.manager = manager
         self.logger = manager.logger
 
+        self.sphinx_info = None
+
+    @property
+    def src_dir(self) -> Optional[str]:
+        """The src directory of the Sphinx application."""
+        if self.sphinx_info is None:
+            return None
+
+        return self.sphinx_info.src_dir
+
+    @property
+    def src_uri(self) -> Optional[str]:
+        """The src uri of the Sphinx application."""
+        src_dir = self.src_dir
+        if src_dir is None:
+            return None
+
+        return Uri.from_fs_path(src_dir)
+
+    @property
+    def conf_dir(self) -> Optional[str]:
+        """The conf directory of the Sphinx application."""
+        if self.sphinx_info is None:
+            return None
+
+        return self.sphinx_info.conf_dir
+
+    @property
+    def conf_uri(self) -> Optional[str]:
+        """The conf uri of the Sphinx application."""
+        conf_dir = self.conf_dir
+        if conf_dir is None:
+            return None
+
+        return Uri.from_fs_path(conf_dir)
+
+    @property
+    def build_dir(self) -> Optional[str]:
+        """The build directory of the Sphinx application."""
+        if self.sphinx_info is None:
+            return None
+
+        return self.sphinx_info.build_dir
+
+    @property
+    def build_uri(self) -> Optional[str]:
+        """The build uri of the Sphinx application."""
+        build_dir = self.build_dir
+        if build_dir is None:
+            return None
+
+        return Uri.from_fs_path(build_dir)
+
+    async def start(self, config: SphinxConfig):
+        """Start the sphinx agent."""
+        command = [*config.python_command, "-m", "sphinx_agent"]
+        self.logger.debug("Starting sphinx agent: %s", " ".join(command))
+
+        await self.start_io(
+            *command, env={"PYTHONPATH": config.python_path}, cwd=config.cwd
+        )
+
     async def server_exit(self, server: asyncio.subprocess.Process):
+        """Called when the sphinx agent process exits."""
         self.logger.debug(f"Process exited with code: {server.returncode}")
 
         if server.returncode != 0:
             stderr = await server.stderr.read()
             self.logger.debug("Stderr:\n%s", stderr.decode("utf8"))
+
+    async def create_application(self, config: SphinxConfig):
+        """Create a sphinx application object."""
+
+        if self.stopped:
+            raise RuntimeError("Client is stopped.")
+
+        self.logger.debug("Starting sphinx: %s", " ".join(config.build_command))
+        self.sphinx_info = await self.protocol.send_request_async(
+            "sphinx/createApp", {"command": config.build_command}
+        )
+        return self.sphinx_info
 
 
 def make_sphinx_client(manager: SphinxManager):

--- a/lib/esbonio/esbonio/server/features/sphinx_manager/config.py
+++ b/lib/esbonio/esbonio/server/features/sphinx_manager/config.py
@@ -1,0 +1,110 @@
+import hashlib
+import importlib.util
+import logging
+import pathlib
+from typing import List
+from typing import Optional
+
+import appdirs
+import attrs
+import pygls.uris as Uri
+from pygls.workspace import Workspace
+
+
+def get_python_path() -> Optional[pathlib.Path]:
+    spec = importlib.util.find_spec("esbonio.sphinx_agent")
+    if spec is None:
+        return None
+
+    if spec.origin is None:
+        return None
+
+    # origin = .../esbonio/sphinx_agent/__init__.py
+    agent = pathlib.Path(spec.origin)
+    return agent.parent.parent
+
+
+@attrs.define
+class SphinxConfig:
+    """Configuration for the sphinx application instance."""
+
+    python_command: List[str] = attrs.field(factory=list)
+    """The command to use when launching the python interpreter."""
+
+    build_command: List[str] = attrs.field(factory=list)
+    """The sphinx-build command to use."""
+
+    cwd: str = attrs.field(default="")
+    """The working directory to use."""
+
+    python_path: Optional[pathlib.Path] = attrs.field(default=get_python_path())
+    """The value of ``PYTHONPATH`` to use when injecting the sphinx agent into the
+    target environment"""
+
+    def resolve(
+        self,
+        uri: str,
+        workspace: Workspace,
+        logger: logging.Logger,
+    ) -> "Optional[SphinxConfig]":
+        """Resolve the configuration based on user provided values."""
+
+        if self.python_path is None:
+            logger.error("Unable to locate the sphinx agent")
+            return None
+
+        cwd = self._resolve_cwd(uri, workspace, logger)
+        if cwd is None:
+            return None
+
+        build_command = self.build_command
+        if len(build_command) == 0:
+            build_command = self._guess_build_command(uri, logger)
+
+        return SphinxConfig(
+            cwd=cwd,
+            python_command=self.python_command,
+            build_command=build_command,
+            python_path=self.python_path,
+        )
+
+    def _resolve_cwd(self, uri: str, workspace: Workspace, logger: logging.Logger):
+        for folder_uri in workspace.folders.keys():
+            if uri.startswith(folder_uri):
+                break
+        else:
+            folder_uri = workspace.root_uri
+
+        cwd = Uri.to_fs_path(folder_uri)
+        if cwd is None:
+            logger.error("Unable to determine working directory from '%s'", folder_uri)
+            return None
+
+        logger.debug("Cwd: %s", cwd)
+        return cwd
+
+    def _guess_build_command(self, uri: str, logger: logging.Logger) -> List[str]:
+        """Try and guess something a sensible build command given the uri."""
+
+        path = Uri.to_fs_path(uri)
+        if path is None:
+            return []
+
+        # Search upwards from the given uri to see if we find something that looks like
+        # a sphinx conf.py file.
+        previous = None
+        current = pathlib.Path(path)
+
+        while previous != current:
+            previous = current
+            current = previous.parent
+
+            conf_py = current / "conf.py"
+            logger.debug("Trying path: %s", current)
+            if conf_py.exists():
+                cache = appdirs.user_cache_dir("esbonio", "swyddfa")
+                project = hashlib.md5(str(current).encode()).hexdigest()
+                build_dir = str(pathlib.Path(cache, project))
+                return ["sphinx-build", "-M", "dirhtml", str(current), str(build_dir)]
+
+        return []

--- a/lib/esbonio/esbonio/server/features/sphinx_manager/manager.py
+++ b/lib/esbonio/esbonio/server/features/sphinx_manager/manager.py
@@ -1,125 +1,19 @@
 from __future__ import annotations
 
-import hashlib
-import importlib.util
-import logging
-import pathlib
 import typing
 from typing import Dict
-from typing import List
 from typing import Optional
 
-import appdirs
-import attrs
 import lsprotocol.types as lsp
 import pygls.uris as Uri
-from pygls.workspace import Workspace
 
 from esbonio.server import LanguageFeature
 
 from .client import make_sphinx_client
+from .config import SphinxConfig
 
 if typing.TYPE_CHECKING:
     from .client import SphinxClient
-
-
-def get_python_path() -> Optional[pathlib.Path]:
-    spec = importlib.util.find_spec("esbonio.sphinx_agent")
-    if spec is None:
-        return None
-
-    if spec.origin is None:
-        return None
-
-    # origin = .../esbonio/sphinx_agent/__init__.py
-    agent = pathlib.Path(spec.origin)
-    return agent.parent.parent
-
-
-@attrs.define
-class SphinxConfig:
-    """Configuration for the sphinx application instance."""
-
-    python_command: List[str] = attrs.field(factory=list)
-    """The command to use when launching the python interpreter."""
-
-    build_command: List[str] = attrs.field(factory=list)
-    """The sphinx-build command to use."""
-
-    cwd: str = attrs.field(default="")
-    """The working directory to use."""
-
-    python_path: Optional[pathlib.Path] = attrs.field(default=get_python_path())
-    """The value of ``PYTHONPATH`` to use when injecting the sphinx agent into the
-    target environment"""
-
-    def resolve(
-        self,
-        uri: str,
-        workspace: Workspace,
-        logger: logging.Logger,
-    ) -> "Optional[SphinxConfig]":
-        """Resolve the configuration based on user provided values."""
-
-        if self.python_path is None:
-            logger.error("Unable to locate the sphinx agent")
-            return None
-
-        cwd = self._resolve_cwd(uri, workspace, logger)
-        if cwd is None:
-            return None
-
-        build_command = self.build_command
-        if len(build_command) == 0:
-            build_command = self._guess_build_command(uri, logger)
-
-        return SphinxConfig(
-            cwd=cwd,
-            python_command=self.python_command,
-            build_command=build_command,
-            python_path=self.python_path,
-        )
-
-    def _resolve_cwd(self, uri: str, workspace: Workspace, logger: logging.Logger):
-        for folder_uri in workspace.folders.keys():
-            if uri.startswith(folder_uri):
-                break
-        else:
-            folder_uri = workspace.root_uri
-
-        cwd = Uri.to_fs_path(folder_uri)
-        if cwd is None:
-            logger.error("Unable to determine working directory from '%s'", folder_uri)
-            return None
-
-        logger.debug("Cwd: %s", cwd)
-        return cwd
-
-    def _guess_build_command(self, uri: str, logger: logging.Logger) -> List[str]:
-        """Try and guess something a sensible build command given the uri."""
-
-        path = Uri.to_fs_path(uri)
-        if path is None:
-            return []
-
-        # Search upwards from the given uri to see if we find something that looks like
-        # a sphinx conf.py file.
-        previous = None
-        current = pathlib.Path(path)
-
-        while previous != current:
-            previous = current
-            current = previous.parent
-
-            conf_py = current / "conf.py"
-            logger.debug("Trying path: %s", current)
-            if conf_py.exists():
-                cache = appdirs.user_cache_dir("esbonio", "swyddfa")
-                project = hashlib.md5(str(current).encode()).hexdigest()
-                build_dir = str(pathlib.Path(cache, project))
-                return ["sphinx-build", "-M", "dirhtml", str(current), str(build_dir)]
-
-        return []
 
 
 class SphinxManager(LanguageFeature):
@@ -179,26 +73,18 @@ class SphinxManager(LanguageFeature):
             self.logger.error("Unable to start Sphinx: missing build command")
             return None
 
-        command = [*resolved.python_command, "-m", "sphinx_agent"]
-        self.logger.debug("Starting sphinx agent: %s", " ".join(command))
-
         client = make_sphinx_client(self)
-        await client.start_io(
-            *command, env={"PYTHONPATH": resolved.python_path}, cwd=resolved.cwd
-        )
+        await client.start(resolved)
 
-        if client.stopped:
+        sphinx_info = await client.create_application(resolved)
+        if sphinx_info is None:
+            self.logger.error("No application object!")
+            await client.stop()
             return None
 
-        self.logger.debug("Starting sphinx: %s", " ".join(resolved.build_command))
-        response = await client.protocol.send_request_async(
-            "sphinx/createApp", {"command": resolved.build_command}
-        )
-        self.logger.debug("Sphinx started: %s", response)
-
-        src_uri = Uri.from_fs_path(response.src_dir)
+        src_uri = client.src_uri
         if src_uri is None:
-            self.logger.error("Invalid srcdir '%s'", response.src_dir)
+            self.logger.error("No src uri!")
             await client.stop()
             return None
 

--- a/lib/esbonio/esbonio/server/server.py
+++ b/lib/esbonio/esbonio/server/server.py
@@ -287,6 +287,8 @@ def _get_setup_arguments(
             args[name] = server
             continue
 
+        from .feature import LanguageFeature
+
         if issubclass(type_, LanguageFeature):
             # Try and obtain an instance of the requested language feature.
             feature = server.get_feature(type_)


### PR DESCRIPTION
Rather than spin up the http server in a separate process (like
`SphinxLanguageServer` does), it looks like we can get away with
pushing it into the server's `ThreadPoolExecutor` which should make
communication a little easier.

The idea here is that the client calls the
`esbonio.server.previewFile` command with the uri it wishes to
preview. The `PreviewManager` then spins up the http server and
otherwise configures it to serve the relevant Sphinx project.

It then replies to the client with the full uri required to view the
relevant HTML file - removing the need for each client to figure it
out themselves.

While multi-project support is possible - it's only one at a time at
the moment