### PR TITLE
Store diagnostics in the database

### DIFF
--- a/lib/esbonio/changes/689.feature.md
+++ b/lib/esbonio/changes/689.feature.md
@@ -1,0 +1,1 @@
+For the clients that support the pull diagnostics model, the server now supports the `textDocument/diagnostic` and `workspace/diagnostic` methods.

--- a/lib/esbonio/esbonio/server/cli.py
+++ b/lib/esbonio/esbonio/server/cli.py
@@ -73,6 +73,7 @@ def main(argv: Optional[Sequence[str]] = None):
         "esbonio.server.features.sphinx_manager",
         "esbonio.server.features.preview_manager",
         "esbonio.server.features.symbols",
+        "esbonio.server.features.sphinx_support.diagnostics",
     ]
 
     for mod in args.included_modules:

--- a/lib/esbonio/esbonio/server/features/sphinx_manager/client.py
+++ b/lib/esbonio/esbonio/server/features/sphinx_manager/client.py
@@ -1,3 +1,4 @@
+from typing import Any
 from typing import Dict
 from typing import List
 from typing import Optional
@@ -36,11 +37,6 @@ class SphinxClient(Protocol):
         """The URI to the Sphinx application's build dir."""
 
     @property
-    def diagnostics(self) -> Dict[Uri, List[types.Diagnostic]]:
-        """A mapping of source file uris to any diagnostic items."""
-        ...
-
-    @property
     def conf_uri(self) -> Optional[Uri]:
         """The URI to the Sphinx application's conf dir."""
 
@@ -72,6 +68,10 @@ class SphinxClient(Protocol):
 
     async def get_build_path(self, src_uri: Uri) -> Optional[str]:
         """Get the build path associated with the given ``src_uri``."""
+
+    async def get_diagnostics(self) -> Dict[Uri, List[Dict[str, Any]]]:
+        """Get the diagnostics for the project."""
+        ...
 
     async def stop(self):
         """Stop the client."""

--- a/lib/esbonio/esbonio/server/features/sphinx_manager/client_subprocess.py
+++ b/lib/esbonio/esbonio/server/features/sphinx_manager/client_subprocess.py
@@ -291,6 +291,10 @@ def make_test_sphinx_client() -> SubprocessSphinxClient:
     def _(params):
         logger.info("%s", params.message)
 
+    @client.feature("$/progress")
+    def _on_progress(params):
+        logger.info("%s", params)
+
     return client
 
 

--- a/lib/esbonio/esbonio/server/features/sphinx_manager/manager.py
+++ b/lib/esbonio/esbonio/server/features/sphinx_manager/manager.py
@@ -122,23 +122,6 @@ class SphinxManager(LanguageFeature):
         finally:
             self.stop_progress(client)
 
-        # Update diagnostics
-        source = f"sphinx[{client.id}]"
-        self.server.clear_diagnostics(source)
-        for uri, items in client.diagnostics.items():
-            diagnostics = [
-                lsp.Diagnostic(
-                    range=d.range,  # type: ignore[arg-type]
-                    message=d.message,
-                    source=source,
-                    severity=d.severity,  # type: ignore[arg-type]
-                )
-                for d in items
-            ]
-            self.server.set_diagnostics(f"sphinx[{client.id}]", uri, diagnostics)
-
-        self.server.sync_diagnostics()
-
         # Notify listeners.
         for listener in self.handlers.get("build", set()):
             try:

--- a/lib/esbonio/esbonio/server/features/sphinx_support/diagnostics.py
+++ b/lib/esbonio/esbonio/server/features/sphinx_support/diagnostics.py
@@ -1,0 +1,28 @@
+from functools import partial
+
+from lsprotocol import types
+
+from esbonio.server import EsbonioLanguageServer
+from esbonio.server.features.sphinx_manager import SphinxClient
+from esbonio.server.features.sphinx_manager import SphinxManager
+
+
+async def refresh_diagnostics(
+    server: EsbonioLanguageServer, client: SphinxClient, result
+):
+    """Refresh sphinx diagnostics."""
+    # TODO: Per-client id.
+    server.clear_diagnostics("sphinx")
+
+    collection = await client.get_diagnostics()
+    for uri, items in collection.items():
+        diagnostics = [
+            server.converter.structure(item, types.Diagnostic) for item in items
+        ]
+        server.set_diagnostics("sphinx", uri, diagnostics)
+
+    server.sync_diagnostics()
+
+
+def esbonio_setup(server: EsbonioLanguageServer, sphinx_manager: SphinxManager):
+    sphinx_manager.add_listener("build", partial(refresh_diagnostics, server))

