### PR TITLE
VSCode extension improvements and test cases for the lsp server

### DIFF
--- a/code/.bumpversion.cfg
+++ b/code/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.90.0
+current_version = 0.90.1
 commit = False
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(-dev(?P<dev>\d+))?

--- a/code/changes/619.breaking.rst
+++ b/code/changes/619.breaking.rst
@@ -1,0 +1,28 @@
+The following server configuration options have been removed as they are no longer required.
+
+- ``esbonio.server.installBehavior``
+- ``esbonio.server.updateBehavior``
+- ``esbonio.server.updateFrequency``
+
+The language server is now bundled as part of the VSCode extension itself, so a separate installation step is no longer necessary.
+
+The following sphinx configuration options have been removed
+
+- ``esbonio.server.hideSphinxOutput``
+- ``esbonio.sphinx.buildDir``
+- ``esbonio.sphinx.builderName``
+- ``esbonio.sphinx.confDir``
+- ``esbonio.sphinx.doctreeDir``
+- ``esbonio.sphinx.forceFullBuild``
+- ``esbonio.sphinx.keepGoing``
+- ``esbonio.sphinx.makeMode``
+- ``esbonio.sphinx.numJobs``
+- ``esbonio.sphinx.quiet``
+- ``esbonio.sphinx.silent``
+- ``esbonio.sphinx.srcDir``
+- ``esbonio.sphinx.tags``
+- ``esbonio.sphinx.verbosity``
+- ``esbonio.sphinx.warningIsError``
+
+The Sphinx application instance is now launched using a standard ``sphinx-build`` command line provided through the ``esbonio.sphinx.buildCommand`` option, so individual options are no longer necessary.
+**Note:** The ``esbonio.sphinx.configOverrides`` option has been preserved as it can be easier to use than the equivalent command line options.

--- a/code/changes/xxx.enhancement.rst
+++ b/code/changes/xxx.enhancement.rst
@@ -1,0 +1,25 @@
+The following server configuration values have been added
+
+- ``esbonio.server.enableDevTools``: Enable integration with `lsp-devtools <https://github.com/swyddfa/lsp-devtools>`__ for the language server itself.
+
+The following sphinx configuration values have been added
+
+- ``esbonio.sphinx.buildCommand``: Set the ``sphinx-build`` command to use when invoking the Sphinx subprocess
+
+- ``esbonio.sphinx.pythonCommand``: By default, the extension will attempt to reuse the Python environment you have configured in the Python extension when invoking Sphinx.
+  This option can be used to override this behavior.
+
+- ``esbonio.sphinx.cwd``: The working directory from which to launch the Sphinx process
+
+- ``esbonio.sphinx.envPassthrough``: A list of envrionment variables to pass through to the Sphinx process.
+
+- ``esbonio.sphinx.enableDevTools``: Enable integration with `lsp-devtools <https://github.com/swyddfa/lsp-devtools>`__ for the sphinx process
+
+  - ``esbonio.sphinx.pythonPath``: Used to override the Python packages (typically ``esbonio.sphinx_agent``) that are injected into the Sphinx environment
+
+The following preview related options have been added
+
+- ``esbonio.sphinx.enableSyncScrolling``: Enable support for syncronised scrolling between the editor and preview pane
+- ``esbonio.preview.bind``: Set the network interface that the preview server binds to
+- ``esbonio.preview.httpPort``: Set the port number the HTTP server binds to
+- ``esbonio.preview.wsPort``: Set the port number the WebSocket server binds to

--- a/code/package.json
+++ b/code/package.json
@@ -8,7 +8,7 @@
     "author": "Esbonio Developers",
     "publisher": "swyddfa",
     "license": "MIT",
