### PR TITLE
Spelling: Relevant

### DIFF
--- a/docs/extensions/relevant_to.rst
+++ b/docs/extensions/relevant_to.rst
@@ -1,4 +1,4 @@
-Relevent To
+Relevant To
 ===========
 
 The ``esbonio.relevant_to`` extension is similar to the `sphinx-panels`_ and `sphinx-tabs`_ extensions, where you can define sections of documentation that is only relevant to a given subject (e.g. Python version) and be able to choose between them.
@@ -37,9 +37,9 @@ Ensure that the extension is enabled by including ``esbonio.relevant_to`` in the
    ]
 
 
-Then within your documentation, "relevant sections" are defined using the :rst:dir:`relevent-to` directive.
+Then within your documentation, "relevant sections" are defined using the :rst:dir:`relevant-to` directive.
 
-.. rst:directive:: relevent-to
+.. rst:directive:: relevant-to
 
    Define sections that can be swapped out based on the chosen subject.
    Consider the following example.

--- a/lib/esbonio-extensions/esbonio/relevant_to/__init__.py
+++ b/lib/esbonio-extensions/esbonio/relevant_to/__init__.py
@@ -89,7 +89,7 @@ class relevant_section(nodes.Element):
     ...
 
 
-def visit_relevent_section(self, node: relevant_section):
+def visit_relevant_section(self, node: relevant_section):
     # Swap the body out for an empty one so we can capture all the content that
     # should be written to a separate file
     node.page_body = self.body
@@ -197,7 +197,7 @@ class CollectSections(Transform):
 def setup(app: Sphinx):
     app.add_directive("relevant-to", RelevantTo)
     app.add_node(
-        relevant_section, html=(visit_relevent_section, depart_relevant_section)
+        relevant_section, html=(visit_relevant_section, depart_relevant_section)
     )
     app.add_node(
         relevant_to_script, html=(visit_relevant_to_script, depart_relevant_to_script)


### PR DESCRIPTION
A few spelling mistakes. Notably, ``visit_relevent_section``. But it seems that this isn't considered public API, so I've just renamed rather than deprecation + alias etc.

A