--- a/lib/esbonio/esbonio/sphinx_agent/app.py
+++ b/lib/esbonio/esbonio/sphinx_agent/app.py
@@ -1,124 +1,33 @@
 from __future__ import annotations
 
 import pathlib
-import sqlite3
-from dataclasses import dataclass
-from dataclasses import field
-from typing import Any
-from typing import List
-from typing import Literal
-from typing import Optional
-from typing import Set
-from typing import Tuple
-from typing import Union
+import typing
 
 from sphinx.application import Sphinx as _Sphinx
 
+from .database import Database
+from .log import SphinxLogHandler
 
-class Database:
-    @dataclass
-    class Column:
-        name: str
-        dtype: str
-        notnull: bool = field(default=False)
-        default: Optional[Any] = field(default=None)
-        pk: int = field(default=0)
 
-        @property
-        def definition(self):
-            # TODO: Is there a way to do this via a prepared statement?
-            return f"{self.name} {self.dtype}"
+class Esbonio:
+    """Esbonio specific functionality."""
 
-    @dataclass
-    class Table:
-        name: str
-        columns: List[Database.Column]
+    db: Database
 
-        @property
-        def create_statement(self):
-            """Return the SQL statement required to create this table."""
-            # TODO: Is there a way to do this via a prepared statement?
-            columns = ",".join([c.definition for c in self.columns])
-            return "".join([f"CREATE TABLE {self.name} (", columns, ");"])
+    log: SphinxLogHandler
 
-    def __init__(self, dbpath: Union[pathlib.Path, Literal[":memory:"]]):
-        self.dbpath = dbpath
-
-        # Ensure that WAL is enabled.
-        self.db = sqlite3.connect(self.dbpath)
-        self.db.execute("PRAGMA journal_mode(WAL)")
-
-        self._checked_tables: Set[str] = set()
-
-    def _get_table(self, name: str) -> Optional[Table]:
-        """Get the table with the given name, if it exists."""
-        # TODO: SQLite does not seem to like '?' syntax in this statement...
-        cursor = self.db.execute(f"PRAGMA table_info({name});")
-        rows = cursor.fetchall()
-
-        if len(rows) == 0:
-            # Table does not exist
-            return None
-
-        columns = [
-            self.Column(name=name, dtype=type_, notnull=notnull, default=default, pk=pk)
-            for (_, name, type_, notnull, default, pk) in rows
-        ]
-
-        return self.Table(name=name, columns=columns)
-
-    def _create_table(self, table: Table):
-        """Create the given table."""
-        cursor = self.db.cursor()
-
-        # TODO: Is there a way to do this via a prepared statement?
-        cursor.execute(f"DROP TABLE IF EXISTS {table.name}")
-        cursor.execute(table.create_statement)
-        self.db.commit()
-
-    def clear_table(self, table: Table):
-        """Clear the given table"""
-        cursor = self.db.cursor()
-
-        # TODO: Is there a way to do this via a prepared statement?
-        cursor.execute(f"DELETE FROM {table.name}")
-        self.db.commit()
-
-    def ensure_table(self, table: Table):
-        """Ensure that the given table exists in the database.
-
-        If the table *does* exist, but has the wrong shape, it will be dropped and
-        recreated.
-        """
-        # If we've already checked the table, then there's nothing to do
-        if table.name in self._checked_tables:
-            return
-
-        if (existing := self._get_table(table.name)) is None:
-            self._create_table(table)
-            return
-
-        # Are the tables compatible?
-        if len(existing.columns) != len(table.columns):
-            self._create_table(table)
-        else:
-            for existing_col, col in zip(existing.columns, table.columns):
-                if existing_col.name != col.name or existing_col.dtype != col.dtype:
-                    self._create_table(table)
-                    break
-
-        self._checked_tables.add(table.name)
-
-    def insert_values(self, table: Table, values: List[Tuple]):
-        """Insert the given values into the given table."""
-        cursor = self.db.cursor()
-
-        placeholder = "(" + ",".join(["?" for _ in range(len(values[0]))]) + ")"
-        cursor.executemany(f"INSERT INTO {table.name} VALUES {placeholder}", values)
-        self.db.commit()
+    def __init__(self, dbpath: pathlib.Path):
+        self.db = Database(dbpath)
+        self.log = typing.cast(SphinxLogHandler, None)
 
 
 class Sphinx(_Sphinx):
     """A regular sphinx application with a few extra fields."""
 
