### PR TITLE
Re-implement completion for directives

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,6 +17,7 @@ repos:
   rev: 7.0.0
   hooks:
   - id: flake8
+    exclude: 'scripts/sphinx-app.py'
     args: [--config=lib/esbonio/setup.cfg]
 
 - repo: https://github.com/pycqa/isort

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -77,9 +77,13 @@
             "request": "launch",
             "module": "pytest",
             "justMyCode": false,
-            "subProcess": false,
+            "subProcess": true,
             "python": "${command:python.interpreterPath}",
-            "cwd": "${workspaceFolder}/lib/esbonio"
+            // "python": "${workspaceFolder}/lib/esbonio/.tox/py312-sphinx5/bin/python",
+            "cwd": "${workspaceFolder}/lib/esbonio",
+            //"args": [
+            //    "tests/sphinx-agent/test_sa_build.py"
+            //]
         },
         {
             "name": "Python: Attach",

--- a/lib/esbonio/changes/105.enhancement.md
+++ b/lib/esbonio/changes/105.enhancement.md
@@ -1,0 +1,1 @@
+When providing completion suggestions for directives, `esbonio` now takes the `.. default-domain::` directive into account

--- a/lib/esbonio/changes/706.feature.md
+++ b/lib/esbonio/changes/706.feature.md
@@ -1,0 +1,1 @@
+The language server can now provide completion suggestions for MyST directives.

--- a/lib/esbonio/esbonio/server/__init__.py
+++ b/lib/esbonio/esbonio/server/__init__.py
@@ -2,12 +2,14 @@ from esbonio.sphinx_agent.types import Uri
 
 from ._log import LOG_NAMESPACE
 from ._log import MemoryHandler
+from .feature import CompletionContext
 from .feature import LanguageFeature
 from .server import EsbonioLanguageServer
 from .server import EsbonioWorkspace
 
 __all__ = [
     "LOG_NAMESPACE",
+    "CompletionContext",
     "EsbonioLanguageServer",
     "EsbonioWorkspace",
     "LanguageFeature",

--- a/lib/esbonio/esbonio/server/__init__.py
+++ b/lib/esbonio/esbonio/server/__init__.py
@@ -2,6 +2,7 @@ from esbonio.sphinx_agent.types import Uri
 
 from ._log import LOG_NAMESPACE
 from ._log import MemoryHandler
+from .feature import CompletionConfig
 from .feature import CompletionContext
 from .feature import LanguageFeature
 from .server import EsbonioLanguageServer
@@ -9,6 +10,7 @@ from .server import EsbonioWorkspace
 
 __all__ = [
     "LOG_NAMESPACE",
+    "CompletionConfig",
     "CompletionContext",
     "EsbonioLanguageServer",
     "EsbonioWorkspace",

--- a/lib/esbonio/esbonio/server/cli.py
+++ b/lib/esbonio/esbonio/server/cli.py
@@ -72,6 +72,7 @@ def main(argv: Optional[Sequence[str]] = None):
         "esbonio.server.features.log",
         "esbonio.server.features.sphinx_manager",
         "esbonio.server.features.preview_manager",
+        "esbonio.server.features.directives",
         "esbonio.server.features.sphinx_support.diagnostics",
         "esbonio.server.features.sphinx_support.symbols",
     ]

--- a/lib/esbonio/esbonio/server/cli.py
+++ b/lib/esbonio/esbonio/server/cli.py
@@ -75,6 +75,7 @@ def main(argv: Optional[Sequence[str]] = None):
         "esbonio.server.features.directives",
         "esbonio.server.features.sphinx_support.diagnostics",
         "esbonio.server.features.sphinx_support.symbols",
+        "esbonio.server.features.sphinx_support.directives",
     ]
 
     for mod in args.included_modules:

--- a/lib/esbonio/esbonio/server/feature.py
+++ b/lib/esbonio/esbonio/server/feature.py
@@ -1,11 +1,7 @@
 from __future__ import annotations
 
 import typing
-from typing import Any
-from typing import Coroutine
-from typing import List
-from typing import Optional
-from typing import Union
+from typing import Literal
 
 import attrs
 from lsprotocol import types
@@ -16,6 +12,11 @@ from . import Uri
 
 if typing.TYPE_CHECKING:
     import re
+    from typing import Any
+    from typing import Coroutine
+    from typing import List
+    from typing import Optional
+    from typing import Union
 
     from .server import EsbonioLanguageServer
 
@@ -40,8 +41,15 @@ class LanguageFeature:
 
     def __init__(self, server: EsbonioLanguageServer):
         self.server = server
-        self.converter = server.converter
         self.logger = server.logger.getChild(self.__class__.__name__)
+
+    @property
+    def converter(self):
+        return self.server.converter
+
+    @property
+    def configuration(self):
+        return self.server.configuration
 
     def initialize(self, params: types.InitializeParams):
         """Called during ``initialize``."""
@@ -77,6 +85,17 @@ class LanguageFeature:
     ) -> WorkspaceSymbolResult:
         """Called when a workspace symbols request is received."""
         ...
+
+
+@attrs.define
+class CompletionConfig:
+    """Configuration options that control completion behavior."""
+
+    preferred_insert_behavior: Literal["insert", "replace"] = attrs.field(
+        default="replace"
+    )
+    """This option indicates if the user prefers we use ``insertText`` or ``textEdit``
+    when rendering ``CompletionItems``."""
 
 
 @attrs.define