-    "version": "0.90.0",
+    "version": "0.90.1",
     "keywords": [
         "sphinx",
         "documentation"
@@ -140,7 +140,7 @@
                         "items": {
                             "type": "string"
                         },
-                        "description": "A list of logger names to limit output from"
+                        "description": "If set, only messages from the named loggers will be shown"
                     },
                     "esbonio.server.pythonPath": {
                         "scope": "window",
@@ -153,12 +153,6 @@
             {
                 "title": "Sphinx",
                 "properties": {
-                    "esbonio.sphinx.pythonCommand": {
-                        "scope": "resource",
-                        "type": "array",
-                        "default": [],
-                        "description": "The command to use when launching the Python interpreter."
-                    },
                     "esbonio.sphinx.buildCommand": {
                         "scope": "resource",
                         "type": "array",
@@ -167,6 +161,56 @@
                         },
                         "default": [],
                         "description": "The sphinx-build command to use."
+                    },
+                    "esbonio.sphinx.pythonCommand": {
+                        "scope": "resource",
+                        "type": "array",
+                        "default": [],
+                        "description": "The command to use when launching the Python interpreter for the process hosting the Sphinx application."
+                    },
+                    "esbonio.sphinx.cwd": {
+                        "scope": "resource",
+                        "type": "string",
+                        "default": "",
+                        "description": "The working directory from which to launch the Sphinx process. If not set, this will default to the root of the workspace folder containing the project."
+                    },
+                    "esbonio.sphinx.envPassthrough": {
+                        "scope": "resource",
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "default": [],
+                        "description": "A list of environment variables to pass through to the Sphinx process."
+                    }
+                }
+            },
+            {
+                "title": "Previews",
+                "properties": {
+                    "esbonio.sphinx.enableSyncScrolling": {
+                        "scope": "window",
+                        "type": "boolean",
+                        "default": true,
+                        "description": "Enable syncronsied scrolling between the editor and preview pane"
+                    },
+                    "esbonio.preview.bind": {
+                        "scope": "window",
+                        "type": "string",
+                        "default": "localhost",
+                        "description": "The network interface to bind the preview server to."
+                    },
+                    "esbonio.preview.httpPort": {
+                        "scope": "window",
+                        "type": "integer",
+                        "default": 0,
+                        "description": "The port number to bind the HTTP server to.\nIf 0, a random port number will be chosen"
+                    },
+                    "esbonio.preview.wsPort": {
+                        "scope": "window",
+                        "type": "integer",
+                        "default": 0,
+                        "description": "The port number to bind the WebSocket server to.\nIf 0, a random port number will be chosen"
                     }
                 }
             },
@@ -209,6 +253,15 @@
                         "type": "boolean",
                         "default": false,
                         "description": "Flag to enable support for additional developer tooling for sphinx agent instances."
+                    },
+                    "esbonio.sphinx.pythonPath": {
+                        "scope": "resource",
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "default": [],
+                        "description": "List of paths to use when constructing the value of PYTHONPATH. Used to inject the sphinx agent into the target environment."
                     }
                 }
             }

--- a/code/pyproject.toml
+++ b/code/pyproject.toml
@@ -6,6 +6,11 @@ issue_format = "`#{issue} <https://github.com/swyddfa/esbonio/issues/{issue}>`_"
 underlines = ["-", "^", "\""]
 
 [[tool.towncrier.type]]
+directory = "breaking"
+name = "Breaking Changes"
+showcontent = true
+
+[[tool.towncrier.type]]
 directory = "feature"
 name = "Features"
 showcontent = true
@@ -23,11 +28,6 @@ showcontent = true
 [[tool.towncrier.type]]
 directory = "enhancement"
 name = "Enhancements"
-showcontent = true
-
-[[tool.towncrier.type]]
-directory = "breaking"
-name = "Breaking Changes"
 showcontent = true
 
 [[tool.towncrier.type]]

