### PR TITLE
lsp: Clamp `Position` values to the valid range

### DIFF
--- a/lib/esbonio/changes/714.fix.rst
+++ b/lib/esbonio/changes/714.fix.rst
@@ -1,0 +1,2 @@
+Fix ``ValueError`` thrown when the server is given invalid ``Position`` data.
+Invalid values will be clamped to the range permitted by the language server protocol (``[0, 2147483647]``)

--- a/lib/esbonio/esbonio/cli/__init__.py
+++ b/lib/esbonio/esbonio/cli/__init__.py
@@ -4,6 +4,7 @@ import sys
 import warnings
 from typing import Union
 
+from lsprotocol import types
 from pygls.protocol import default_converter
 
 try:
@@ -16,6 +17,18 @@ def esbonio_converter():
     converter = default_converter()
     converter.register_structure_hook(Union[Literal["auto"], int], lambda obj, _: obj)
 
+    def position_hook(obj, type_):
+        """Parse a position, gracefully handling invalid data"""
+        l: int = obj.get("line", None) or 0
+        c: int = obj.get("character", None) or 0
+
+        # Clamp positions to valid range.
+        return types.Position(
+            line=min(max(l, 0), 2147483647),
+            character=min(max(c, 0), 2147483647),
+        )
+
+    converter.register_structure_hook(types.Position, position_hook)
     return converter
 
 

--- a/lib/esbonio/pyproject.toml
+++ b/lib/esbonio/pyproject.toml
@@ -84,7 +84,7 @@ deps =
 extras = test
 commands =
     python ../../scripts/check-sphinx-version.py
-    pytest {posargs}
+    pytest {posargs:tests}
 
 [testenv:pkg]
 deps =

--- a/lib/esbonio/setup.cfg
+++ b/lib/esbonio/setup.cfg
@@ -51,6 +51,7 @@ test =
   mock; python_version<"3.8"
   pytest
   pytest-lsp>=0.3.1
+  pytest-asyncio<0.23
   pytest-cov
   pytest-timeout
 typecheck =

--- a/lib/esbonio/tests/sphinx-default/test_sd_code_actions.py
+++ b/lib/esbonio/tests/sphinx-default/test_sd_code_actions.py
@@ -1,0 +1,34 @@
+import attrs
+import pytest
+from lsprotocol import types
+from pytest_lsp import LanguageClient
+
+
+@pytest.mark.asyncio
+async def test_code_actions_invalid_params(client: LanguageClient):
+    """Ensure that the server can handle invalid code actions data."""
+
+    with attrs.validators.disabled():
+        params = types.CodeActionParams(
+            text_document=types.TextDocumentIdentifier(
+                uri=client.root_uri + "/test.rst"
+            ),
+            range=types.Range(
+                start=types.Position(line=1, character=0),
+                end=types.Position(line=1, character=5),
+            ),
+            context=types.CodeActionContext(
+                diagnostics=[
+                    types.Diagnostic(
+                        message="I am an invalid diagnostic",
+                        range=types.Range(
+                            start=types.Position(line=1, character=0),
+                            end=types.Position(line=1, character=int(1e100)),
+                        ),
+                    )
+                ]
+            ),
+        )
+
+    results = await client.text_document_code_action_async(params)
+    assert results == []

--- a/lib/esbonio/tests/unit_tests/test_converter.py
+++ b/lib/esbonio/tests/unit_tests/test_converter.py
@@ -1,0 +1,51 @@
+import pytest
+from lsprotocol import types
+
+from esbonio.cli import esbonio_converter
+
+
+@pytest.mark.parametrize(
+    "data, expected",
+    [
+        (dict(line=None, character=0), types.Position(line=0, character=0)),
+        (dict(line=-1, character=0), types.Position(line=0, character=0)),
+        (
+            dict(line=int(1e100), character=0),
+            types.Position(line=2147483647, character=0),
+        ),
+        (dict(line=1, character=-2), types.Position(line=1, character=0)),
+        (dict(line=1, character=None), types.Position(line=1, character=0)),
+        (
+            dict(line=1, character=int(1e100)),
+            types.Position(line=1, character=2147483647),
+        ),
+        (
+            dict(
+                diagnostics=[
+                    dict(
+                        message="Example message",
+                        range=dict(
+                            start=dict(line=1, character=0),
+                            end=dict(line=1, character=int(1e100)),
+                        ),
+                    )
+                ]
+            ),
+            types.CodeActionContext(
+                diagnostics=[
+                    types.Diagnostic(
+                        message="Example message",
+                        range=types.Range(
+                            start=types.Position(line=1, character=0),
+                            end=types.Position(line=1, character=2147483647),
+                        ),
+                    ),
+                ],
+            ),
+        ),
+    ],
+)
+def test_parse_invalid_data(data, expected):
+    """Ensure that we can handle invalid data as gracefully as possible."""
+    converter = esbonio_converter()
+    assert converter.structure(data, type(expected)) == expected


### PR DESCRIPTION
This should fix all the `ValueErrors` (like #714) caused by VSCode extensions using very large column numbers when reporting diagnostics.

