### PR TITLE
lsp: Update to `pytest-asyncio` v0.23

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,7 +22,7 @@ updates:
     target-branch: "develop"
     schedule:
       interval: "weekly"
-        
+
   - package-ecosystem: "pip"
     directory: "/lib/esbonio/tests/workspaces/demo"
     target-branch: "develop"

--- a/lib/esbonio/tests/conftest.py
+++ b/lib/esbonio/tests/conftest.py
@@ -1,4 +1,3 @@
-import asyncio
 import pathlib
 
 import pytest
@@ -19,18 +18,3 @@ def uri_for():
         return Uri.for_file(str(path))
 
     return fn
-
-
-@pytest.fixture(scope="session")
-def event_loop():
-    # We need to redefine the event_loop fixture to match the scope of our
-    # client_server fixture.
-    #
-    # https://github.com/pytest-dev/pytest-asyncio/issues/68#issuecomment-334083751
-
-    loop = asyncio.get_event_loop_policy().new_event_loop()
-    asyncio.set_event_loop(loop)
-
-    yield loop
-
-    loop.close()

--- a/lib/esbonio/tests/e2e/test_e2e_symbols.py
+++ b/lib/esbonio/tests/e2e/test_e2e_symbols.py
@@ -95,7 +95,7 @@ def document_symbol(
         ),
     ],
 )
-@pytest.mark.asyncio
+@pytest.mark.asyncio(scope="session")
 async def test_document_symbols(
     client: LanguageClient,
     uri_for,
@@ -249,7 +249,7 @@ async def test_document_symbols(
         ("--not-a-real-symbol-name--", None),
     ],
 )
-@pytest.mark.asyncio
+@pytest.mark.asyncio(scope="session")
 async def test_workspace_symbols(
     client: LanguageClient,
     query: str,

--- a/lib/esbonio/tests/sphinx-agent/test_sa_build.py
+++ b/lib/esbonio/tests/sphinx-agent/test_sa_build.py
@@ -108,7 +108,7 @@ async def client_build_error(
     yield
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio(scope="module")
 async def test_build_error(client_build_error: SubprocessSphinxClient):
     """Ensure that when a build error occurs, useful information is reported."""
 

--- a/lib/esbonio/tox.ini
+++ b/lib/esbonio/tox.ini
@@ -37,7 +37,7 @@ deps =
     coverage[toml]
     pytest
     pytest-lsp>=0.3.1
-    pytest-asyncio!=0.23.0,!=0.23.1,!=0.23.2
+    pytest-asyncio>=0.23.3
 set_env = COVERAGE_PROCESS_START={toxinidir}/pyproject.toml
 commands_pre =
     python -c 'import pathlib; pathlib.Path("{env_site_packages_dir}/cov.pth").write_text("import coverage; coverage.process_startup()")'


### PR DESCRIPTION
Strangely, unless we explicitly request a scope for each test that aligns with the scope of the client fixture the tests depend on, the test suite will hang (on my machine at least...).

The issue does not seem to be present in `pytest-asyncio` itself, which suggests there's something funny going on in `pytest-lsp`.

Opened swyddfa/lsp-devtools#126 to track this