### PR TITLE
Implement `astext()` for `a_role`

### DIFF
--- a/lib/esbonio/changes/685.fix.rst
+++ b/lib/esbonio/changes/685.fix.rst
@@ -1,0 +1,1 @@
+Fix ``ValueError`` thrown when building the document symbol for a title node that only contains a role.

--- a/lib/esbonio/esbonio/lsp/rst/io.py
+++ b/lib/esbonio/esbonio/lsp/rst/io.py
@@ -32,6 +32,9 @@ class a_directive(nodes.Element, nodes.Inline):
 class a_role(nodes.Element):
     """Represents a role."""
 
+    def astext(self):
+        return self["text"]
+
 
 def dummy_role(name, rawtext, text, lineno, inliner, options={}, content=[]):
     node = a_role()

--- a/lib/esbonio/esbonio/lsp/symbols.py
+++ b/lib/esbonio/esbonio/lsp/symbols.py
@@ -73,6 +73,9 @@ class SymbolVisitor(NodeVisitor):
             symbol = self.push_symbol()
 
         name = node.astext()
+        if len(name) == 0:
+            name = "title_node"
+
         line = (node.line or 1) - 1
 
         symbol.name = name
@@ -93,6 +96,9 @@ class SymbolVisitor(NodeVisitor):
         symbol = self.push_symbol()
 
         name = node["text"]  # type: ignore
+        if len(name) == 0:
+            name = "a_directive"
+
         line = (node.line or 1) - 1
 
         symbol.name = name

--- a/lib/esbonio/tests/sphinx-default/test_sd_directives.py
+++ b/lib/esbonio/tests/sphinx-default/test_sd_directives.py
@@ -481,7 +481,7 @@ async def test_insert_range(
         ),
         (
             "theorems/pythagoras.rst",
-            53,
+            56,
             9,
             "sphinx/domains/python.py",
         ),

--- a/lib/esbonio/tests/sphinx-default/test_sd_roles.py
+++ b/lib/esbonio/tests/sphinx-default/test_sd_roles.py
@@ -430,7 +430,7 @@ async def test_role_target_insert_range(
         ),
         pytest.param(
             "theorems/pythagoras.rst",
-            50,
+            53,
             19,
             "docutils/parsers/rst/roles.py",
             marks=pytest.mark.skipif(
@@ -440,7 +440,7 @@ async def test_role_target_insert_range(
         ),
         pytest.param(
             "theorems/pythagoras.rst",
-            50,
+            53,
             19,
             "sphinx/roles.py",
             marks=pytest.mark.skipif(

--- a/lib/esbonio/tests/sphinx-default/test_sd_symbols.py
+++ b/lib/esbonio/tests/sphinx-default/test_sd_symbols.py
@@ -51,6 +51,58 @@ def symbol(
     )
 
 
+CODE_TRIANGLE = symbol(
+    name=":code:`Triangle`",
+    kind=SymbolKind.String,
+    range="33:0-33:15",
+    children=[
+        symbol(
+            name=".. class:: Triangle(a: float, b: float, c: float)",
+            kind=SymbolKind.Class,
+            range="35:0-35:48",
+            children=[
+                symbol(
+                    name=".. attribute:: a",
+                    kind=SymbolKind.Class,
+                    range="39:0-39:15",
+                ),
+                symbol(
+                    name=".. attribute:: b",
+                    kind=SymbolKind.Class,
+                    range="43:0-43:15",
+                ),
+                symbol(
+                    name=".. attribute:: c",
+                    kind=SymbolKind.Class,
+                    range="47:0-47:15",
+                ),
+                symbol(
+                    name=".. method:: is_right_angled() -> bool",
+                    kind=SymbolKind.Class,
+                    range="51:0-51:36",
+                    children=[],
+                ),
+            ],
+        ),
+        symbol(
+            name=".. function:: calc_hypotenuse(a: float, b: float) -> float",
+            kind=SymbolKind.Class,
+            range="56:0-56:57",
+        ),
+        symbol(
+            name=".. function:: calc_side(c: float, b: float) -> float",
+            kind=SymbolKind.Class,
+            range="65:0-65:51",
+        ),
+        symbol(
+            name=".. |rhs| replace:: right hand side",
+            kind=SymbolKind.Class,
+            range="74:0-74:33",
+        ),
+    ],
+)
+
+
 @pytest.mark.parametrize(
     "filepath,expected",
     [
@@ -98,49 +150,7 @@ def symbol(
                                     kind=SymbolKind.Class,
                                     range="28:0-28:16",
                                 ),
-                                symbol(
-                                    name=".. class:: Triangle(a: float, b: float, c: float)",
-                                    kind=SymbolKind.Class,
-                                    range="32:0-32:48",
-                                    children=[
-                                        symbol(
-                                            name=".. attribute:: a",
-                                            kind=SymbolKind.Class,
-                                            range="36:0-36:15",
-                                        ),
-                                        symbol(
-                                            name=".. attribute:: b",
-                                            kind=SymbolKind.Class,
-                                            range="40:0-40:15",
-                                        ),
-                                        symbol(
-                                            name=".. attribute:: c",
-                                            kind=SymbolKind.Class,
-                                            range="44:0-44:15",
-                                        ),
-                                        symbol(
-                                            name=".. method:: is_right_angled() -> bool",
-                                            kind=SymbolKind.Class,
-                                            range="48:0-48:36",
-                                            children=[],
-                                        ),
-                                    ],
-                                ),
-                                symbol(
-                                    name=".. function:: calc_hypotenuse(a: float, b: float) -> float",
-                                    kind=SymbolKind.Class,
-                                    range="53:0-53:57",
-                                ),
-                                symbol(
-                                    name=".. function:: calc_side(c: float, b: float) -> float",
-                                    kind=SymbolKind.Class,
-                                    range="62:0-62:51",
-                                ),
-                                symbol(
-                                    name=".. |rhs| replace:: right hand side",
-                                    kind=SymbolKind.Class,
-                                    range="71:0-71:33",
-                                ),
+                                CODE_TRIANGLE,
                             ],
                         ),
                     ],

--- a/lib/esbonio/tests/sphinx-default/workspace/theorems/pythagoras.rst
+++ b/lib/esbonio/tests/sphinx-default/workspace/theorems/pythagoras.rst
@@ -30,6 +30,9 @@ length of a missing side of a right angled triangle when the other two are known
 
    Used to represent an unknown value.
 
+:code:`Triangle`
+^^^^^^^^^^^^^^^^
+
 .. class:: Triangle(a: float, b: float, c: float)
 
    Represents a triangle


### PR DESCRIPTION
This should ensure that roles in titles are handled in document symbol requests correctly. Also provide a fallback name for symbols to try and prevent a similar situation from failing so dramatically in the future.

Closes #685 