-    esbonio: Database
+    esbonio: Esbonio
+
+    def __init__(self, *args, **kwargs):
+        dbpath = pathlib.Path(kwargs["outdir"], "esbonio.db").resolve()
+        self.esbonio = Esbonio(dbpath)
+
+        super().__init__(*args, **kwargs)

--- a/lib/esbonio/esbonio/sphinx_agent/database.py
+++ b/lib/esbonio/esbonio/sphinx_agent/database.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import pathlib
+import sqlite3
+from dataclasses import dataclass
+from dataclasses import field
+from typing import Any
+from typing import List
+from typing import Literal
+from typing import Optional
+from typing import Set
+from typing import Tuple
+from typing import Union
+
+
+class Database:
+    @dataclass
+    class Column:
+        name: str
+        dtype: str
+        notnull: bool = field(default=False)
+        default: Optional[Any] = field(default=None)
+        pk: int = field(default=0)
+
+        @property
+        def definition(self):
+            # TODO: Is there a way to do this via a prepared statement?
+            return f"{self.name} {self.dtype}"
+
+    @dataclass
+    class Table:
+        name: str
+        columns: List[Database.Column]
+
+        @property
+        def create_statement(self):
+            """Return the SQL statement required to create this table."""
+            # TODO: Is there a way to do this via a prepared statement?
+            columns = ",".join([c.definition for c in self.columns])
+            return "".join([f"CREATE TABLE {self.name} (", columns, ");"])
+
+    def __init__(self, dbpath: Union[pathlib.Path, Literal[":memory:"]]):
+        self.path = dbpath
+
+        if isinstance(self.path, pathlib.Path) and not self.path.parent.exists():
+            self.path.parent.mkdir(parents=True)
+
+        self.db = sqlite3.connect(self.path)
+
+        # Ensure that Write Ahead Logging is enabled.
+        self.db.execute("PRAGMA journal_mode(WAL)")
+
+        self._checked_tables: Set[str] = set()
+
+    def _get_table(self, name: str) -> Optional[Table]:
+        """Get the table with the given name, if it exists."""
+        # TODO: SQLite does not seem to like '?' syntax in this statement...
+        cursor = self.db.execute(f"PRAGMA table_info({name});")
+        rows = cursor.fetchall()
+
+        if len(rows) == 0:
+            # Table does not exist
+            return None
+
+        columns = [
+            self.Column(name=name, dtype=type_, notnull=notnull, default=default, pk=pk)
+            for (_, name, type_, notnull, default, pk) in rows
+        ]
+
+        return self.Table(name=name, columns=columns)
+
+    def _create_table(self, table: Table):
+        """Create the given table."""
+        cursor = self.db.cursor()
+
+        # TODO: Is there a way to do this via a prepared statement?
+        cursor.execute(f"DROP TABLE IF EXISTS {table.name}")
+        cursor.execute(table.create_statement)
+        self.db.commit()
+
+    def clear_table(self, table: Table):
+        """Clear the given table"""
+        cursor = self.db.cursor()
+
+        # TODO: Is there a way to do this via a prepared statement?
+        cursor.execute(f"DELETE FROM {table.name}")
+        self.db.commit()
+
+    def ensure_table(self, table: Table):
+        """Ensure that the given table exists in the database.
+
+        If the table *does* exist, but has the wrong shape, it will be dropped and
+        recreated.
+        """
+        # If we've already checked the table, then there's nothing to do
+        if table.name in self._checked_tables:
+            return
+
+        if (existing := self._get_table(table.name)) is None:
+            self._create_table(table)
+            return
+
+        # Are the tables compatible?
+        if len(existing.columns) != len(table.columns):
+            self._create_table(table)
+        else:
+            for existing_col, col in zip(existing.columns, table.columns):
+                if existing_col.name != col.name or existing_col.dtype != col.dtype:
+                    self._create_table(table)
+                    break
+
+        self._checked_tables.add(table.name)
+
+    def insert_values(self, table: Table, values: List[Tuple]):
+        """Insert the given values into the given table."""
+
+        if len(values) == 0:
+            return
+
+        cursor = self.db.cursor()
+
+        placeholder = "(" + ",".join(["?" for _ in range(len(values[0]))]) + ")"
+        cursor.executemany(f"INSERT INTO {table.name} VALUES {placeholder}", values)
+        self.db.commit()