--- a/lib/esbonio/esbonio/server/features/directives.py
+++ b/lib/esbonio/esbonio/server/features/directives.py
@@ -1,0 +1,392 @@
+import inspect
+import re
+from typing import Dict
+from typing import List
+from typing import Optional
+
+import attrs
+from lsprotocol import types
+
+from esbonio import server
+from esbonio.sphinx_agent.types import RST_DIRECTIVE
+
+
+@attrs.define
+class Directive:
+    """Represents a directive."""
+
+    name: str
+    """The name of the directive, as the user would type in an rst file."""
+
+    implementation: Optional[str]
+    """The dotted name of the directive's implementation."""
+
+
+class DirectiveProvider:
+    """Base class for directive providers"""
+
+    def suggest_directives(
+        self, context: server.CompletionContext
+    ) -> Optional[List[Directive]]:
+        """Given a completion context, suggest directives that may be used."""
+        return None
+
+
+class DirectiveFeature(server.LanguageFeature):
+    """reStructuredText directive support."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self._providers: Dict[int, DirectiveProvider] = {}
+
+    def add_provider(self, provider: DirectiveProvider):
+        """Register a directive provider.
+
+        Parameters
+        ----------
+        provider
+           The directive provider
+        """
+        self._providers[id(provider)] = provider
+
+    completion_triggers = [RST_DIRECTIVE]
+
+    async def completion(
+        self, context: server.CompletionContext
+    ) -> Optional[List[types.CompletionItem]]:
+        """Provide auto-completion suggestions for directives."""
+
+        groups = context.match.groupdict()
+
+        # Are we completing a directive's options?
+        if "directive" not in groups:
+            return await self.complete_options(context)
+
+        # Are we completing the directive's argument?
+        directive_end = context.match.span()[0] + len(groups["directive"])
+        complete_directive = groups["directive"].endswith("::")
+
+        if complete_directive and directive_end < context.position.character:
+            return await self.complete_arguments(context)
+
+        return await self.complete_directives(context)
+
+    async def complete_options(self, context: server.CompletionContext):
+        return None
+
+    async def complete_arguments(self, context: server.CompletionContext):
+        return None
+
+    async def complete_directives(self, context: server.CompletionContext):
+        items = []
+
+        for directive in await self.suggest_directives(context):
+            if (item := render_directive_completion(context, directive)) is not None:
+                items.append(item)
+
+        if len(items) > 0:
+            return items
+
+    async def suggest_directives(
+        self, context: server.CompletionContext
+    ) -> List[Directive]:
+        """Suggest directives that may be used, given a completion context.
+
+        Parameters
+        ----------
+        context
+           The completion context.
+        """
+        items = []
+
+        for provider in self._providers.values():
+            try:
+                result = provider.suggest_directives(context)
+                if inspect.isawaitable(result):
+                    result = await result
+
+                if result:
+                    items.extend(result)
+            except Exception:
+                name = type(provider).__name__
+                self.logger.error(
+                    "Error in '%s.suggest_directives'", name, exc_info=True
+                )
+
+        return items
+
+
+WORD = re.compile("[a-zA-Z]+")
+
+
+def render_directive_completion(
+    context: server.CompletionContext, directive: Directive
+) -> Optional[types.CompletionItem]:
+    """Render the given directive as a ``CompletionItem`` according to the current
+    context.
+
+    Parameters
+    ----------
+    context
+       The context in which the completion should be rendered.
+
+    directive
+       The directive to render
+
+    Returns
+    -------
+    Optional[CompletionItem]
+       The final completion item or ``None``.
+       If ``None`` is returned, then the given completion should be skipped.
+    """
+
+    # TODO: Bring this back
+    # if context.config.preferred_insert_behavior == "insert":
+    #     return _render_directive_with_insert_text(context, name, directive)
+
+    return _render_directive_with_text_edit(context, directive)
+
+
+def _render_directive_with_insert_text(
+    context: server.CompletionContext,
+    directive: Directive,
+) -> Optional[types.CompletionItem]:
+    """Render a ``CompletionItem`` using ``insertText`` fields.
+
+    This implements the ``insert`` behavior for directives.
+    Parameters
+    ----------
+    context
+       The context in which the completion is being generated.
+
+    name
+       The name of the directive, as it appears in an rst file.
+
+    directive
+       The class implementing the directive.
+
+    """
+    insert_text = f".. {directive.name}::"
+    user_text = context.match.group(0).strip()
+
+    # Since we can't replace any existing text, it only makes sense
+    # to offer completions that ailgn with what the user has already written.
+    if not insert_text.startswith(user_text):
+        return None
+
+    # Except that's not entirely true... to quote the LSP spec. (emphasis added)
+    #
+    # > in the model the client should filter against what the user has already typed
+    # > **using the word boundary rules of the language** (e.g. resolving the word
+    # > under the cursor position). The reason for this mode is that it makes it
+    # > extremely easy for a server to implement a basic completion list and get it
+    # > filtered on the client.
+    #
+    # So in other words... if the cursor is inside a word, that entire word will be
+    # replaced with what we have in `insert_text` so we need to be able to do something
+    # like
+    #    ..         -> image::
+    #    .. im      -> image::
+    #
+    #    ..         -> code-block::
+    #    .. cod     -> code-block::
+    #    .. code-bl -> block::
+    #
+    #    ..         -> c:function::
+    #    .. c       -> c:function::
+    #    .. c:      -> function::
+    #    .. c:fun   -> function::
+    #
+    # And since the client is free to interpret this how it likes, it's unlikely we'll
+    # be able to get this right in all cases for all clients. So for now this is going
+    # to target Kate's interpretation since it currently does not support ``text_edit``
+    # and it was the editor that prompted this to be implemented in the first place.
+    #
+    # See: https://github.com/swyddfa/esbonio/issues/471
+
+    # If the existing text ends with a delimiter, then we should simply remove the
+    # entire prefix
+    if user_text.endswith((":", "-", " ")):
+        start_index = len(user_text)
+
+    # Look for groups of word chars, replace text until the start of the final group
+    else:
+        start_indices = [m.start() for m in WORD.finditer(user_text)] or [
+            len(user_text)
+        ]
+        start_index = max(start_indices)
+
+    item = _render_directive_common(directive)
+    item.insert_text = insert_text[start_index:]
+    return item
+
+
+def _render_directive_with_text_edit(
+    context: server.CompletionContext,
+    directive: Directive,
+) -> Optional[types.CompletionItem]:
+    """Render a directive's ``CompletionItem`` using the ``textEdit`` field.
+
+    This implements the ``replace`` insert behavior for directives.
+
+    Parameters
+    ----------
+    context
+       The context in which the completion is being generated.
+
+    directive
+       The directive to render.
+
+    """
+    match = context.match
+
+    # Calculate the range of text the CompletionItems should edit.
+    # If there is an existing argument to the directive, we should leave it untouched
+    # otherwise, edit the whole line to insert any required arguments.
+    start = match.span()[0] + match.group(0).find(".")
+
+    if match.group("argument"):
+        end = match.span()[0] + match.group(0).find("::") + 2
+    else:
+        end = match.span()[1]
+
+    insert_text = f".. {directive.name}::"
+
+    item = _render_directive_common(directive)
+    item.filter_text = insert_text
+    item.insert_text_format = types.InsertTextFormat.PlainText
+    item.text_edit = types.TextEdit(
+        new_text=insert_text,
+        range=types.Range(
+            start=types.Position(line=context.position.line, character=start),
+            end=types.Position(line=context.position.line, character=end),
+        ),
+    )
+
+    return item
+
+
+def _render_directive_common(directive: Directive) -> types.CompletionItem:
+    """Render the common fields of a directive's completion item."""
+
+    return types.CompletionItem(
+        label=directive.name,
+        detail=directive.implementation,
+        kind=types.CompletionItemKind.Class,
+        data={"completion_type": "directive"},
+    )
+
+
+# def _render_directive_option_with_insert_text(
+#     context: CompletionContext,
+#     directive: Directive,
+# ) -> Optional[types.CompletionItem]:
+#     """Render a directive option's ``CompletionItem`` using the ``insertText`` field.
+
+#     This implements the ``insert`` insert behavior for directive options.
+
+#     Parameters
+#     ----------
+#     context
+#        The context in which the completion is being generated.
+
+#     name
+#        The name of the directive option, as it appears in an rst file.
+
+#     directive
+#        The name of the directive, as it appears in an rst file.
+
+#     implementation
+#        The class implementing the directive.
+
+#     """
+
+#     insert_text = f":{name}:"
+#     user_text = context.match.group(0).strip()
+
+#     if not insert_text.startswith(user_text):
+#         return None
+
+#     if user_text.endswith((":", "-", " ")):
+#         start_index = len(user_text)
+
+#     else:
+#         start_indices = [m.start() for m in WORD.finditer(user_text)] or [
+#             len(user_text)
+#         ]
+#         start_index = max(start_indices)
+
+#     item = _render_directive_option_common(name, directive, implementation)
+#     item.insert_text = insert_text[start_index:]
+#     return item
+
+
+# def _render_directive_option_with_text_edit(
+#     context: CompletionContext,
+#     name: str,
+#     directive: str,
+#     implementation: Type[Directive],
+# ) -> CompletionItem:
+#     """Render a directive option's ``CompletionItem`` using the``textEdit`` field.
+
+#     This implements the ``replace`` insert behavior for directive options.
+
+#     Parameters
+#     ----------
+#     context
+#        The context in which the completion is being generated.
+
+#     name
+#        The name of the directive option, as it appears in an rst file.
+
+#     directive
+#        The name of the directive, as it appears in an rst file.
+
+#     implementation
+#        The class implementing the directive.
+
+#     """
+
+#     match = context.match
+#     groups = match.groupdict()
+
+#     option = groups["option"]
+#     start = match.span()[0] + match.group(0).find(option)
+#     end = start + len(option)
+
+#     range_ = Range(
+#         start=Position(line=context.position.line, character=start),
+#         end=Position(line=context.position.line, character=end),
+#     )
+
+#     insert_text = f":{name}:"
+
+#     item = _render_directive_option_common(name, directive, implementation)
+#     item.filter_text = insert_text
+#     item.text_edit = TextEdit(range=range_, new_text=insert_text)
+
+#     return item
+
+
+# def _render_directive_option_common(
+#     name: str, directive: str, impl: Type[Directive]
+# ) -> CompletionItem:
+#     """Render the common fields of a directive option's completion item."""
+
+#     try:
+#         impl_name = f"{impl.__module__}.{impl.__name__}"
+#     except AttributeError:
+#         impl_name = f"{impl.__module__}.{impl.__class__.__name__}"
+
+#     return CompletionItem(
+#         label=name,
+#         detail=f"{impl_name}:{name}",
+#         kind=CompletionItemKind.Field,
+#         data={"completion_type": "directive_option", "for_directive": directive},
+#     )
+
+
+def esbonio_setup(server: server.EsbonioLanguageServer):
+    directives = DirectiveFeature(server)
+    server.add_feature(directives)

--- a/lib/esbonio/esbonio/server/features/directives/__init__.py
+++ b/lib/esbonio/esbonio/server/features/directives/__init__.py
@@ -86,9 +86,13 @@ class DirectiveFeature(server.LanguageFeature):
         if "directive" not in groups:
             return await self.complete_options(context)
 
+        # Don't offer completions for targets
+        if (groups["name"] or "").startswith("_"):
+            return None
+
         # Are we completing the directive's argument?
         directive_end = context.match.span()[0] + len(groups["directive"])
-        complete_directive = groups["directive"].endswith("::")
+        complete_directive = groups["directive"].endswith(("::", "}"))
 
         if complete_directive and directive_end < context.position.character:
             return await self.complete_arguments(context)
@@ -108,7 +112,6 @@ class DirectiveFeature(server.LanguageFeature):
 
         language = self.server.get_language_at(context.doc, context.position)
         render_func = completion.get_directive_renderer(language, self._insert_behavior)
-
         if render_func is None:
             return None
 

--- a/lib/esbonio/esbonio/server/features/directives/__init__.py
+++ b/lib/esbonio/esbonio/server/features/directives/__init__.py
@@ -124,9 +124,11 @@ class DirectiveFeature(server.LanguageFeature):
 
         for provider in self._providers.values():
             try:
-                result = provider.suggest_directives(context)
-                if inspect.isawaitable(result):
-                    result = await result
+                result: Optional[List[Directive]] = None
+
+                aresult = provider.suggest_directives(context)
+                if inspect.isawaitable(aresult):
+                    result = await aresult
 
                 if result:
                     items.extend(result)

--- a/lib/esbonio/esbonio/server/features/directives/__init__.py
+++ b/lib/esbonio/esbonio/server/features/directives/__init__.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import inspect
+import typing
+
+import attrs
+from lsprotocol import types
+
+from esbonio import server
+from esbonio.sphinx_agent.types import MYST_DIRECTIVE
+from esbonio.sphinx_agent.types import RST_DIRECTIVE
+
+from . import completion
+
+if typing.TYPE_CHECKING:
+    from typing import Dict
+    from typing import List
+    from typing import Optional
+
+
+@attrs.define
+class Directive:
+    """Represents a directive."""
+
+    name: str
+    """The name of the directive, as the user would type in an rst file."""
+
+    implementation: Optional[str]
+    """The dotted name of the directive's implementation."""
+
+
+class DirectiveProvider:
+    """Base class for directive providers"""
+
+    def suggest_directives(
+        self, context: server.CompletionContext
+    ) -> Optional[List[Directive]]:
+        """Given a completion context, suggest directives that may be used."""
+        return None
+
+
+class DirectiveFeature(server.LanguageFeature):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self._providers: Dict[int, DirectiveProvider] = {}
+
+    def add_provider(self, provider: DirectiveProvider):
+        """Register a directive provider.
+
+        Parameters
+        ----------
+        provider
+           The directive provider
+        """
+        self._providers[id(provider)] = provider
+
+    completion_triggers = [RST_DIRECTIVE, MYST_DIRECTIVE]
+
+    async def completion(
+        self, context: server.CompletionContext
+    ) -> Optional[List[types.CompletionItem]]:
+        """Provide auto-completion suggestions for directives."""
+
+        groups = context.match.groupdict()
+
+        # Are we completing a directive's options?
+        if "directive" not in groups:
+            return await self.complete_options(context)
+
+        # Are we completing the directive's argument?
+        directive_end = context.match.span()[0] + len(groups["directive"])
+        complete_directive = groups["directive"].endswith("::")
+
+        if complete_directive and directive_end < context.position.character:
+            return await self.complete_arguments(context)
+
+        return await self.complete_directives(context)
+
+    async def complete_options(self, context: server.CompletionContext):
+        return None
+
+    async def complete_arguments(self, context: server.CompletionContext):
+        return None
+
+    async def complete_directives(
+        self, context: server.CompletionContext
+    ) -> Optional[List[types.CompletionItem]]:
+        """Return completion suggestions for the available directives."""
+
+        style = "replace"  # TODO: Use config value
+        language = self.server.get_language_at(context.doc, context.position)
+        render_func = completion.get_directive_renderer(language, style)
+
+        if render_func is None:
+            return None
+
+        items = []
+        for directive in await self.suggest_directives(context):
+            if (item := render_func(context, directive)) is not None:
+                items.append(item)
+
+        if len(items) > 0:
+            return items
+
+        return None
+
+    async def suggest_directives(
+        self, context: server.CompletionContext
+    ) -> List[Directive]:
+        """Suggest directives that may be used, given a completion context.
+
+        Parameters
+        ----------
+        context
+           The completion context.
+        """
+        items = []
+
+        for provider in self._providers.values():
+            try:
+                result = provider.suggest_directives(context)
+                if inspect.isawaitable(result):
+                    result = await result
+
+                if result:
+                    items.extend(result)
+            except Exception:
+                name = type(provider).__name__
+                self.logger.error(
+                    "Error in '%s.suggest_directives'", name, exc_info=True
+                )
+
+        return items
+
+
+def esbonio_setup(server: server.EsbonioLanguageServer):
+    directives = DirectiveFeature(server)
+    server.add_feature(directives)

