### PR TITLE
lsp: Introduce `ConfigChangeEvent`

### DIFF
--- a/lib/esbonio/esbonio/server/__init__.py
+++ b/lib/esbonio/esbonio/server/__init__.py
@@ -1,5 +1,6 @@
 from esbonio.sphinx_agent.types import Uri
 
+from ._configuration import ConfigChangeEvent
 from ._log import LOG_NAMESPACE
 from ._log import MemoryHandler
 from .feature import CompletionConfig
@@ -8,8 +9,9 @@ from .feature import LanguageFeature
 from .server import EsbonioLanguageServer
 from .server import EsbonioWorkspace
 
-__all__ = [
+__all__ = (
     "LOG_NAMESPACE",
+    "ConfigChangeEvent",
     "CompletionConfig",
     "CompletionContext",
     "EsbonioLanguageServer",
@@ -17,4 +19,4 @@ __all__ = [
     "LanguageFeature",
     "MemoryHandler",
     "Uri",
-]
+)

--- a/lib/esbonio/esbonio/server/features/directives/__init__.py
+++ b/lib/esbonio/esbonio/server/features/directives/__init__.py
@@ -71,9 +71,11 @@ class DirectiveFeature(server.LanguageFeature):
             self.update_configuration,
         )
 
-    def update_configuration(self, config: server.CompletionConfig):
+    def update_configuration(
+        self, event: server.ConfigChangeEvent[server.CompletionConfig]
+    ):
         """Called when the user's configuration is updated."""
-        self._insert_behavior = config.preferred_insert_behavior
+        self._insert_behavior = event.value.preferred_insert_behavior
 
     async def completion(
         self, context: server.CompletionContext


### PR DESCRIPTION
Rather than send just the current configuration value to a subscription callback we now send a `ConfigChangeEvent` which includes additional information such as the config scope and the previous value.