--- a/lib/esbonio/esbonio/sphinx_agent/handlers/__init__.py
+++ b/lib/esbonio/esbonio/sphinx_agent/handlers/__init__.py
@@ -34,7 +34,10 @@ STATIC_DIR = (pathlib.Path(__file__).parent.parent / "static").resolve()
 sphinx_logger = logging.getLogger(SPHINX_LOG_NAMESPACE)
 
 # Inject our own 'core' extensions into Sphinx
-sphinx.application.builtin_extensions += (f"{__name__}.database",)
+sphinx.application.builtin_extensions += (
+    f"{__name__}.files",
+    f"{__name__}.diagnostics",
+)
 
 
 class SphinxHandler:

--- a/lib/esbonio/esbonio/sphinx_agent/handlers/diagnostics.py
+++ b/lib/esbonio/esbonio/sphinx_agent/handlers/diagnostics.py
@@ -1,0 +1,48 @@
+from typing import Optional
+
+from sphinx.config import Config
+
+from ..app import Database
+from ..app import Sphinx
+from ..util import as_json
+
+DIAGNOSTICS_TABLE = Database.Table(
+    "diagnostics",
+    [
+        Database.Column(name="path", dtype="TEXT"),
+        Database.Column(name="diagnostic", dtype="JSON"),
+    ],
+)
+
+
+def init_db(app: Sphinx, config: Config):
+    app.esbonio.db.ensure_table(DIAGNOSTICS_TABLE)
+
+
+def clear_diagnostics(app: Sphinx, docname: str, source):
+    """Clear the diagnostics assocated with the given file."""
+    filepath = app.env.doc2path(docname, base=True)
+    app.esbonio.log.diagnostics.pop(filepath, None)
+
+
+def sync_diagnostics(app: Sphinx, exc: Optional[Exception]):
+    app.esbonio.db.clear_table(DIAGNOSTICS_TABLE)
+
+    results = []
+    diagnostics = app.esbonio.log.diagnostics
+
+    for fpath, items in diagnostics.items():
+        for item in items:
+            results.append((fpath, as_json(item)))
+
+    app.esbonio.db.insert_values(DIAGNOSTICS_TABLE, results)
+
+
+def setup(app: Sphinx):
+    app.connect("config-inited", init_db)
+    app.connect("source-read", clear_diagnostics)
+
+    # TODO
+    # app.connect("include-read")
+
+    app.connect("build-finished", sync_diagnostics)