--- a/lib/esbonio/esbonio/server/features/directives/__init__.py
+++ b/lib/esbonio/esbonio/server/features/directives/__init__.py
@@ -13,9 +13,12 @@ from esbonio.sphinx_agent.types import RST_DIRECTIVE
 from . import completion
 
 if typing.TYPE_CHECKING:
+    from typing import Any
+    from typing import Coroutine
     from typing import Dict
     from typing import List
     from typing import Optional
+    from typing import Union
 
 
 @attrs.define
@@ -34,7 +37,9 @@ class DirectiveProvider:
 
     def suggest_directives(
         self, context: server.CompletionContext
-    ) -> Optional[List[Directive]]:
+    ) -> Union[
+        Optional[List[Directive]], Coroutine[Any, Any, Optional[List[Directive]]]
+    ]:
         """Given a completion context, suggest directives that may be used."""
         return None
 
@@ -115,7 +120,7 @@ class DirectiveFeature(server.LanguageFeature):
         context
            The completion context.
         """
-        items = []
+        items: List[Directive] = []
 
         for provider in self._providers.values():
             try:

--- a/lib/esbonio/esbonio/server/features/sphinx_manager/client.py
+++ b/lib/esbonio/esbonio/server/features/sphinx_manager/client.py
@@ -1,16 +1,21 @@
-from typing import Any
-from typing import Dict
-from typing import List
-from typing import Optional
+from __future__ import annotations
+
+import typing
 from typing import Protocol
-from typing import Tuple
 
-import aiosqlite
+if typing.TYPE_CHECKING:
+    from typing import Any
+    from typing import Dict
+    from typing import List
+    from typing import Optional
+    from typing import Tuple
 
-from esbonio.server import Uri
-from esbonio.sphinx_agent import types
+    import aiosqlite
 
-from .config import SphinxConfig
+    from esbonio.server import Uri
+    from esbonio.sphinx_agent import types
+
+    from .config import SphinxConfig
 
 
 class SphinxClient(Protocol):
@@ -85,10 +90,14 @@ class SphinxClient(Protocol):
         """Get the symbols for the given file."""
         ...
 
+    async def find_symbols(self, **kwargs) -> List[types.Symbol]:
+        """Find symbols which match the given criteria."""
+        ...
+
     async def get_workspace_symbols(
         self, query: str
     ) -> List[Tuple[str, str, int, str, str, str]]:
-        """Return all the workspace symbols matching the given query"""
+        """Return all the workspace symbols matching the given query string"""
         ...
 
     async def stop(self):

--- a/lib/esbonio/esbonio/server/features/sphinx_manager/client.py
+++ b/lib/esbonio/esbonio/server/features/sphinx_manager/client.py
@@ -74,6 +74,10 @@ class SphinxClient(Protocol):
         """Get the diagnostics for the project."""
         ...
 
+    async def get_directives(self) -> List[Tuple[str, Optional[str]]]:
+        """Get all the directives known to Sphinx."""
+        ...
+
     async def get_document_symbols(self, src_uri: Uri) -> List[types.Symbol]:
         """Get the symbols for the given file."""
         ...

--- a/lib/esbonio/esbonio/server/features/sphinx_manager/client.py
+++ b/lib/esbonio/esbonio/server/features/sphinx_manager/client.py
@@ -70,6 +70,9 @@ class SphinxClient(Protocol):
     async def get_build_path(self, src_uri: Uri) -> Optional[str]:
         """Get the build path associated with the given ``src_uri``."""
 
+    async def get_config_value(self, name: str) -> Optional[Any]:
+        """Return the requested configuration value, if available."""
+
     async def get_diagnostics(self) -> Dict[Uri, List[Dict[str, Any]]]:
         """Get the diagnostics for the project."""
         ...

--- a/lib/esbonio/esbonio/server/features/sphinx_manager/client_subprocess.py
+++ b/lib/esbonio/esbonio/server/features/sphinx_manager/client_subprocess.py
@@ -244,6 +244,15 @@ class SubprocessSphinxClient(JsonRPCClient):
 
             return result[0]
 
+    async def get_directives(self) -> List[Tuple[str, Optional[str]]]:
+        """Get the directives known to Sphinx."""
+        if self.db is None:
+            return []
+
+        query = "SELECT name, implementation FROM directives"
+        cursor = await self.db.execute(query)
+        return await cursor.fetchall()  # type: ignore[return-value]
+
     async def get_document_symbols(self, src_uri: Uri) -> List[types.Symbol]:
         """Get the symbols for the given file."""
         if self.db is None:

--- a/lib/esbonio/esbonio/server/features/sphinx_manager/client_subprocess.py
+++ b/lib/esbonio/esbonio/server/features/sphinx_manager/client_subprocess.py
@@ -7,11 +7,6 @@ import logging
 import os
 import subprocess
 import typing
-from typing import Any
-from typing import Dict
-from typing import List
-from typing import Optional
-from typing import Tuple
 
 import aiosqlite
 from pygls import IS_WIN
@@ -24,6 +19,12 @@ from esbonio.server import Uri
 from .config import SphinxConfig
 
 if typing.TYPE_CHECKING:
+    from typing import Any
+    from typing import Dict
+    from typing import List
+    from typing import Optional
+    from typing import Tuple
+
     from .client import SphinxClient
     from .manager import SphinxManager
 
@@ -243,6 +244,20 @@ class SubprocessSphinxClient(JsonRPCClient):
                 return None
 
             return result[0]
+
+    async def get_config_value(self, name: str) -> Optional[Any]:
+        """Return the requested configuration value, if available."""
+        if self.db is None:
+            return None
+
+        query = "SELECT value FROM config WHERE name = ?"
+        cursor = await self.db.execute(query, (name,))
+
+        if (row := await cursor.fetchone()) is None:
+            return None
+
+        (value,) = row
+        return json.loads(value)
 
     async def get_directives(self) -> List[Tuple[str, Optional[str]]]:
         """Get the directives known to Sphinx."""

--- a/lib/esbonio/esbonio/server/features/sphinx_support/directives.py
+++ b/lib/esbonio/esbonio/server/features/sphinx_support/directives.py
@@ -1,0 +1,37 @@
+from typing import List
+from typing import Optional
+
+from esbonio import server
+from esbonio.server.features import directives
+from esbonio.server.features.sphinx_manager import SphinxManager
+
+
+class SphinxDirectives(directives.DirectiveProvider):
+    """Support for directives in a sphinx project."""
+
+    def __init__(self, manager: SphinxManager):
+        self.manager = manager
+
+    async def suggest_directives(
+        self, context: server.CompletionContext
+    ) -> Optional[List[directives.Directive]]:
+        """Given a completion context, suggest directives that may be used."""
+
+        if (client := await self.manager.get_client(context.uri)) is None:
+            return None
+
+        result: List[directives.Directive] = []
+        for name, implementation in await client.get_directives():
+            result.append(
+                directives.Directive(name=name, implementation=implementation)
+            )
+
+        return result
+
+
+def esbonio_setup(
+    sphinx_manager: SphinxManager,
+    directive_feature: directives.DirectiveFeature,
+):
+    provider = SphinxDirectives(sphinx_manager)
+    directive_feature.add_provider(provider)

--- a/lib/esbonio/esbonio/server/features/sphinx_support/directives.py
+++ b/lib/esbonio/esbonio/server/features/sphinx_support/directives.py
@@ -43,8 +43,15 @@ class SphinxDirectives(directives.DirectiveProvider):
 
         result: List[directives.Directive] = []
         for name, implementation in await client.get_directives():
+            # std: directives can be used unqualified
+            if name.startswith("std:"):
+                short_name = name.replace("std:", "")
+                result.append(
+                    directives.Directive(name=short_name, implementation=implementation)
+                )
+
             # Also suggest unqualified versions of directives from the currently active domain.
-            if name.startswith(f"{active_domain}:"):
+            elif name.startswith(f"{active_domain}:"):
                 short_name = name.replace(f"{active_domain}:", "")
                 result.append(
                     directives.Directive(name=short_name, implementation=implementation)

--- a/lib/esbonio/esbonio/server/features/sphinx_support/directives.py
+++ b/lib/esbonio/esbonio/server/features/sphinx_support/directives.py
@@ -1,9 +1,16 @@
-from typing import List
-from typing import Optional
+from __future__ import annotations
+
+import typing
+
+from lsprotocol import types
 
 from esbonio import server
 from esbonio.server.features import directives
 from esbonio.server.features.sphinx_manager import SphinxManager
+
+if typing.TYPE_CHECKING:
+    from typing import List
+    from typing import Optional
 
 
 class SphinxDirectives(directives.DirectiveProvider):
@@ -20,14 +27,25 @@ class SphinxDirectives(directives.DirectiveProvider):
         if (client := await self.manager.get_client(context.uri)) is None:
             return None
 
-        # TODO .. default-domain:: support
+        # Does the document have a default domain set?
+        results = await client.find_symbols(
+            uri=str(context.uri.resolve()),
+            kind=types.SymbolKind.Class.value,
+            detail="default-domain",
+        )
+        if len(results) > 0:
+            default_domain = results[0][1]
+        else:
+            default_domain = None
+
         primary_domain = await client.get_config_value("primary_domain")
+        active_domain = default_domain or primary_domain or "py"
 
         result: List[directives.Directive] = []
         for name, implementation in await client.get_directives():
-            # Also suggest unqualified versions of directives from the primary_domain.
-            if name.startswith(f"{primary_domain}:"):
-                short_name = name.replace(f"{primary_domain}:", "")
+            # Also suggest unqualified versions of directives from the currently active domain.
+            if name.startswith(f"{active_domain}:"):
+                short_name = name.replace(f"{active_domain}:", "")
                 result.append(
                     directives.Directive(name=short_name, implementation=implementation)
                 )

--- a/lib/esbonio/esbonio/server/features/sphinx_support/directives.py
+++ b/lib/esbonio/esbonio/server/features/sphinx_support/directives.py
@@ -20,8 +20,18 @@ class SphinxDirectives(directives.DirectiveProvider):
         if (client := await self.manager.get_client(context.uri)) is None:
             return None
 
+        # TODO .. default-domain:: support
+        primary_domain = await client.get_config_value("primary_domain")
+
         result: List[directives.Directive] = []
         for name, implementation in await client.get_directives():
+            # Also suggest unqualified versions of directives from the primary_domain.
+            if name.startswith(f"{primary_domain}:"):
+                short_name = name.replace(f"{primary_domain}:", "")
+                result.append(
+                    directives.Directive(name=short_name, implementation=implementation)
+                )
+
             result.append(
                 directives.Directive(name=name, implementation=implementation)
             )

--- a/lib/esbonio/esbonio/server/server.py
+++ b/lib/esbonio/esbonio/server/server.py
@@ -5,13 +5,6 @@ import collections
 import inspect
 import logging
 import typing
-from typing import Any
-from typing import Callable
-from typing import Dict
-from typing import List
-from typing import Optional
-from typing import Tuple
-from typing import Type
 from typing import TypeVar
 from uuid import uuid4
 
@@ -26,6 +19,14 @@ from . import Uri
 from ._configuration import Configuration
 
 if typing.TYPE_CHECKING:
+    from typing import Any
+    from typing import Callable
+    from typing import Dict
+    from typing import List
+    from typing import Optional
+    from typing import Tuple
+    from typing import Type
+
     from .feature import LanguageFeature
 
 __version__ = "1.0.0b0"

--- a/lib/esbonio/esbonio/server/server.py
+++ b/lib/esbonio/esbonio/server/server.py
@@ -19,7 +19,7 @@ import cattrs
 from lsprotocol import types
 from pygls.capabilities import get_capability
 from pygls.server import LanguageServer
-from pygls.workspace import Document
+from pygls.workspace import TextDocument
 from pygls.workspace import Workspace
 
 from . import Uri
@@ -36,7 +36,7 @@ LF = TypeVar("LF", bound="LanguageFeature")
 class EsbonioWorkspace(Workspace):
     """A modified version of pygls' workspace that ensures uris are always resolved."""
 