--- a/code/src/node/client.ts
+++ b/code/src/node/client.ts
@@ -239,7 +239,7 @@ export class EsbonioClient {
       middleware: {
         workspace: {
           configuration: async (params: ConfigurationParams, token: CancellationToken, next) => {
-            this.logger.debug(`workspace/configuration: ${JSON.stringify(params, undefined, 2)}`)
+            // this.logger.debug(`workspace/configuration: ${JSON.stringify(params, undefined, 2)}`)
 
             let index = -1
             params.items.forEach((item, i) => {

--- a/lib/esbonio/tests/conftest.py
+++ b/lib/esbonio/tests/conftest.py
@@ -1,8 +1,9 @@
 import asyncio
 import pathlib
 
-import pygls.uris as Uri
 import pytest
+
+from esbonio.server import Uri
 
 TEST_DIR = pathlib.Path(__file__).parent
 
@@ -15,11 +16,7 @@ def uri_for():
     def fn(*args):
         path = (TEST_DIR / pathlib.Path(*args)).resolve()
         assert path.exists()
-
-        uri = Uri.from_fs_path(str(path))
-        assert uri is not None
-
-        return uri
+        return Uri.for_file(str(path))
 
     return fn
 

--- a/lib/esbonio/tests/sphinx-agent/test_sa_build.py
+++ b/lib/esbonio/tests/sphinx-agent/test_sa_build.py
@@ -1,0 +1,80 @@
+import logging
+import sys
+
+import pytest
+import pytest_asyncio
+from lsprotocol.types import WorkspaceFolder
+from pygls.workspace import Workspace
+
+from esbonio.server import Uri
+from esbonio.server.features.sphinx_manager.client_subprocess import (
+    SubprocessSphinxClient,
+)
+from esbonio.server.features.sphinx_manager.config import SphinxConfig
+
+
+@pytest_asyncio.fixture(scope="module")
+async def sphinx_client(uri_for, tmp_path_factory):
+    # TODO: Integrate with `pytest_lsp`
+    logger = logging.getLogger("sphinx_client")
+    logger.setLevel(logging.INFO)
+
+    client = SubprocessSphinxClient()
+
+    @client.feature("window/logMessage")
+    def _(params):
+        logger.info("%s", params.message)
+
+    build_dir = tmp_path_factory.mktemp("build")
+    test_uri = uri_for("sphinx-default", "workspace", "index.rst")
+    sd_workspace = uri_for("sphinx-default", "workspace")
+
+    workspace = Workspace(
+        None,
+        workspace_folders=[
+            WorkspaceFolder(uri=str(sd_workspace), name="sphinx-default"),
+        ],
+    )
+    config = SphinxConfig(
+        build_command=["sphinx-build", "-M", "html", ".", str(build_dir)],
+        python_command=[sys.executable],
+        env_passthrough=["PYTHONPATH"],
+    )
+    resolved = config.resolve(test_uri, workspace, client.logger)
+    assert resolved is not None
+
+    info = await client.create_application(resolved)
+    assert info is not None
+
+    yield client
+
+    if not client.stopped:
+        await client.stop()
+
+
+@pytest.mark.asyncio
+async def test_build_file_map(sphinx_client, uri_for):
+    """Ensure that we can trigger a Sphinx build correctly and the returned
+    build_file_map is correct."""
+
+    src = sphinx_client.src_uri
+    assert src is not None
+
+    build_file_map = {
+        (src / "index.rst").fs_path: "index.html",
+        (src / "definitions.rst").fs_path: "definitions.html",
+        (src / "directive_options.rst").fs_path: "directive_options.html",
+        (src / "glossary.rst").fs_path: "glossary.html",
+        (src / "math.rst").fs_path: "theorems/pythagoras.html",
+        (src / "code" / "cpp.rst").fs_path: "code/cpp.html",
+        (src / "theorems" / "index.rst").fs_path: "theorems/index.html",
+        (src / "theorems" / "pythagoras.rst").fs_path: "theorems/pythagoras.html",
+        # It looks like non-existant files show up in this mapping as well
+        (src / ".." / "badfile.rst").fs_path: "definitions.html",
+    }
+
+    result = await sphinx_client.build()
+    assert result.build_file_map == build_file_map
+
+    build_uri_map = {Uri.for_file(src): out for src, out in build_file_map.items()}
+    assert sphinx_client.build_file_map == build_uri_map

--- a/lib/esbonio/tests/sphinx-agent/test_sa_create_app.py
+++ b/lib/esbonio/tests/sphinx-agent/test_sa_create_app.py
@@ -41,7 +41,10 @@ async def test_create_application(sphinx_client, uri_for):
             WorkspaceFolder(uri=str(sd_workspace), name="sphinx-default"),
         ],
     )
-    config = SphinxConfig(python_command=[sys.executable])
+    config = SphinxConfig(
+        python_command=[sys.executable],
+        env_passthrough=["PYTHONPATH"],
+    )
     resolved = config.resolve(test_uri, workspace, sphinx_client.logger)
     assert resolved is not None
 

--- a/lib/esbonio/tests/sphinx-agent/test_sa_create_app.py
+++ b/lib/esbonio/tests/sphinx-agent/test_sa_create_app.py
@@ -1,14 +1,14 @@
 import logging
 import sys
 
-import pygls.uris as Uri
 import pytest
 from lsprotocol.types import WorkspaceFolder
 from pygls.workspace import Workspace
 
-from esbonio.server.features.sphinx_manager.client import SphinxClient
-from esbonio.server.features.sphinx_manager.client import SphinxConfig
-from esbonio.sphinx_agent import types
+from esbonio.server.features.sphinx_manager.client_subprocess import (
+    SubprocessSphinxClient,
+)
+from esbonio.server.features.sphinx_manager.config import SphinxConfig
 
 
 @pytest.fixture()
@@ -17,7 +17,7 @@ def sphinx_client():
     logger = logging.getLogger("sphinx_client")
     logger.setLevel(logging.INFO)
 
-    client = SphinxClient()
+    client = SubprocessSphinxClient()
 
     @client.feature("window/logMessage")
     def _(params):
@@ -32,13 +32,13 @@ async def test_create_application(sphinx_client, uri_for):
 
     test_uri = uri_for("sphinx-default", "workspace", "index.rst")
     sd_workspace = uri_for("sphinx-default", "workspace")
+    se_workspace = uri_for("sphinx-extensions", "workspace")
+
     workspace = Workspace(
         None,
         workspace_folders=[
-            WorkspaceFolder(
-                uri=uri_for("sphinx-extensions", "workspace"), name="sphinx-extensions"
-            ),
-            WorkspaceFolder(uri=sd_workspace, name="sphinx-default"),
+            WorkspaceFolder(uri=str(se_workspace), name="sphinx-extensions"),
+            WorkspaceFolder(uri=str(sd_workspace), name="sphinx-default"),
         ],
     )
     config = SphinxConfig(python_command=[sys.executable])
@@ -46,15 +46,12 @@ async def test_create_application(sphinx_client, uri_for):
     assert resolved is not None
 
     try:
-        await sphinx_client.start(resolved)
-        assert not sphinx_client.stopped
-
         info = await sphinx_client.create_application(resolved)
         assert info is not None
 
         assert info.builder_name == "dirhtml"
-        assert info.src_dir == Uri.to_fs_path(sd_workspace)
-        assert info.conf_dir == Uri.to_fs_path(sd_workspace)
+        assert info.src_dir == sd_workspace.fs_path
+        assert info.conf_dir == sd_workspace.fs_path
         assert "cache" in info.build_dir.lower()
     finally:
         if not sphinx_client.stopped:

--- a/lib/esbonio/tests/sphinx-agent/test_sa_unit.py
+++ b/lib/esbonio/tests/sphinx-agent/test_sa_unit.py
@@ -13,6 +13,7 @@ import pytest
 from lsprotocol.types import WorkspaceFolder
 from pygls.workspace import Workspace
 
+from esbonio.server import Uri
 from esbonio.server.features.sphinx_manager.config import (
     SphinxConfig as SphinxAgentConfig,
 )
@@ -504,7 +505,7 @@ def test_resolve_sphinx_config(
 ):
     """Ensure that we can resolve the client side config for the SphinxAgent
     correctly."""
-    assert expected == config.resolve(uri, workspace, logger)
+    assert expected == config.resolve(Uri.parse(uri), workspace, logger)
 
 
 ROOT = pathlib.Path(__file__).parent.parent / "sphinx-extensions" / "workspace"


### PR DESCRIPTION
**VSCode**

- Expose new server configuration values
- Previews

  Rather than recreate the HTML page each time, it's now loaded once
  when the webview panel is created. To change page, the extension now
  uses `postMessage()` to send a message into the wrapper webpage which
  in turn updates the `src` on the embedded `<iframe>`

  An indeterminate progress indicator is displayed each time `src` of
  the `<iframe>` is updated. The wrapper webpage listens for a ready
  message from `webview.js` after which it will remove the indicator.

  The following improvements have also been implemented
  - The preview window no longer reopens itself after it has been closed
  - The preview window no longer steals focus
  - The preview is no longer pointlessly refreshed when re-focusing the
    editor for the currently shown document.
  - Thanks to improvements in the language server, the extension no
    longer attempts to show files that are not part of the Sphinx
    project.

**LSP Tests**
- Align tests to the new `Uri` class
- Passthrough `PYTHONPATH` to sphinx agent (useful when running locally with nix)
- Test case for the new `build_file_map`