### PR TITLE
Deprecate appdirs in favour of drop-in replacement platformdirs

### DIFF
--- a/code/requirements.txt
+++ b/code/requirements.txt
@@ -4,10 +4,6 @@
 #
 #    pip-compile --generate-hashes --resolver=backtracking ./requirements.in
 #
-appdirs==1.4.4 \
-    --hash=sha256:7d5d0167b2b1ba821647616af46a749d1c653740dd0d2415100fe26e27afdf41 \
-    --hash=sha256:a841dacd6b99318a741b166adb07e19ee71a274450e68237b4650ca1055ab128
-    # via esbonio
 attrs==23.1.0 \
     --hash=sha256:1f28b4522cdc2fb4256ac1a020c78acf9cba2c6b461ccd2c126f3aa8e8335d04 \
     --hash=sha256:6279836d581513a26f1bf235f9acd333bc9115683f14f7e8fae46c98fc50e015
@@ -37,6 +33,10 @@ lsprotocol==2023.0.0a2 \
     --hash=sha256:80aae7e39171b49025876a524937c10be2eb986f4be700ca22ee7d186b8488aa \
     --hash=sha256:c4f2f77712b50d065b17f9b50d2b88c480dc2ce4bbaa56eea8269dbf54bc9701
     # via pygls
+platformdirs==3.9.1 \
+    --hash=sha256:1b42b450ad933e981d56e59f1b97495428c9bd60698baab9f3eb3d00d5822421 \
+    --hash=sha256:ad8291ae0ae5072f66c16945166cb11c63394c7a3ad1b1bc9828ca3162da8c2f
+    # via esbonio
 # WARNING: pip install will require the following package to be hashed.
 # Consider using a hashable URL like https://github.com/jazzband/pip-tools/archive/SOMECOMMIT.zip
     # via

--- a/docs/lsp/getting-started.rst
+++ b/docs/lsp/getting-started.rst
@@ -173,7 +173,7 @@ The following options control the creation of the Sphinx application object mana
 
 .. confval:: sphinx.buildDir (string)
 
-   By default the language server will choose a cache directory (as determined by `appdirs <https://pypi.org/project/appdirs>`_) to place Sphinx's build output.
+   By default the language server will choose a cache directory (as determined by `platformdirs <https://pypi.org/project/platformdirs>`_) to place Sphinx's build output.
    This option can be used to force the language server to use a location of your choosing, currently accepted values include:
 
    - ``/path/to/src/`` - An absolute path

--- a/lib/esbonio-extensions/esbonio/tutorial.py
+++ b/lib/esbonio-extensions/esbonio/tutorial.py
@@ -622,7 +622,7 @@ if __name__ == "__main__":
     import subprocess
     import sys
 
-    import appdirs
+    import platformdirs
     import pkg_resources
 
     cli = argparse.ArgumentParser(description="Launch the demo tutorial.")
@@ -638,7 +638,7 @@ if __name__ == "__main__":
 
     source = pathlib.Path(demo)
     destination = pathlib.Path(
-        appdirs.user_data_dir(appname="esbonio-tutorial", appauthor="swyddfa")
+        platformdirs.user_data_dir(appname="esbonio-tutorial", appauthor="swyddfa")
     )
 
     if args.reset and destination.exists():

--- a/lib/esbonio-extensions/esbonio/tutorial.py
+++ b/lib/esbonio-extensions/esbonio/tutorial.py
@@ -622,8 +622,8 @@ if __name__ == "__main__":
     import subprocess
     import sys
 
-    import platformdirs
     import pkg_resources
+    import platformdirs
 
     cli = argparse.ArgumentParser(description="Launch the demo tutorial.")
     cli.add_argument(

--- a/lib/esbonio-extensions/setup.cfg
+++ b/lib/esbonio-extensions/setup.cfg
@@ -27,8 +27,8 @@ python_requires = >=3.7
 packages = find_namespace:
 include_package_data = True
 install_requires =
-    appdirs
     esbonio
+    platformdirs
     sphinx
 
 [options.packages.find]

--- a/lib/esbonio/esbonio/lsp/sphinx/config.py
+++ b/lib/esbonio/esbonio/lsp/sphinx/config.py
@@ -17,8 +17,8 @@ from typing import Tuple
 from typing import Union
 from unittest import mock
 
-import appdirs
 import attrs
+import platformdirs
 import pygls.uris as Uri
 from lsprotocol.types import Diagnostic
 from lsprotocol.types import DiagnosticSeverity
@@ -327,7 +327,7 @@ class SphinxConfig:
 
         If nothing is specified in the given ``config``, this will choose a location
         within the user's cache dir (as determined by
-        `appdirs <https://pypi.org/project/appdirs>`). The directory name will be a hash
+        `platformdirs <https://pypi.org/project/platformdirs>`). The directory name will be a hash
         derived from the given ``conf_dir`` for the project.
 
         Alternatively the user (or least language client) can override this by setting