-    def get_document(self, doc_uri: str) -> Document:
+    def get_document(self, doc_uri: str) -> TextDocument:
         uri = str(Uri.parse(doc_uri).resolve())
         return super().get_text_document(uri)
 
@@ -243,6 +243,18 @@ class EsbonioLanguageServer(LanguageServer):
            The diagnostics themselves
         """
         self._diagnostics[(source, uri)] = diagnostics
+
+    def get_language_at(self, document: TextDocument, position: types.Position) -> str:
+        """Return the language at the given location"""
+        language = document.language_id
+
+        if language in {"rst", "restructuredtext"}:
+            return "rst"
+
+        if language in {"markdown"}:
+            return "markdown"
+
+        return ""
 
     def sync_diagnostics(self) -> None:
         """Update the client with the currently stored diagnostics.

--- a/lib/esbonio/esbonio/sphinx_agent/handlers/__init__.py
+++ b/lib/esbonio/esbonio/sphinx_agent/handlers/__init__.py
@@ -38,6 +38,7 @@ sphinx.application.builtin_extensions += (
     f"{__name__}.files",
     f"{__name__}.diagnostics",
     f"{__name__}.symbols",
+    f"{__name__}.directives",
 )
 
 

--- a/lib/esbonio/esbonio/sphinx_agent/handlers/directives.py
+++ b/lib/esbonio/esbonio/sphinx_agent/handlers/directives.py
@@ -1,0 +1,112 @@
+import importlib
+import inspect
+from typing import List
+from typing import Optional
+from typing import Type
+
+from docutils.parsers.rst import Directive
+from docutils.parsers.rst import directives as docutils_directives
+
+from .. import types
+from ..app import Database
+from ..app import Sphinx
+from ..util import as_json
+
+DIRECTIVES_TABLE = Database.Table(
+    "directives",
+    [
+        Database.Column(name="name", dtype="TEXT"),
+        Database.Column(name="implementation", dtype="TEXT"),
+        Database.Column(name="location", dtype="JSON"),
+    ],
+)
+
+
+def get_impl_name(directive: Type[Directive]) -> str:
+    try:
+        return f"{directive.__module__}.{directive.__name__}"
+    except AttributeError:
+        return f"{directive.__module__}.{directive.__class__.__name__}"
+
+
+def get_impl_location(impl: Type[Directive]) -> Optional[str]:
+    """Get the implementation location of the given directive"""
+
+    try:
+        if (filepath := inspect.getsourcefile(impl)) is None:
+            return None
+
+        uri = types.Uri.for_file(filepath).resolve()
+        source, line = inspect.getsourcelines(impl)
+
+        location = types.Location(
+            uri=str(uri),
+            range=types.Range(
+                start=types.Position(line=line - 1, character=0),
+                end=types.Position(line=line + len(source), character=0),
+            ),
+        )
+
+        return as_json(location)
+    except Exception:
+        # TODO: Log the error somewhere..
+        return None
+
+
+def index_directives(app: Sphinx):
+    """Index all the directives that are available to this app.
+
+    Note: While it would be ideal to resolve the implementation location of each
+    directive here, the ``get_impl_location`` function is too slow causing a noticable
+    lag when initializing the sphinx agent.
+
+    Perhaps it's worth investigating adding our own custom events. If we could register
+    a handler and do work on an "initial" doctree when it becomes available, then we can
+    resolve the location of just the directives that are used, as we see them for the
+    first time.
+    """
+
+    directives: List[types.Directive] = []
+
+    ignored_directives = {"restructuredtext-test-directive"}
+    found_directives = {
+        **docutils_directives._directive_registry,
+        **docutils_directives._directives,
+    }
+
+    for name, directive in found_directives.items():
+        if name in ignored_directives:
+            continue
+
+        # core docutils directives are a (module, Class) reference.
+        if isinstance(directive, tuple):
+            try:
+                mod, cls = directive
+                modulename = f"docutils.parsers.rst.directives.{mod}"
+                module = importlib.import_module(modulename)
+
+                directive = getattr(module, cls)
+            except Exception:
+                # TODO: Log the error somewhere...
+                directives.append((name, None, None))
+                continue
+
+        directives.append((name, get_impl_name(directive), None))
+
+    for prefix, domain in app.env.domains.items():
+        for name, directive in domain.directives.items():
+            directives.append(
+                (
+                    f"{prefix}:{name}",
+                    get_impl_name(directive),
+                    None,
+                )
+            )
+
+    app.esbonio.db.ensure_table(DIRECTIVES_TABLE)
+    app.esbonio.db.clear_table(DIRECTIVES_TABLE)
+    app.esbonio.db.insert_values(DIRECTIVES_TABLE, directives)
+
+
+def setup(app: Sphinx):
+    app.connect("builder-inited", index_directives)

--- a/lib/esbonio/esbonio/sphinx_agent/types.py
+++ b/lib/esbonio/esbonio/sphinx_agent/types.py
@@ -462,8 +462,11 @@ def _normalize_path(path: str, preserve_case: bool = False) -> str:
     return path
 
 