--- a/lib/esbonio/esbonio/sphinx_agent/handlers/files.py
+++ b/lib/esbonio/esbonio/sphinx_agent/handlers/files.py
@@ -19,10 +19,7 @@ FILES_TABLE = Database.Table(
 
 
 def init_db(app: Sphinx, config: Config):
-    dbpath = pathlib.Path(app.outdir, "esbonio.db")
-
-    app.esbonio = Database(dbpath)
-    app.esbonio.ensure_table(FILES_TABLE)
+    app.esbonio.db.ensure_table(FILES_TABLE)
 
 
 def build_file_mapping(app: Sphinx, exc: Optional[Exception]):
@@ -48,8 +45,8 @@ def build_file_mapping(app: Sphinx, exc: Optional[Exception]):
 
             files.append((str(path), docname, build_uri))
 
-    app.esbonio.clear_table(FILES_TABLE)
-    app.esbonio.insert_values(FILES_TABLE, files)
+    app.esbonio.db.clear_table(FILES_TABLE)
+    app.esbonio.db.insert_values(FILES_TABLE, files)
 
 
 def setup(app: Sphinx):

--- a/lib/esbonio/esbonio/sphinx_agent/util.py
+++ b/lib/esbonio/esbonio/sphinx_agent/util.py
@@ -17,11 +17,15 @@ def _serialize_message(obj):
     return obj
 
 
-def format_message(data: Any) -> str:
+def as_json(data: Any) -> str:
     if dataclasses.is_dataclass(data):
         data = dataclasses.asdict(data)
 
-    content = json.dumps(data, default=_serialize_message)
+    return json.dumps(data, default=_serialize_message)
+
+
+def format_message(data: Any) -> str:
+    content = as_json(data)
     content_length = len(content)
 
     return f"Content-Length: {content_length}\r\n\r\n{content}"

--- a/lib/esbonio/tests/e2e/test_e2e_diagnostics.py
+++ b/lib/esbonio/tests/e2e/test_e2e_diagnostics.py
@@ -1,0 +1,237 @@
+import pathlib
+import sys
+
+import pytest
+import pytest_lsp
+from lsprotocol import types
+from pytest_lsp import ClientServerConfig
+from pytest_lsp import LanguageClient
+
+SERVER_CMD = ["-m", "esbonio"]
+TEST_DIR = pathlib.Path(__file__).parent.parent
+
+
+@pytest_lsp.fixture(
+    scope="module",
+    config=ClientServerConfig(
+        server_command=[sys.executable, *SERVER_CMD],
+    ),
+)
+async def pull_client(lsp_client: LanguageClient, uri_for, tmp_path_factory):
+    """A client that supports the pull-diagnostics model."""
+    build_dir = tmp_path_factory.mktemp("build")
+    workspace_uri = uri_for("sphinx-default", "workspace")
+    test_uri = workspace_uri / "definitions.rst"
+
+    await lsp_client.initialize_session(
+        types.InitializeParams(
+            capabilities=types.ClientCapabilities(
+                # Signal pull diagnostic support
+                text_document=types.TextDocumentClientCapabilities(
+                    diagnostic=types.DiagnosticClientCapabilities(
+                        dynamic_registration=False
+                    )
+                ),
+                # Signal workDoneProgress/create support.
+                window=types.WindowClientCapabilities(
+                    work_done_progress=True,
+                ),
+            ),
+            initialization_options={
+                "server": {"logLevel": "debug"},
+                "sphinx": {
+                    "buildCommand": [
+                        "sphinx-build",
+                        "-M",
+                        "html",
+                        workspace_uri.fs_path,
+                        str(build_dir),
+                    ],
+                    "pythonCommand": [sys.executable],
+                },
+            },
+            workspace_folders=[
+                types.WorkspaceFolder(uri=str(workspace_uri), name="sphinx-default"),
+            ],
+        )
+    )
+
+    # Open a text document to trigger sphinx client creation.
+    lsp_client.text_document_did_open(
+        types.DidOpenTextDocumentParams(
+            text_document=types.TextDocumentItem(
+                uri=str(test_uri),
+                language_id="restructuredtext",
+                version=0,
+                text=pathlib.Path(test_uri).read_text(),
+            )
+        )
+    )
+
+    await lsp_client.wait_for_notification("sphinx/appCreated")
+
+    # Save the document to trigger a build
+    lsp_client.text_document_did_save(
+        types.DidSaveTextDocumentParams(
+            text_document=types.TextDocumentIdentifier(uri=str(test_uri))
+        )
+    )
+
+    build_finished = False
+    while not build_finished:
+        await lsp_client.wait_for_notification("$/progress")
+        report = list(lsp_client.progress_reports.values())[0][-1]
+        build_finished = report.kind == "end"
+
+    yield
+
+    # Teardown
+    await lsp_client.shutdown_session()
+
+
+@pytest.mark.asyncio
+async def test_document_diagnostic(pull_client: LanguageClient, uri_for):
+    """Ensure that we can get the diagnostics for a single document correctly."""
+
+    workspace_uri = uri_for("sphinx-default", "workspace")
+    test_uri = workspace_uri / "definitions.rst"
+    report = await pull_client.text_document_diagnostic_async(
+        types.DocumentDiagnosticParams(
+            text_document=types.TextDocumentIdentifier(uri=str(test_uri))
+        )
+    )
+
+    assert report.kind == "full"
+
+    # We will only check the diagnostic message, full details will be handled by other
+    # test cases.
+    messages = {d.message for d in report.items}
+    assert messages == {
+        "image file not readable: _static/bad.png",
+        "unknown document: '/changelog'",
+    }
+
+    assert len(pull_client.diagnostics) == 0, "Server should not publish diagnostics"
+
+
+@pytest.mark.asyncio
+async def test_workspace_diagnostic(pull_client: LanguageClient, uri_for):
+    """Ensure that we can get diagnostics for the whole workspace correctly."""
+    report = await pull_client.workspace_diagnostic_async(
+        types.WorkspaceDiagnosticParams(previous_result_ids=[])
+    )
+
+    workspace_uri = uri_for("sphinx-default", "workspace")
+    expected = {
+        str(workspace_uri / "definitions.rst"): {
+            "image file not readable: _static/bad.png",
+            "unknown document: '/changelog'",
+        },
+        str(workspace_uri / "directive_options.rst"): {
+            "image file not readable: filename.png",
+            "document isn't included in any toctree",
+        },
+    }
+    assert len(report.items) == len(expected)
+    for item in report.items:
+        assert expected[item.uri] == {d.message for d in item.items}
+
+    assert len(pull_client.diagnostics) == 0, "Server should not publish diagnostics"
+
+
+@pytest_lsp.fixture(
+    scope="module",
+    config=ClientServerConfig(
+        server_command=[sys.executable, *SERVER_CMD],
+    ),
+)
+async def pub_client(lsp_client: LanguageClient, uri_for, tmp_path_factory):
+    """A client that does **not** support the pull-diagnostics model."""
+    build_dir = tmp_path_factory.mktemp("build")
+    workspace_uri = uri_for("sphinx-default", "workspace")
+    test_uri = workspace_uri / "definitions.rst"
+
+    await lsp_client.initialize_session(
+        types.InitializeParams(
+            capabilities=types.ClientCapabilities(
+                # Signal workDoneProgress/create support.
+                window=types.WindowClientCapabilities(
+                    work_done_progress=True,
+                ),
+            ),
+            initialization_options={
+                "server": {"logLevel": "debug"},
+                "sphinx": {
+                    "buildCommand": [
+                        "sphinx-build",
+                        "-M",
+                        "html",
+                        workspace_uri.fs_path,
+                        str(build_dir),
+                    ],
+                    "pythonCommand": [sys.executable],
+                },
+            },
+            workspace_folders=[
+                types.WorkspaceFolder(uri=str(workspace_uri), name="sphinx-default"),
+            ],
+        )
+    )
+
+    # Open a text document to trigger sphinx client creation.
+    lsp_client.text_document_did_open(
+        types.DidOpenTextDocumentParams(
+            text_document=types.TextDocumentItem(
+                uri=str(test_uri),
+                language_id="restructuredtext",
+                version=0,
+                text=pathlib.Path(test_uri).read_text(),
+            )
+        )
+    )
+
+    await lsp_client.wait_for_notification("sphinx/appCreated")
+
+    # Save the document to trigger a build
+    lsp_client.text_document_did_save(
+        types.DidSaveTextDocumentParams(
+            text_document=types.TextDocumentIdentifier(uri=str(test_uri))
+        )
+    )
+
+    build_finished = False
+    while not build_finished:
+        await lsp_client.wait_for_notification("$/progress")
+        report = list(lsp_client.progress_reports.values())[0][-1]
+        build_finished = report.kind == "end"
+
+    yield
+
+    # Teardown
+    await lsp_client.shutdown_session()
+
+
+@pytest.mark.asyncio
+async def test_publish_diagnostics(pub_client: LanguageClient, uri_for):
+    """Ensure that the server publishes the diagnostics it finds"""
+    workspace_uri = uri_for("sphinx-default", "workspace")
+    expected = {
+        str(workspace_uri / "definitions.rst"): {
+            "image file not readable: _static/bad.png",
+            "unknown document: '/changelog'",
+        },
+        str(workspace_uri / "directive_options.rst"): {
+            "image file not readable: filename.png",
+            "document isn't included in any toctree",
+        },
+    }
+
+    # The server might not have published its diagnostics yet
+    while len(pub_client.diagnostics) < len(expected):
+        await pub_client.wait_for_notification(types.TEXT_DOCUMENT_PUBLISH_DIAGNOSTICS)
+
+    for uri, expected_msgs in expected.items():
+        items = pub_client.diagnostics[uri]
+        actual_msgs = {d.message for d in items}
+
+        assert expected_msgs == actual_msgs

--- a/lib/esbonio/tests/sphinx-agent/conftest.py
+++ b/lib/esbonio/tests/sphinx-agent/conftest.py
@@ -15,16 +15,12 @@ from esbonio.server.features.sphinx_manager.config import SphinxConfig
 
 
 @pytest_lsp.fixture(
-    scope="session",
-    params=["html", "dirhtml"],
     config=ClientServerConfig(
         server_command=[sys.executable, "-m", "esbonio.sphinx_agent"],
         client_factory=make_test_sphinx_client,
     ),
 )
-async def client(
-    request, sphinx_client: SubprocessSphinxClient, uri_for, tmp_path_factory
-):
+async def client(sphinx_client: SubprocessSphinxClient, uri_for, tmp_path_factory):
     build_dir = tmp_path_factory.mktemp("build")
     test_uri = uri_for("sphinx-default", "workspace", "index.rst")
     sd_workspace = uri_for("sphinx-default", "workspace")
@@ -39,7 +35,7 @@ async def client(
         build_command=[
             "sphinx-build",
             "-M",
-            request.param,
+            "html",
             sd_workspace.fs_path,
             str(build_dir),
         ],

--- a/lib/esbonio/tests/sphinx-agent/handlers/test_database.py
+++ b/lib/esbonio/tests/sphinx-agent/handlers/test_database.py
@@ -34,56 +34,31 @@ async def test_files_table(client: SubprocessSphinxClient):
     else:
         actual = {r for r in results if "badfile" not in r[1]}
 
-    if client.builder == "html":
-        expected = {
-            # Ignore this file..., it's behavior seems very inconsistent across
-            # Python/Sphinx versions...
-            # (apath(src, "..", "badfile.rst"), "../badfile", "definitions.html"),
-            (apath(src, "index.rst"), "index", "index.html"),
-            (apath(src, "definitions.rst"), "definitions", "definitions.html"),
-            (apath(src, "glossary.rst"), "glossary", "glossary.html"),
-            (apath(src, "math.rst"), "math", "math.html"),
-            (apath(src, "math.rst"), "math", "theorems/pythagoras.html"),
-            (apath(src, "code", "cpp.rst"), "code/cpp", "code/cpp.html"),
-            (
-                apath(src, "theorems", "index.rst"),
-                "theorems/index",
-                "theorems/index.html",
-            ),
-            (
-                apath(src, "theorems", "pythagoras.rst"),
-                "theorems/pythagoras",
-                "theorems/pythagoras.html",
-            ),
-            (
-                apath(src, "directive_options.rst"),
-                "directive_options",
-                "directive_options.html",
-            ),
-        }
-
-    else:
-        expected = {
-            # Ignore this file..., it's behavior seems very inconsistent across
-            # Python/Sphinx versions...
-            # (apath(src, "..", "badfile.rst"), "../badfile", "definitions/"),
-            (apath(src, "index.rst"), "index", ""),
-            (apath(src, "definitions.rst"), "definitions", "definitions/"),
-            (apath(src, "glossary.rst"), "glossary", "glossary/"),
-            (apath(src, "math.rst"), "math", "math/"),
-            (apath(src, "math.rst"), "math", "theorems/pythagoras/"),
-            (apath(src, "code", "cpp.rst"), "code/cpp", "code/cpp/"),
-            (apath(src, "theorems", "index.rst"), "theorems/index", "theorems/"),
-            (
-                apath(src, "theorems", "pythagoras.rst"),
-                "theorems/pythagoras",
-                "theorems/pythagoras/",
-            ),
-            (
-                apath(src, "directive_options.rst"),
-                "directive_options",
-                "directive_options/",
-            ),
-        }
+    expected = {
+        # Ignore this file..., it's behavior seems very inconsistent across
+        # Python/Sphinx versions...
+        # (apath(src, "..", "badfile.rst"), "../badfile", "definitions.html"),
+        (apath(src, "index.rst"), "index", "index.html"),
+        (apath(src, "definitions.rst"), "definitions", "definitions.html"),
+        (apath(src, "glossary.rst"), "glossary", "glossary.html"),
+        (apath(src, "math.rst"), "math", "math.html"),
+        (apath(src, "math.rst"), "math", "theorems/pythagoras.html"),
+        (apath(src, "code", "cpp.rst"), "code/cpp", "code/cpp.html"),
+        (
+            apath(src, "theorems", "index.rst"),
+            "theorems/index",
+            "theorems/index.html",
+        ),
+        (
+            apath(src, "theorems", "pythagoras.rst"),
+            "theorems/pythagoras",
+            "theorems/pythagoras.html",
+        ),
+        (
+            apath(src, "directive_options.rst"),
+            "directive_options",
+            "directive_options.html",
+        ),
+    }
 
     assert expected == actual

--- a/lib/esbonio/tests/sphinx-agent/handlers/test_diagnostics.py
+++ b/lib/esbonio/tests/sphinx-agent/handlers/test_diagnostics.py
@@ -1,0 +1,97 @@
+import pathlib
+from typing import Any
+from typing import Dict
+from typing import List
+
+import pytest
+from pygls.protocol import default_converter
+
+from esbonio.server import Uri
+from esbonio.server.features.sphinx_manager.client_subprocess import (
+    SubprocessSphinxClient,
+)
+from esbonio.sphinx_agent import types
+
+
+def check_diagnostics(
+    expected: Dict[Uri, List[types.Diagnostic]],
+    actual: Dict[Uri, List[Dict[str, Any]]],
+):
+    """Ensure that two sets of diagnostics are equal."""
+    converter = default_converter()
+    assert set(actual.keys()) == set(expected.keys())
+
+    for k, ex_diags in expected.items():
+        actual_diags = [converter.structure(d, types.Diagnostic) for d in actual[k]]
+
+        # Order of results is not important
+        assert set(actual_diags) == set(ex_diags)
+
+
+@pytest.mark.asyncio
+async def test_diagnostics(client: SubprocessSphinxClient, uri_for):
+    """Ensure that the sphinx agent reports diagnostics collected during the build, and
+    that they are correctly reset when fixed."""
+    definitions_uri = uri_for("sphinx-default/workspace/definitions.rst")
+    options_uri = uri_for("sphinx-default/workspace/directive_options.rst")
+
+    expected = {
+        definitions_uri: [
+            types.Diagnostic(
+                message="image file not readable: _static/bad.png",
+                severity=types.DiagnosticSeverity.Warning,
+                range=types.Range(
+                    start=types.Position(line=28, character=0),
+                    end=types.Position(line=29, character=0),
+                ),
+            ),
+            types.Diagnostic(
+                message="unknown document: '/changelog'",
+                severity=types.DiagnosticSeverity.Warning,
+                range=types.Range(
+                    start=types.Position(line=13, character=0),
+                    end=types.Position(line=14, character=0),
+                ),
+            ),
+        ],
+        options_uri: [
+            types.Diagnostic(
+                message="image file not readable: filename.png",
+                severity=types.DiagnosticSeverity.Warning,
+                range=types.Range(
+                    start=types.Position(line=0, character=0),
+                    end=types.Position(line=1, character=0),
+                ),
+            ),
+            types.Diagnostic(
+                message="document isn't included in any toctree",
+                severity=types.DiagnosticSeverity.Warning,
+                range=types.Range(
+                    start=types.Position(line=0, character=0),
+                    end=types.Position(line=1, character=0),
+                ),
+            ),
+        ],
+    }
+
+    actual = await client.get_diagnostics()
+    check_diagnostics(expected, actual)
+
+    await client.build(
+        content_overrides={definitions_uri.fs_path: "My Custom Title\n==============="}
+    )
+
+    actual = await client.get_diagnostics()
+    check_diagnostics({options_uri: expected[options_uri]}, actual)
+
+    # The original diagnostics should be reported when the issues are re-introduced.
+    #
+    # Note: We have to "override" the contents of the file with the original text to
+    #       trick Sphinx into re-building the file.
+    await client.build(
+        content_overrides={
+            definitions_uri.fs_path: pathlib.Path(definitions_uri).read_text()
+        }
+    )
+    actual = await client.get_diagnostics()
+    check_diagnostics(expected, actual)

--- a/lib/esbonio/tox.ini
+++ b/lib/esbonio/tox.ini
@@ -38,7 +38,7 @@ commands_pre =
     coverage erase
 commands =
     python ../../scripts/check-sphinx-version.py
-    pytest {posargs:tests/sphinx-agent -vv}
+    pytest {posargs:tests/sphinx-agent tests/e2e}
 commands_post =
     coverage combine
     coverage report

--- a/lib/esbonio/tox.ini
+++ b/lib/esbonio/tox.ini
@@ -38,7 +38,7 @@ commands_pre =
     coverage erase
 commands =
     python ../../scripts/check-sphinx-version.py
-    pytest tests/sphinx-agent {posargs:-vv}
+    pytest {posargs:tests/sphinx-agent -vv}
 commands_post =
     coverage combine
     coverage report


### PR DESCRIPTION
- Instead of pushing the diagnostics to the parent language server with each build result, captured diagnostics are now saved to the sphinx-agent's database.
- For clients that don't support the pull diagnostics model (introduced in LSP v3.17), the server uses `textDocument/publishDiagnostics` as before.
- For the clients that do support the pull model, the language server now implements the `textDocument/diagnostic`  and `workspace/diagnostic` methods.