@@ -352,7 +352,7 @@ class SphinxConfig:
 
         if not self.build_dir:
             # Try to pick a sensible dir based on the project's location
-            cache = appdirs.user_cache_dir("esbonio", "swyddfa")
+            cache = platformdirs.user_cache_dir("esbonio", "swyddfa")
             project = hashlib.md5(str(actual_conf_dir).encode()).hexdigest()
 
             return pathlib.Path(cache) / project

--- a/lib/esbonio/esbonio/server/features/sphinx_manager/config.py
+++ b/lib/esbonio/esbonio/server/features/sphinx_manager/config.py
@@ -5,8 +5,8 @@ import pathlib
 from typing import List
 from typing import Optional
 
-import appdirs
 import attrs
+import platformdirs
 from pygls.workspace import Workspace
 
 from esbonio.server import Uri
@@ -232,7 +232,7 @@ class SphinxConfig:
             conf_py = current / "conf.py"
             logger.debug("Trying path: %s", current)
             if conf_py.exists():
-                cache = appdirs.user_cache_dir("esbonio", "swyddfa")
+                cache = platformdirs.user_cache_dir("esbonio", "swyddfa")
                 project = hashlib.md5(str(current).encode()).hexdigest()
                 build_dir = str(pathlib.Path(cache, project))
                 return ["sphinx-build", "-M", "dirhtml", str(current), str(build_dir)]