-# Could represent either a document symbol or workspace symbol depending on context.
-Symbol = Tuple[
+# -- DB Types
+#
+# These represent the structure of data as stored in the SQLite database
+Directive = Tuple[str, Optional[str], Optional[str]]
+Symbol = Tuple[  # Represents either a document symbol or workspace symbol depending on context.
     int,  # id
     str,  # name
     int,  # kind
@@ -484,6 +487,12 @@ class Position:
 class Range:
     start: Position
     end: Position
+
+
+@dataclasses.dataclass(frozen=True)
+class Location:
+    uri: str
+    range: Range
 
 
 class DiagnosticSeverity(enum.IntEnum):

--- a/lib/esbonio/esbonio/sphinx_agent/types.py
+++ b/lib/esbonio/esbonio/sphinx_agent/types.py
@@ -47,7 +47,6 @@ RST_DIRECTIVE: "re.Pattern" = re.compile(
         (?P<substitution_text>[^|]+)?
       \|?)?
       [ ]?
-      ((?P<domain>[\w]+):(?!:))?      # directives may include a domain
       (?P<name>([\w-]|:(?!:))+)?      # directives have a name
       (::)?                           # directives end with '::'
     )
@@ -62,9 +61,6 @@ the initial declaration. A number of named capture groups are available.
 
 ``name``
    The name of the directive, not including the domain prefix.
-
-``domain``
-   The domain prefix
 
 ``directive``
    Everything that makes up a directive, from the initial ``..`` up to and including the

--- a/lib/esbonio/esbonio/sphinx_agent/util.py
+++ b/lib/esbonio/esbonio/sphinx_agent/util.py
@@ -14,6 +14,9 @@ def _serialize_message(obj):
     if isinstance(obj, _TranslationProxy):
         return str(obj)
 
+    if isinstance(obj, set):
+        return list(obj)
+
     return obj
 
 

--- a/lib/esbonio/pyproject.toml
+++ b/lib/esbonio/pyproject.toml
@@ -54,6 +54,10 @@ source_pkgs = ["esbonio"]
 show_missing = true
 skip_covered = true
 sort = "Cover"
+exclude_also = [
+    # Typing imports will never be executed
+    "if typing.TYPE_CHECKING:",
+]
 
 [tool.isort]
 force_single_line = true

--- a/lib/esbonio/tests/conftest.py
+++ b/lib/esbonio/tests/conftest.py
@@ -14,7 +14,7 @@ def uri_for():
 
     def fn(*args):
         path = (TEST_DIR / pathlib.Path(*args)).resolve()
-        assert path.exists()
+        assert path.exists(), f"{path} does not exist"
         return Uri.for_file(str(path))
 
     return fn

--- a/lib/esbonio/tests/e2e/test_e2e_directives.py
+++ b/lib/esbonio/tests/e2e/test_e2e_directives.py
@@ -1,0 +1,222 @@
+from __future__ import annotations
+
+import pathlib
+import typing
+
+import pytest
+from lsprotocol import types
+from pytest_lsp import LanguageClient
+
+if typing.TYPE_CHECKING:
+    from typing import Optional
+    from typing import Set
+
+
+EXPECTED = {
+    "function",
+    "module",
+    "option",
+    "program",
+    "image",
+    "toctree",
+    "c:macro",
+    "c:function",
+    "py:function",
+    "py:module",
+    "std:program",
+    "std:option",
+}
+
+UNEXPECTED = {
+    "macro",
+    "restructuredtext-test-directive",
+}
+
+
+@pytest.mark.parametrize(
+    "text, expected, unexpected",
+    [
+        (".", None, None),
+        ("..", EXPECTED, UNEXPECTED),
+        (".. ", EXPECTED, UNEXPECTED),
+        (".. d", EXPECTED, UNEXPECTED),
+        (".. code-b", EXPECTED, UNEXPECTED),
+        (".. codex-block:: ", None, None),
+        (".. c:", EXPECTED, UNEXPECTED),
+        (".. _some_label:", None, None),
+        ("   .", None, None),
+        ("   ..", EXPECTED, UNEXPECTED),
+        ("   .. ", EXPECTED, UNEXPECTED),
+        ("   .. d", EXPECTED, UNEXPECTED),
+        ("   .. doctest:: ", None, None),
+        ("   .. code-b", EXPECTED, UNEXPECTED),
+        ("   .. codex-block:: ", None, None),
+        ("   .. _some_label:", None, None),
+        ("   .. c:", EXPECTED, UNEXPECTED),
+    ],
+)
+@pytest.mark.asyncio(scope="session")
+async def test_rst_directive_completions(
+    client: LanguageClient,
+    uri_for,
+    text: str,
+    expected: Optional[Set[str]],
+    unexpected: Optional[Set[str]],
+):
+    """Ensure that the language server can offer directive completions in rst
+    documents."""
+    test_uri = uri_for("workspaces", "demo", "rst", "directives.rst")
+
+    uri = str(test_uri)
+    fpath = pathlib.Path(test_uri)
+    contents = fpath.read_text()
+    linum = contents.splitlines().index(".. Add your note here...")
+
+    # Open the file
+    client.text_document_did_open(
+        types.DidOpenTextDocumentParams(
+            text_document=types.TextDocumentItem(
+                uri=uri,
+                language_id="restructuredtext",
+                version=1,
+                text=contents,
+            )
+        )
+    )
+
+    # Write some text
+    #
+    # This should replace the '.. Add your note here...' comment in
+    # 'demo/rst/directives.rst' with the provided text
+    client.text_document_did_change(
+        types.DidChangeTextDocumentParams(
+            text_document=types.VersionedTextDocumentIdentifier(uri=uri, version=2),
+            content_changes=[
+                types.TextDocumentContentChangeEvent_Type1(
+                    text=text,
+                    range=types.Range(
+                        start=types.Position(line=linum, character=0),
+                        end=types.Position(line=linum + 1, character=0),
+                    ),
+                )
+            ],
+        )
+    )
+
+    # Make the completion request
+    results = await client.text_document_completion_async(
+        types.CompletionParams(
+            text_document=types.TextDocumentIdentifier(uri=uri),
+            position=types.Position(line=linum, character=len(text)),
+        )
+    )
+
+    # Close the document - without saving!
+    client.text_document_did_close(
+        types.DidCloseTextDocumentParams(
+            text_document=types.TextDocumentIdentifier(uri=uri)
+        )
+    )
+
+    if expected is None:
+        assert results is None
+    else:
+        items = {item.label for item in results.items}
+        unexpected = unexpected or set()
+
+        assert expected == items & expected
+        assert set() == items & unexpected
+
+
+@pytest.mark.parametrize(
+    "text, expected, unexpected",
+    [
+        ("`", None, None),
+        ("``", None, None),
+        ("```", EXPECTED, UNEXPECTED),
+        ("```{", EXPECTED, UNEXPECTED),
+        ("```{d", EXPECTED, UNEXPECTED),
+        ("```{code-b", EXPECTED, UNEXPECTED),
+        ("```{codex-block} ", None, None),
+        ("```{c:", EXPECTED, UNEXPECTED),
+        ("   `", None, None),
+        ("   ``", None, None),
+        ("   ```", EXPECTED, UNEXPECTED),
+        ("   ```{", EXPECTED, UNEXPECTED),
+        ("   ```{d", EXPECTED, UNEXPECTED),
+        ("   ```{doctest}", None, None),
+        ("   ```{code-b", EXPECTED, UNEXPECTED),
+        ("   ```{codex-block}", None, None),
+        ("   ```{c:", EXPECTED, UNEXPECTED),
+    ],
+)
+@pytest.mark.asyncio(scope="session")
+async def test_myst_directive_completions(
+    client: LanguageClient,
+    uri_for,
+    text: str,
+    expected: Optional[Set[str]],
+    unexpected: Optional[Set[str]],
+):
+    """Ensure that the language server can offer completions in MyST documents."""
+    test_uri = uri_for("workspaces", "demo", "myst", "directives.md")
+
+    uri = str(test_uri)
+    fpath = pathlib.Path(test_uri)
+    contents = fpath.read_text()
+    linum = contents.splitlines().index("% Add your note here...")
+
+    # Open the file
+    client.text_document_did_open(
+        types.DidOpenTextDocumentParams(
+            text_document=types.TextDocumentItem(
+                uri=uri,
+                language_id="markdown",
+                version=1,
+                text=contents,
+            )
+        )
+    )
+
+    # Write some text
+    #
+    # This should replace the '% Add your note here...' comment in
+    # 'demo/myst/directives.md' with the provided text
+    client.text_document_did_change(
+        types.DidChangeTextDocumentParams(
+            text_document=types.VersionedTextDocumentIdentifier(uri=uri, version=2),
+            content_changes=[
+                types.TextDocumentContentChangeEvent_Type1(
+                    text=text,
+                    range=types.Range(
+                        start=types.Position(line=linum, character=0),
+                        end=types.Position(line=linum + 1, character=0),
+                    ),
+                )
+            ],
+        )
+    )
+
+    # Make the completion request
+    results = await client.text_document_completion_async(
+        types.CompletionParams(
+            text_document=types.TextDocumentIdentifier(uri=uri),
+            position=types.Position(line=linum, character=len(text)),
+        )
+    )
+
+    # Close the document - without saving!
+    client.text_document_did_close(
+        types.DidCloseTextDocumentParams(
+            text_document=types.TextDocumentIdentifier(uri=uri)
+        )
+    )
+
+    if expected is None:
+        assert results is None
+    else:
+        items = {item.label for item in results.items}
+        unexpected = unexpected or set()
+
+        assert expected == items & expected
+        assert set() == items & unexpected

--- a/lib/esbonio/tests/server/features/test_directive_completion.py
+++ b/lib/esbonio/tests/server/features/test_directive_completion.py
@@ -1,0 +1,703 @@
+from __future__ import annotations
+
+import typing
+
+import pytest
+from lsprotocol import types
+from pygls.workspace import TextDocument
+from pytest_lsp import client_capabilities
+
+from esbonio import server
+from esbonio.server.features.directives import Directive
+from esbonio.server.features.directives import completion
+from esbonio.server.testing import range_from_str
+from esbonio.sphinx_agent.types import MYST_DIRECTIVE
+from esbonio.sphinx_agent.types import RST_DIRECTIVE
+
+if typing.TYPE_CHECKING:
+    from typing import Literal
+    from typing import Optional
+
+
+VSCODE = "visual-studio-code"
+NVIM = "neovim"
+PATTERNS = {"rst": RST_DIRECTIVE, "markdown": MYST_DIRECTIVE}
+
+
+@pytest.mark.parametrize(
+    "client,language,insert_behavior,directive,text,character,expected",
+    [
+        (  # Standard rst directive completion with replacement
+            VSCODE,
+            "rst",
+            "replace",
+            Directive(
+                name="image",
+                implementation="docutils.parsers.rst.directives.images.Image",
+            ),
+            "..",
+            None,
+            types.CompletionItem(
+                label="image",
+                detail="docutils.parsers.rst.directives.images.Image",
+                kind=types.CompletionItemKind.Class,
+                filter_text=".. image::",
+                insert_text_format=types.InsertTextFormat.PlainText,
+                text_edit=types.TextEdit(
+                    range=range_from_str("0:0-0:2"), new_text=".. image::"
+                ),
+                data=dict(completion_type="directive"),
+            ),
+        ),
+        (  # We need to take into account indentation
+            VSCODE,
+            "rst",
+            "replace",
+            Directive(
+                name="image",
+                implementation="docutils.parsers.rst.directives.images.Image",
+            ),
+            "   ..",
+            None,
+            types.CompletionItem(
+                label="image",
+                detail="docutils.parsers.rst.directives.images.Image",
+                kind=types.CompletionItemKind.Class,
+                filter_text=".. image::",
+                insert_text_format=types.InsertTextFormat.PlainText,
+                text_edit=types.TextEdit(
+                    range=range_from_str("0:3-0:5"), new_text=".. image::"
+                ),
+                data=dict(completion_type="directive"),
+            ),
+        ),
+        (  # The replacement should remove all exiting text
+            VSCODE,
+            "rst",
+            "replace",
+            Directive(
+                name="image",
+                implementation="docutils.parsers.rst.directives.images.Image",
+            ),
+            ".. inc",
+            None,
+            types.CompletionItem(
+                label="image",
+                detail="docutils.parsers.rst.directives.images.Image",
+                kind=types.CompletionItemKind.Class,
+                filter_text=".. image::",
+                insert_text_format=types.InsertTextFormat.PlainText,
+                text_edit=types.TextEdit(
+                    range=range_from_str("0:0-0:6"), new_text=".. image::"
+                ),
+                data=dict(completion_type="directive"),
+            ),
+        ),
+        (  # Unless the directive has an existing argument, then we should not replace
+            # it
+            VSCODE,
+            "rst",
+            "replace",
+            Directive(
+                name="image",
+                implementation="docutils.parsers.rst.directives.images.Image",
+            ),
+            ".. include:: filename.png",
+            3,  # character
+            types.CompletionItem(
+                label="image",
+                detail="docutils.parsers.rst.directives.images.Image",
+                kind=types.CompletionItemKind.Class,
+                filter_text=".. image::",
+                insert_text_format=types.InsertTextFormat.PlainText,
+                text_edit=types.TextEdit(
+                    range=range_from_str("0:0-0:12"), new_text=".. image::"
+                ),
+                data=dict(completion_type="directive"),
+            ),
+        ),
+        (  # When doing 'insert' completions, we should skip directives with
+            # incompatible prefixes
+            VSCODE,
+            "rst",
+            "insert",
+            Directive(
+                name="image",
+                implementation="docutils.parsers.rst.directives.images.Image",
+            ),
+            ".. inc",
+            None,
+            None,
+        ),
+        (  # 'insert' completions still do some replacement, but it's up to the client's
+            # interpretation of what is considered a 'word'
+            VSCODE,
+            "rst",
+            "insert",
+            Directive(
+                name="image",
+                implementation="docutils.parsers.rst.directives.images.Image",
+            ),
+            ".. im",
+            None,
+            types.CompletionItem(
+                label="image",
+                detail="docutils.parsers.rst.directives.images.Image",
+                kind=types.CompletionItemKind.Class,
+                insert_text="image::",
+                insert_text_format=types.InsertTextFormat.PlainText,
+                data=dict(completion_type="directive"),
+            ),
+        ),
+        (
+            VSCODE,
+            "rst",
+            "insert",
+            Directive(
+                name="code-block",
+                implementation="sphinx.directives.code.CodeBlock",
+            ),
+            ".. co",
+            None,
+            types.CompletionItem(
+                label="code-block",
+                detail="sphinx.directives.code.CodeBlock",
+                kind=types.CompletionItemKind.Class,
+                insert_text="code-block::",
+                insert_text_format=types.InsertTextFormat.PlainText,
+                data=dict(completion_type="directive"),
+            ),
+        ),
+        (
+            VSCODE,
+            "rst",
+            "insert",
+            Directive(
+                name="code-block",
+                implementation="sphinx.directives.code.CodeBlock",
+            ),
+            ".. code-",
+            None,
+            types.CompletionItem(
+                label="code-block",
+                detail="sphinx.directives.code.CodeBlock",
+                kind=types.CompletionItemKind.Class,
+                insert_text="block::",
+                insert_text_format=types.InsertTextFormat.PlainText,
+                data=dict(completion_type="directive"),
+            ),
+        ),
+        (
+            VSCODE,
+            "rst",
+            "insert",
+            Directive(
+                name="code-block",
+                implementation="sphinx.directives.code.CodeBlock",
+            ),
+            ".. code-bl",
+            None,
+            types.CompletionItem(
+                label="code-block",
+                detail="sphinx.directives.code.CodeBlock",
+                kind=types.CompletionItemKind.Class,
+                insert_text="block::",
+                insert_text_format=types.InsertTextFormat.PlainText,
+                data=dict(completion_type="directive"),
+            ),
+        ),
+        (
+            VSCODE,
+            "rst",
+            "insert",
+            Directive(
+                name="c:function",
+                implementation="sphinx.domains.c.CFunctionObject",
+            ),
+            "..",
+            None,
+            types.CompletionItem(
+                label="c:function",
+                detail="sphinx.domains.c.CFunctionObject",
+                kind=types.CompletionItemKind.Class,
+                insert_text=" c:function::",
+                insert_text_format=types.InsertTextFormat.PlainText,
+                data=dict(completion_type="directive"),
+            ),
+        ),
+        (
+            VSCODE,
+            "rst",
+            "insert",
+            Directive(
+                name="c:function",
+                implementation="sphinx.domains.c.CFunctionObject",
+            ),
+            ".. c",
+            None,
+            types.CompletionItem(
+                label="c:function",
+                detail="sphinx.domains.c.CFunctionObject",
+                kind=types.CompletionItemKind.Class,
+                insert_text="c:function::",
+                insert_text_format=types.InsertTextFormat.PlainText,
+                data=dict(completion_type="directive"),
+            ),
+        ),
+        (
+            VSCODE,
+            "rst",
+            "insert",
+            Directive(
+                name="c:function",
+                implementation="sphinx.domains.c.CFunctionObject",
+            ),
+            ".. c:",
+            None,
+            types.CompletionItem(
+                label="c:function",
+                detail="sphinx.domains.c.CFunctionObject",
+                kind=types.CompletionItemKind.Class,
+                insert_text="function::",
+                insert_text_format=types.InsertTextFormat.PlainText,
+                data=dict(completion_type="directive"),
+            ),
+        ),
+        (
+            VSCODE,
+            "rst",
+            "insert",
+            Directive(
+                name="c:function",
+                implementation="sphinx.domains.c.CFunctionObject",
+            ),
+            ".. c:fun",
+            None,
+            types.CompletionItem(
+                label="c:function",
+                detail="sphinx.domains.c.CFunctionObject",
+                kind=types.CompletionItemKind.Class,
+                insert_text="function::",
+                insert_text_format=types.InsertTextFormat.PlainText,
+                data=dict(completion_type="directive"),
+            ),
+        ),
+        (  # If the client supports it, we can use snippets to include the closing fences
+            VSCODE,
+            "markdown",
+            "replace",
+            Directive(
+                name="image",
+                implementation="docutils.parsers.rst.directives.images.Image",
+            ),
+            """```""",
+            None,
+            types.CompletionItem(
+                label="image",
+                detail="docutils.parsers.rst.directives.images.Image",
+                kind=types.CompletionItemKind.Class,
+                filter_text="```{image} $0\n```",
+                insert_text_format=types.InsertTextFormat.Snippet,
+                text_edit=types.TextEdit(
+                    range=range_from_str("0:0-0:3"), new_text="```{image} $0\n```"
+                ),
+                data=dict(completion_type="directive"),
+            ),
+        ),
+        (  # Otherwise, they should be omitted
+            NVIM,
+            "markdown",
+            "replace",
+            Directive(
+                name="image",
+                implementation="docutils.parsers.rst.directives.images.Image",
+            ),
+            """```""",
+            None,
+            types.CompletionItem(
+                label="image",
+                detail="docutils.parsers.rst.directives.images.Image",
+                kind=types.CompletionItemKind.Class,
+                filter_text="```{image}",
+                insert_text_format=types.InsertTextFormat.PlainText,
+                text_edit=types.TextEdit(
+                    range=range_from_str("0:0-0:3"), new_text="```{image}"
+                ),
+                data=dict(completion_type="directive"),
+            ),
+        ),
+        (  # Be sure to take into account indentation
+            VSCODE,
+            "markdown",
+            "replace",
+            Directive(
+                name="image",
+                implementation="docutils.parsers.rst.directives.images.Image",
+            ),
+            """   ```""",
+            None,
+            types.CompletionItem(
+                label="image",
+                detail="docutils.parsers.rst.directives.images.Image",
+                kind=types.CompletionItemKind.Class,
+                filter_text="```{image} $0\n```",
+                insert_text_format=types.InsertTextFormat.Snippet,
+                text_edit=types.TextEdit(
+                    range=range_from_str("0:3-0:6"), new_text="```{image} $0\n```"
+                ),
+                data=dict(completion_type="directive"),
+            ),
+        ),
+        (
+            VSCODE,
+            "markdown",
+            "replace",
+            Directive(
+                name="image",
+                implementation="docutils.parsers.rst.directives.images.Image",
+            ),
+            """```{inc""",
+            None,
+            types.CompletionItem(
+                label="image",
+                detail="docutils.parsers.rst.directives.images.Image",
+                kind=types.CompletionItemKind.Class,
+                filter_text="```{image} $0\n```",
+                insert_text_format=types.InsertTextFormat.Snippet,
+                text_edit=types.TextEdit(
+                    range=range_from_str("0:0-0:7"), new_text="```{image} $0\n```"
+                ),
+                data=dict(completion_type="directive"),
+            ),
+        ),
+        (
+            NVIM,
+            "markdown",
+            "replace",
+            Directive(
+                name="image",
+                implementation="docutils.parsers.rst.directives.images.Image",
+            ),
+            """```{inc""",
+            None,
+            types.CompletionItem(
+                label="image",
+                detail="docutils.parsers.rst.directives.images.Image",
+                kind=types.CompletionItemKind.Class,
+                filter_text="```{image}",
+                insert_text_format=types.InsertTextFormat.PlainText,
+                text_edit=types.TextEdit(
+                    range=range_from_str("0:0-0:7"), new_text="```{image}"
+                ),
+                data=dict(completion_type="directive"),
+            ),
+        ),
+        (  # Arguments should not be replaced
+            VSCODE,
+            "markdown",
+            "replace",
+            Directive(
+                name="image",
+                implementation="docutils.parsers.rst.directives.images.Image",
+            ),
+            """```{include} filename.png""",
+            7,  # character index
+            types.CompletionItem(
+                label="image",
+                detail="docutils.parsers.rst.directives.images.Image",
+                kind=types.CompletionItemKind.Class,
+                filter_text="```{image}",
+                insert_text_format=types.InsertTextFormat.PlainText,
+                text_edit=types.TextEdit(
+                    range=range_from_str("0:0-0:12"), new_text="```{image}"
+                ),
+                data=dict(completion_type="directive"),
+            ),
+        ),
+        (
+            VSCODE,
+            "markdown",
+            "insert",
+            Directive(
+                name="image",
+                implementation="docutils.parsers.rst.directives.images.Image",
+            ),
+            """```{inc""",
+            None,
+            None,
+        ),
+        (
+            VSCODE,
+            "markdown",
+            "insert",
+            Directive(
+                name="image",
+                implementation="docutils.parsers.rst.directives.images.Image",
+            ),
+            "```",
+            None,
+            types.CompletionItem(
+                label="image",
+                detail="docutils.parsers.rst.directives.images.Image",
+                kind=types.CompletionItemKind.Class,
+                insert_text="{image} $0\n```",
+                insert_text_format=types.InsertTextFormat.Snippet,
+                data=dict(completion_type="directive"),
+            ),
+        ),
+        (
+            VSCODE,
+            "markdown",
+            "insert",
+            Directive(
+                name="image",
+                implementation="docutils.parsers.rst.directives.images.Image",
+            ),
+            "```{",
+            None,
+            types.CompletionItem(
+                label="image",
+                detail="docutils.parsers.rst.directives.images.Image",
+                kind=types.CompletionItemKind.Class,
+                insert_text="image} $0\n```",
+                insert_text_format=types.InsertTextFormat.Snippet,
+                data=dict(completion_type="directive"),
+            ),
+        ),
+        (
+            VSCODE,
+            "markdown",
+            "insert",
+            Directive(
+                name="image",
+                implementation="docutils.parsers.rst.directives.images.Image",
+            ),
+            "```{im",
+            None,
+            types.CompletionItem(
+                label="image",
+                detail="docutils.parsers.rst.directives.images.Image",
+                kind=types.CompletionItemKind.Class,
+                insert_text="image} $0\n```",
+                insert_text_format=types.InsertTextFormat.Snippet,
+                data=dict(completion_type="directive"),
+            ),
+        ),
+        (
+            NVIM,
+            "markdown",
+            "insert",
+            Directive(
+                name="image",
+                implementation="docutils.parsers.rst.directives.images.Image",
+            ),
+            "```{im",
+            None,
+            types.CompletionItem(
+                label="image",
+                detail="docutils.parsers.rst.directives.images.Image",
+                kind=types.CompletionItemKind.Class,
+                insert_text="image}",
+                insert_text_format=types.InsertTextFormat.PlainText,
+                data=dict(completion_type="directive"),
+            ),
+        ),
+        (
+            NVIM,
+            "markdown",
+            "insert",
+            Directive(
+                name="code-block",
+                implementation="sphinx.directives.code.CodeBlock",
+            ),
+            "```{co",
+            None,
+            types.CompletionItem(
+                label="code-block",
+                detail="sphinx.directives.code.CodeBlock",
+                kind=types.CompletionItemKind.Class,
+                insert_text="code-block}",
+                insert_text_format=types.InsertTextFormat.PlainText,
+                data=dict(completion_type="directive"),
+            ),
+        ),
+        (
+            NVIM,
+            "markdown",
+            "insert",
+            Directive(
+                name="code-block",
+                implementation="sphinx.directives.code.CodeBlock",
+            ),
+            "```{code-",
+            None,
+            types.CompletionItem(
+                label="code-block",
+                detail="sphinx.directives.code.CodeBlock",
+                kind=types.CompletionItemKind.Class,
+                insert_text="block}",
+                insert_text_format=types.InsertTextFormat.PlainText,
+                data=dict(completion_type="directive"),
+            ),
+        ),
+        (
+            NVIM,
+            "markdown",
+            "insert",
+            Directive(
+                name="code-block",
+                implementation="sphinx.directives.code.CodeBlock",
+            ),
+            "```{code-bl",
+            None,
+            types.CompletionItem(
+                label="code-block",
+                detail="sphinx.directives.code.CodeBlock",
+                kind=types.CompletionItemKind.Class,
+                insert_text="block}",
+                insert_text_format=types.InsertTextFormat.PlainText,
+                data=dict(completion_type="directive"),
+            ),
+        ),
+        (
+            NVIM,
+            "markdown",
+            "insert",
+            Directive(
+                name="c:function",
+                implementation="sphinx.domains.c.CFunctionObject",
+            ),
+            "```",
+            None,
+            types.CompletionItem(
+                label="c:function",
+                detail="sphinx.domains.c.CFunctionObject",
+                kind=types.CompletionItemKind.Class,
+                insert_text="{c:function}",
+                insert_text_format=types.InsertTextFormat.PlainText,
+                data=dict(completion_type="directive"),
+            ),
+        ),
+        (
+            NVIM,
+            "markdown",
+            "insert",
+            Directive(
+                name="c:function",
+                implementation="sphinx.domains.c.CFunctionObject",
+            ),
+            "```{c",
+            None,
+            types.CompletionItem(
+                label="c:function",
+                detail="sphinx.domains.c.CFunctionObject",
+                kind=types.CompletionItemKind.Class,
+                insert_text="c:function}",
+                insert_text_format=types.InsertTextFormat.PlainText,
+                data=dict(completion_type="directive"),
+            ),
+        ),
+        (
+            NVIM,
+            "markdown",
+            "insert",
+            Directive(
+                name="c:function",
+                implementation="sphinx.domains.c.CFunctionObject",
+            ),
+            "```{c:",
+            None,
+            types.CompletionItem(
+                label="c:function",
+                detail="sphinx.domains.c.CFunctionObject",
+                kind=types.CompletionItemKind.Class,
+                insert_text="function}",
+                insert_text_format=types.InsertTextFormat.PlainText,
+                data=dict(completion_type="directive"),
+            ),
+        ),
+        (
+            NVIM,
+            "markdown",
+            "insert",
+            Directive(
+                name="c:function",
+                implementation="sphinx.domains.c.CFunctionObject",
+            ),
+            "```{c:fun",
+            None,
+            types.CompletionItem(
+                label="c:function",
+                detail="sphinx.domains.c.CFunctionObject",
+                kind=types.CompletionItemKind.Class,
+                insert_text="function}",
+                insert_text_format=types.InsertTextFormat.PlainText,
+                data=dict(completion_type="directive"),
+            ),
+        ),
+    ],
+)
+def test_render_directive_completion(
+    client: str,
+    language: Literal["rst", "markdown"],
+    insert_behavior: Literal["insert", "replace"],
+    directive: Directive,
+    text: str,
+    character: Optional[int],
+    expected: Optional[types.CompletionItem],
+):
+    """Ensure that we can render directive completions correctly.
+
+    Parameters
+    ----------
+    client
+       The name of the client to use.
+
+       This will be passed to the ``client_capabilities`` function from ``pytest_lsp``
+       and will control what capabilities (e.g. snippet support) will be available.
+
+    language
+       The language in which the completion item will be inserted.
+
+    insert_behavior
+       How the completion item should behave when inserted.
+
+    directive
+       The directive to generate the completion item for.
+
+    text
+       The text used to help generate the completion context.
+
+    character
+       The character column at which the request is being made.
+       If ``None``, it will be assumed that the request is being made at
+       the end of ``text``.
+
+    expected
+       The expected result.
+    """
+
+    match = PATTERNS[language].match(text)
+    if not match:
+        raise ValueError(f"'{text}' is not valid in this context")
+
+    line = 0
+    character = len(text) if character is None else character
+    uri = "file:///test.txt"
+
+    context = server.CompletionContext(
+        uri=server.Uri.parse(uri),
+        doc=TextDocument(uri=uri),
+        match=match,
+        position=types.Position(line=line, character=character),
+        capabilities=client_capabilities(client),
+    )
+
+    render_func = completion.get_directive_renderer(language, insert_behavior)
+    assert render_func is not None
+
+    item = render_func(context, directive)
+    if expected is None:
+        assert item is None
+    else:
+        assert item == expected

--- a/lib/esbonio/tests/server/test_patterns.py
+++ b/lib/esbonio/tests/server/test_patterns.py
@@ -66,7 +66,7 @@ def test_myst_directive_regex(string, expected):
         ("..", {"directive": ".."}),
         (".. d", {"directive": ".. d"}),
         (".. image::", {"name": "image", "directive": ".. image::"}),
-        (".. c:", {"domain": "c", "directive": ".. c:"}),
+        (".. c:", {"name": "c:", "directive": ".. c:"}),
         (".. |", {"directive": ".. |", "substitution": "|"}),
         (
             ".. |e",
@@ -109,7 +109,7 @@ def test_myst_directive_regex(string, expected):
         ),
         (
             ".. c:function::",
-            {"name": "function", "domain": "c", "directive": ".. c:function::"},
+            {"name": "c:function", "directive": ".. c:function::"},
         ),
         (
             ".. image:: filename.png",
@@ -126,8 +126,7 @@ def test_myst_directive_regex(string, expected):
         (
             ".. cpp:function:: malloc",
             {
-                "name": "function",
-                "domain": "cpp",
+                "name": "cpp:function",
                 "argument": "malloc",
                 "directive": ".. cpp:function::",
             },
@@ -139,8 +138,7 @@ def test_myst_directive_regex(string, expected):
         (
             "   .. cpp:function:: malloc",
             {
-                "name": "function",
-                "domain": "cpp",
+                "name": "cpp:function",
                 "argument": "malloc",
                 "directive": ".. cpp:function::",
             },
@@ -148,24 +146,21 @@ def test_myst_directive_regex(string, expected):
         (
             ".. rst:directive:option::",
             {
-                "name": "directive:option",
-                "domain": "rst",
+                "name": "rst:directive:option",
                 "directive": ".. rst:directive:option::",
             },
         ),
         (
             "   .. rst:directive:option::",
             {
-                "name": "directive:option",
-                "domain": "rst",
+                "name": "rst:directive:option",
                 "directive": ".. rst:directive:option::",
             },
         ),
         (
             "   .. rst:directive:option:: height",
             {
-                "name": "directive:option",
-                "domain": "rst",
+                "name": "rst:directive:option",
                 "directive": ".. rst:directive:option::",
                 "argument": "height",
             },

--- a/lib/esbonio/tests/sphinx-agent/handlers/test_database.py
+++ b/lib/esbonio/tests/sphinx-agent/handlers/test_database.py
@@ -27,7 +27,13 @@ async def test_files_table(client: SubprocessSphinxClient):
 
     expected = {
         (anuri(src, "index.rst"), "index", "index.html"),
+        (anuri(src, "rst", "directives.rst"), "rst/directives", "rst/directives.html"),
         (anuri(src, "rst", "symbols.rst"), "rst/symbols", "rst/symbols.html"),
+        (
+            anuri(src, "myst", "directives.md"),
+            "myst/directives",
+            "myst/directives.html",
+        ),
         (anuri(src, "myst", "symbols.md"), "myst/symbols", "myst/symbols.html"),
         (anuri(src, "demo_rst.rst"), "demo_rst", "demo_rst.html"),
         (anuri(src, "demo_myst.md"), "demo_myst", "demo_myst.html"),

--- a/lib/esbonio/tests/unit_tests/test_directive_completions.py
+++ b/lib/esbonio/tests/unit_tests/test_directive_completions.py
@@ -7,132 +7,17 @@ from docutils.parsers.rst import Directive
 from docutils.parsers.rst.directives.images import Image
 from lsprotocol.types import CompletionItem
 from lsprotocol.types import CompletionItemKind
-from lsprotocol.types import InsertTextFormat
 from lsprotocol.types import TextEdit
-from sphinx.directives.code import CodeBlock
-from sphinx.domains.c import CFunctionObject
 
 from esbonio.lsp import CompletionContext
-from esbonio.lsp.directives.completions import render_directive_completion
 from esbonio.lsp.directives.completions import render_directive_option_completion
 from esbonio.lsp.testing import make_completion_context
 from esbonio.lsp.testing import range_from_str
-from esbonio.lsp.util.patterns import DIRECTIVE
 from esbonio.lsp.util.patterns import DIRECTIVE_OPTION
 
-make_directive_completion_context = partial(make_completion_context, DIRECTIVE)
 make_directive_option_completion_context = partial(
     make_completion_context, DIRECTIVE_OPTION
 )
-
-
-@pytest.mark.parametrize(
-    "context, name, directive, expected",
-    [
-        (
-            make_directive_completion_context(".."),
-            "image",
-            Image,
-            CompletionItem(
-                label="image",
-                filter_text=".. image::",
-                insert_text_format=InsertTextFormat.PlainText,
-                text_edit=TextEdit(
-                    range=range_from_str("0:0-0:2"), new_text=".. image::"
-                ),
-            ),
-        ),
-        (
-            make_directive_completion_context(".. inc"),
-            "image",
-            Image,
-            CompletionItem(
-                label="image",
-                filter_text=".. image::",
-                insert_text_format=InsertTextFormat.PlainText,
-                text_edit=TextEdit(
-                    range=range_from_str("0:0-0:6"), new_text=".. image::"
-                ),
-            ),
-        ),
-        (
-            make_directive_completion_context(".. inc", prefer_insert=True),
-            "image",
-            Image,
-            None,
-        ),
-        (
-            make_directive_completion_context(".. im", prefer_insert=True),
-            "image",
-            Image,
-            CompletionItem(label="image", insert_text="image::"),
-        ),
-        (
-            make_directive_completion_context(".. co", prefer_insert=True),
-            "code-block",
-            CodeBlock,
-            CompletionItem(label="code-block", insert_text="code-block::"),
-        ),
-        (
-            make_directive_completion_context(".. code-", prefer_insert=True),
-            "code-block",
-            CodeBlock,
-            CompletionItem(label="code-block", insert_text="block::"),
-        ),
-        (
-            make_directive_completion_context(".. code-bl", prefer_insert=True),
-            "code-block",
-            CodeBlock,
-            CompletionItem(label="code-block", insert_text="block::"),
-        ),
-        (
-            make_directive_completion_context("..", prefer_insert=True),
-            "c:function",
-            CFunctionObject,
-            CompletionItem(label="c:function", insert_text=" c:function::"),
-        ),
-        (
-            make_directive_completion_context(".. c", prefer_insert=True),
-            "c:function",
-            CFunctionObject,
-            CompletionItem(label="c:function", insert_text="c:function::"),
-        ),
-        (
-            make_directive_completion_context(".. c:", prefer_insert=True),
-            "c:function",
-            CFunctionObject,
-            CompletionItem(label="c:function", insert_text="function::"),
-        ),
-        (
-            make_directive_completion_context(".. c:fun", prefer_insert=True),
-            "c:function",
-            CFunctionObject,
-            CompletionItem(label="c:function", insert_text="function::"),
-        ),
-    ],
-)
-def test_render_directive_completion(
-    context: CompletionContext,
-    name: str,
-    directive: Type[Directive],
-    expected: Optional[CompletionItem],
-):
-    """Ensure that we can render directive completions correctly, according to the
-    current context."""
-
-    # These fields are always present, so let's not force the test author to add them
-    # in :)
-    if expected is not None:
-        expected.kind = CompletionItemKind.Class
-        expected.data = {"completion_type": "directive"}
-
-        try:
-            expected.detail = f"{directive.__module__}.{directive.__name__}"
-        except AttributeError:
-            expected.detail = f"{directive.__module__}.{directive.__class__.__name__}"
-
-    actual = render_directive_completion(context, name, directive)
-    assert actual == expected
 
 
 @pytest.mark.parametrize(

--- a/lib/esbonio/tests/workspaces/demo/myst/directives.md
+++ b/lib/esbonio/tests/workspaces/demo/myst/directives.md
@@ -1,0 +1,11 @@
+# Directives
+
+The language server has extensive support for directives.
+
+## Completion
+
+The most obvious feature is the completion suggestions, try inserting a `{note}` directive on the next line
+
+% Add your note here...
+
+Notice how VSCode automatically presented you with a list of all the directives you can use in this Sphinx project?

--- a/lib/esbonio/tests/workspaces/demo/rst/directives.rst
+++ b/lib/esbonio/tests/workspaces/demo/rst/directives.rst
@@ -11,11 +11,3 @@ The most obvious feature is the completion suggestions, try inserting a ``.. not
 .. Add your note here...
 
 Notice how VSCode automatically presented you with a list of all the directives you can use in this Sphinx project?
-
-Goto ...
---------
-
-The language server also provides a number of "Goto" navigation commands.
-On the ``.. note::`` directive you inserted above, try each of the following commands
-
-- ``Implementation`` goto the source code that implements the selected directive

--- a/lib/esbonio/tests/workspaces/demo/rst/directives.rst
+++ b/lib/esbonio/tests/workspaces/demo/rst/directives.rst
@@ -1,0 +1,21 @@
+Directives
+==========
+
+The language server has extensive support for directives.
+
+Completion
+----------
+
+The most obvious feature is the completion suggestions, try inserting a ``.. note::`` directive on the next line
+
+.. Add your note here...
+
+Notice how VSCode automatically presented you with a list of all the directives you can use in this Sphinx project?
+
+Goto ...
+--------
+
+The language server also provides a number of "Goto" navigation commands.
+On the ``.. note::`` directive you inserted above, try each of the following commands
+
+- ``Implementation`` goto the source code that implements the selected directive

--- a/scripts/sphinx-app.py
+++ b/scripts/sphinx-app.py
@@ -29,11 +29,12 @@ The HTML pages are in docs/_build.
 >>> app
 <sphinx.application.Sphinx object at 0x7f0ad0fdb5b0>
 """
+import inspect
 import pathlib
+import time
 
-from sphinx.application import Sphinx
-
-from esbonio.lsp.sphinx import SphinxLanguageServer
+from esbonio.sphinx_agent import types
+from esbonio.sphinx_agent.app import Sphinx
 
 root = pathlib.Path(__file__).parent.parent
 
@@ -46,5 +47,3 @@ app = Sphinx(
     freshenv=True,  # Have Sphinx reload everything on first build.
 )
 app.build()
-ls = SphinxLanguageServer()
-ls.app = app


### PR DESCRIPTION
This re-implements completion suggestions for directives (as in `.. figure::` or ```` ```{toctree} ```` ), completions for a directive's arguments and options will come in a future PR.

- Completions for both reStructuredText and MyST are supported.
  **Note:** The MyST syntax for directives is a lot more complicated than the rst syntax, so the following is not yet supported
  - Using `:::{note}` style directives
  - Nesting directives 
- Support for the `insert` and `replace`  style of completions, using the `esbonio.server.completion.preferredInsertBehavior` option as before.
 Thanks to the new configuration framework, you can even switch between them without restarting the server!
- Last but not least, `esbonio` will finally respect the `..default-domain::` directive when generating completion suggestions! Closes #105 

Related: #312