### PR TITLE
Fixes for the Sphinx agent

### DIFF
--- a/lib/esbonio/esbonio/server/features/sphinx_manager/client.py
+++ b/lib/esbonio/esbonio/server/features/sphinx_manager/client.py
@@ -3,12 +3,15 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import os
 import sys
 import typing
 from typing import Any
+from typing import Dict
 from typing import Optional
 
 import pygls.uris as Uri
+from pygls import IS_WIN
 from pygls.client import Client
 from pygls.protocol import JsonRPCProtocol
 
@@ -112,7 +115,7 @@ class SphinxClient(Client):
             command.extend([sys.executable, "-m", "lsp_devtools", "agent", "--"])
 
         command.extend([*config.python_command, "-m", "sphinx_agent"])
-        env = {"PYTHONPATH": ":".join([str(p) for p in config.python_path])}
+        env = get_sphinx_env(config)
 
         self.logger.debug("Sphinx agent env: %s", json.dumps(env, indent=2))
         self.logger.debug("Starting sphinx agent: %s", " ".join(command))

--- a/lib/esbonio/esbonio/server/features/sphinx_manager/config.py
+++ b/lib/esbonio/esbonio/server/features/sphinx_manager/config.py
@@ -53,6 +53,9 @@ class SphinxConfig:
     build_command: List[str] = attrs.field(factory=list)
     """The sphinx-build command to use."""
 
+    env_passthrough: List[str] = attrs.field(factory=list)
+    """List of environment variables to pass through to the Sphinx subprocess"""
+
     cwd: str = attrs.field(default="")
     """The working directory to use."""
 


### PR DESCRIPTION
- Decouple the `SphinxClient` from the `SphinxManager` feature.
- Update the helper `_resolve_xxx` methods on `SphinxConfig` to behave more consistently.
  Only resolve fields if no value has been given.
- Add "private" helper method to `SphinxManager` for fetching the user's `SphinxConfig`
- If the sphinx agent's process exits - cancel any pending requests
- Add option to allow the user specify a list of environment variables to pass through to the sphinx agent's process 