--- a/lib/esbonio/flake.nix
+++ b/lib/esbonio/flake.nix
@@ -41,8 +41,8 @@
 
                 packages = with pkgs."python${py}Packages"; [
                   # Runtime deps
-                  appdirs
                   docutils
+                  platformdirs
                   pygls
                   websockets
 
@@ -61,7 +61,7 @@
 
               packages = with pkgs."python${py}Packages"; [
                 # Runtime deps
-                appdirs
+                platformdirs
                 pygls
                 sphinx
 

--- a/lib/esbonio/nix/esbonio-overlay.nix
+++ b/lib/esbonio/nix/esbonio-overlay.nix
@@ -8,8 +8,8 @@ final: prev: {
         src = ./..;
 
         propagatedBuildInputs = with python-prev; [
-          appdirs
           docutils
+          platformdirs
           pygls
           websockets
         ];

--- a/lib/esbonio/pyproject.toml
+++ b/lib/esbonio/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
     "Topic :: Documentation",
     "Topic :: Documentation :: Sphinx",
 ]
-dependencies = ["appdirs", "docutils", "pygls>=1.0.0", "websockets"]
+dependencies = ["platformdirs", "docutils", "pygls>=1.0.0", "websockets"]
 
 [project.urls]
 "Bug Tracker" = "https://github.com/swyddfa/esbonio/issues"
@@ -39,7 +39,6 @@ test = ["pytest", "pytest-lsp>=0.3", "pytest-cov", "pytest-timeout"]
 typecheck = [
     "mypy",
     "pytest-lsp>=0.3",
-    "types-appdirs",
     "types-docutils",
     "types-pygments",
 ]

--- a/lib/esbonio/tests/sphinx-default/test_sd_sphinx.py
+++ b/lib/esbonio/tests/sphinx-default/test_sd_sphinx.py
@@ -3,7 +3,7 @@ import sys
 import tempfile
 from typing import List
 
-import appdirs
+import platformdirs
 import pygls.uris as uri
 import pytest
 from lsprotocol.types import ClientCapabilities
@@ -126,7 +126,7 @@ async def test_document_links(
             SphinxConfig(
                 conf_dir="ROOT",
                 src_dir="ROOT",
-                build_dir=appdirs.user_cache_dir("esbonio", "swyddfa"),
+                build_dir=platformdirs.user_cache_dir("esbonio", "swyddfa"),
                 builder_name="html",
             ),
         ),
@@ -137,7 +137,7 @@ async def test_document_links(
             SphinxConfig(
                 conf_dir="ROOT",
                 src_dir="ROOT",
-                build_dir=appdirs.user_cache_dir("esbonio", "swyddfa"),
+                build_dir=platformdirs.user_cache_dir("esbonio", "swyddfa"),
                 builder_name="html",
             ),
         ),
@@ -148,7 +148,7 @@ async def test_document_links(
             SphinxConfig(
                 conf_dir="ROOT/workspace",
                 src_dir="ROOT/workspace",
-                build_dir=appdirs.user_cache_dir("esbonio", "swyddfa"),
+                build_dir=platformdirs.user_cache_dir("esbonio", "swyddfa"),
                 builder_name="html",
             ),
         ),
@@ -159,7 +159,7 @@ async def test_document_links(
             SphinxConfig(
                 conf_dir="ROOT/workspace",
                 src_dir="ROOT/workspace",
-                build_dir=appdirs.user_cache_dir("esbonio", "swyddfa"),
+                build_dir=platformdirs.user_cache_dir("esbonio", "swyddfa"),
                 builder_name="html",
             ),
         ),
@@ -170,7 +170,7 @@ async def test_document_links(
             SphinxConfig(
                 conf_dir="ROOT/workspace",
                 src_dir="ROOT/workspace",
-                build_dir=appdirs.user_cache_dir("esbonio", "swyddfa"),
+                build_dir=platformdirs.user_cache_dir("esbonio", "swyddfa"),
                 builder_name="html",
             ),
         ),
@@ -181,7 +181,7 @@ async def test_document_links(
             SphinxConfig(
                 conf_dir="ROOT",
                 src_dir="ROOT",
-                build_dir=appdirs.user_cache_dir("esbonio", "swyddfa"),
+                build_dir=platformdirs.user_cache_dir("esbonio", "swyddfa"),
                 builder_name="html",
             ),
         ),
@@ -192,7 +192,7 @@ async def test_document_links(
             SphinxConfig(
                 conf_dir="ROOT",
                 src_dir="ROOT",
-                build_dir=appdirs.user_cache_dir("esbonio", "swyddfa"),
+                build_dir=platformdirs.user_cache_dir("esbonio", "swyddfa"),
                 builder_name="html",
             ),
         ),
@@ -203,7 +203,7 @@ async def test_document_links(
             SphinxConfig(
                 conf_dir="ROOT",
                 src_dir="ROOT/../workspace",
-                build_dir=appdirs.user_cache_dir("esbonio", "swyddfa"),
+                build_dir=platformdirs.user_cache_dir("esbonio", "swyddfa"),
                 builder_name="html",
             ),
         ),
@@ -217,7 +217,7 @@ async def test_document_links(
             SphinxConfig(
                 conf_dir="ROOT/workspace-src",
                 src_dir="ROOT/workspace",
-                build_dir=appdirs.user_cache_dir("esbonio", "swyddfa"),
+                build_dir=platformdirs.user_cache_dir("esbonio", "swyddfa"),
                 builder_name="html",
             ),
         ),
@@ -231,7 +231,7 @@ async def test_document_links(
             SphinxConfig(
                 conf_dir="ROOT/workspace-src",
                 src_dir="ROOT/workspace",
-                build_dir=appdirs.user_cache_dir("esbonio", "swyddfa"),
+                build_dir=platformdirs.user_cache_dir("esbonio", "swyddfa"),
                 builder_name="html",
             ),
         ),
@@ -242,7 +242,7 @@ async def test_document_links(
             SphinxConfig(
                 conf_dir="ROOT",
                 src_dir="ROOT",
-                build_dir=appdirs.user_cache_dir("esbonio", "swyddfa"),
+                build_dir=platformdirs.user_cache_dir("esbonio", "swyddfa"),
                 builder_name="html",
             ),
         ),
@@ -253,7 +253,7 @@ async def test_document_links(
             SphinxConfig(
                 conf_dir="ROOT",
                 src_dir="ROOT/../workspace",
-                build_dir=appdirs.user_cache_dir("esbonio", "swyddfa"),
+                build_dir=platformdirs.user_cache_dir("esbonio", "swyddfa"),
                 builder_name="html",
             ),
         ),


### PR DESCRIPTION
**Disclaimer**
I was unable to get a development environment setup for this project, but the `appdirs`->`platformdirs` conversion *should* be pretty much seamless.