### PR TITLE
Introduce the `ProjectManager`

### DIFF
--- a/lib/esbonio/changes/660.fix.md
+++ b/lib/esbonio/changes/660.fix.md
@@ -1,0 +1,1 @@
+The server should no longer sometimes spawn duplicated Sphinx processes

--- a/lib/esbonio/esbonio/server/cli.py
+++ b/lib/esbonio/esbonio/server/cli.py
@@ -60,16 +60,13 @@ def build_parser() -> argparse.ArgumentParser:
 
 
 def main(argv: Optional[Sequence[str]] = None):
-    """Standard main function for each of the default language servers."""
-
-    # Put these here to avoid circular import issues.
-
     cli = build_parser()
     args = cli.parse_args(argv)
 
     # Order matters!
     modules = [
         "esbonio.server.features.log",
+        "esbonio.server.features.project_manager",
         "esbonio.server.features.sphinx_manager",
         "esbonio.server.features.preview_manager",
         "esbonio.server.features.directives",

--- a/lib/esbonio/esbonio/server/features/project_manager/__init__.py
+++ b/lib/esbonio/esbonio/server/features/project_manager/__init__.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from esbonio.server import EsbonioLanguageServer
+
+from .manager import ProjectManager
+from .project import Project
+
+__all__ = [
+    "Project",
+    "ProjectManager",
+]
+
+
+def esbonio_setup(server: EsbonioLanguageServer):
+    manager = ProjectManager(server)
+    server.add_feature(manager)

--- a/lib/esbonio/esbonio/server/features/project_manager/manager.py
+++ b/lib/esbonio/esbonio/server/features/project_manager/manager.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import pathlib
+import typing
+
+from esbonio import server
+from esbonio.server import Uri
+
+from .project import Project
+
+if typing.TYPE_CHECKING:
+    from typing import Dict
+    from typing import Optional
+    from typing import Union
+
+
+class ProjectManager(server.LanguageFeature):
+    """Responsible for managing project instances."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.projects: Dict[str, Project] = {}
+        """Holds active project instances"""
+
+    def register_project(self, scope: str, dbpath: Union[str, pathlib.Path]):
+        """Register a project."""
+        self.logger.debug("Registered project for scope '%s': '%s'", scope, dbpath)
+        self.projects[scope] = Project(dbpath)
+
+    def get_project(self, uri: Uri) -> Optional[Project]:
+        """Return the project instance for the given uri, if available"""
+        scope = self.server.configuration.scope_for(uri)
+
+        if (project := self.projects.get(scope, None)) is None:
+            self.logger.debug("No applicable project for uri: %s", uri)
+            return None
+
+        return project

--- a/lib/esbonio/esbonio/server/features/project_manager/project.py
+++ b/lib/esbonio/esbonio/server/features/project_manager/project.py
@@ -25,6 +25,10 @@ class Project:
         self.dbpath = dbpath
         self._connection: Optional[aiosqlite.Connection] = None
 
+    async def close(self):
+        if self._connection is not None:
+            await self._connection.close()
+
     async def get_db(self) -> aiosqlite.Connection:
         if self._connection is None:
             self._connection = await aiosqlite.connect(self.dbpath)

--- a/lib/esbonio/esbonio/server/features/project_manager/project.py
+++ b/lib/esbonio/esbonio/server/features/project_manager/project.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+import json
+import pathlib
+import typing
+
+import aiosqlite
+
+from esbonio.server import Uri
+from esbonio.sphinx_agent import types
+
+if typing.TYPE_CHECKING:
+    from typing import Any
+    from typing import Dict
+    from typing import List
+    from typing import Optional
+    from typing import Tuple
+    from typing import Union
+
+
+class Project:
+    """Represents a documentation project."""
+
+    def __init__(self, dbpath: Union[str, pathlib.Path]):
+        self.dbpath = dbpath
+        self._connection: Optional[aiosqlite.Connection] = None
+
+    async def get_db(self) -> aiosqlite.Connection:
+        if self._connection is None:
+            self._connection = await aiosqlite.connect(self.dbpath)
+
+        return self._connection
+
+    async def get_src_uris(self) -> List[Uri]:
+        """Return all known source uris."""
+        db = await self.get_db()
+
+        query = "SELECT uri FROM files"
+        async with db.execute(query) as cursor:
+            results = await cursor.fetchall()
+            return [Uri.parse(s[0]) for s in results]
+
+    async def get_build_path(self, src_uri: Uri) -> Optional[str]:
+        """Get the build path associated with the given ``src_uri``."""
+        db = await self.get_db()
+
+        query = "SELECT urlpath FROM files WHERE uri = ?"
+        async with db.execute(query, (str(src_uri.resolve()),)) as cursor:
+            if (result := await cursor.fetchone()) is None:
+                return None
+
+            return result[0]
+
+    async def get_config_value(self, name: str) -> Optional[Any]:
+        """Return the requested configuration value, if available."""
+
+        db = await self.get_db()
+        query = "SELECT value FROM config WHERE name = ?"
+        cursor = await db.execute(query, (name,))
+
+        if (row := await cursor.fetchone()) is None:
+            return None
+
+        (value,) = row
+        return json.loads(value)
+
+    async def get_directives(self) -> List[Tuple[str, Optional[str]]]:
+        """Get the directives known to Sphinx."""
+        db = await self.get_db()
+
+        query = "SELECT name, implementation FROM directives"
+        cursor = await db.execute(query)
+        return await cursor.fetchall()  # type: ignore[return-value]
+
+    async def get_document_symbols(self, src_uri: Uri) -> List[types.Symbol]:
+        """Get the symbols for the given file."""
+        db = await self.get_db()
+        query = (
+            "SELECT id, name, kind, detail, range, parent_id, order_id "
+            "FROM symbols WHERE uri = ?"
+        )
+        cursor = await db.execute(query, (str(src_uri.resolve()),))
+        return await cursor.fetchall()  # type: ignore[return-value]
+
+    async def find_symbols(self, **kwargs) -> List[types.Symbol]:
+        """Find symbols which match the given criteria."""
+        db = await self.get_db()
+        base_query = (
+            "SELECT id, name, kind, detail, range, parent_id, order_id FROM symbols"
+        )
+        where: List[str] = []
+        parameters: List[Any] = []
+
+        for param, value in kwargs.items():
+            where.append(f"{param} = ?")
+            parameters.append(value)
+
+        if where:
+            conditions = " AND ".join(where)
+            query = " ".join([base_query, "WHERE", conditions])
+        else:
+            query = base_query
+
+        cursor = await db.execute(query, tuple(parameters))
+        return await cursor.fetchall()  # type: ignore[return-value]
+
+    async def get_workspace_symbols(
+        self, query: str
+    ) -> List[Tuple[str, str, int, str, str, str]]:
+        """Return all the workspace symbols matching the given query string"""
+
+        db = await self.get_db()
+        sql_query = """\
+SELECT
+    child.uri,
+    child.name,
+    child.kind,
+    child.detail,
+    child.range,
+    COALESCE(parent.name, '') AS container_name
+FROM
+    symbols child
+LEFT JOIN
+    symbols parent ON (child.parent_id = parent.id AND child.uri = parent.uri)
+WHERE
+    child.name like ? or child.detail like ?;"""
+
+        query_str = f"%{query}%"
+        cursor = await db.execute(sql_query, (query_str, query_str))
+        return await cursor.fetchall()  # type: ignore[return-value]
+
+    async def get_diagnostics(self) -> Dict[Uri, List[Dict[str, Any]]]:
+        """Get diagnostics for the project."""
+        db = await self.get_db()
+        cursor = await db.execute("SELECT * FROM diagnostics")
+        results: Dict[Uri, List[Dict[str, Any]]] = {}
+
+        for uri_str, item in await cursor.fetchall():
+            uri = Uri.parse(uri_str)
+            diagnostic = json.loads(item)
+            results.setdefault(uri, []).append(diagnostic)
+
+        return results

--- a/lib/esbonio/esbonio/server/features/sphinx_manager/__init__.py
+++ b/lib/esbonio/esbonio/server/features/sphinx_manager/__init__.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from esbonio.server import EsbonioLanguageServer
+from esbonio.server.features.project_manager import ProjectManager
 
 from .client import ClientState
 from .client import SphinxClient
@@ -16,6 +17,6 @@ __all__ = [
 ]
 
 
-def esbonio_setup(server: EsbonioLanguageServer):
-    manager = SphinxManager(make_subprocess_sphinx_client, server)
+def esbonio_setup(server: EsbonioLanguageServer, project_manager: ProjectManager):
+    manager = SphinxManager(make_subprocess_sphinx_client, project_manager, server)
     server.add_feature(manager)

--- a/lib/esbonio/esbonio/server/features/sphinx_manager/client.py
+++ b/lib/esbonio/esbonio/server/features/sphinx_manager/client.py
@@ -93,37 +93,5 @@ class SphinxClient(Protocol):
         """Trigger a Sphinx build."""
         ...
 
-    async def get_src_uris(self) -> List[Uri]:
-        """Return all known source files."""
-        ...
-
-    async def get_build_path(self, src_uri: Uri) -> Optional[str]:
-        """Get the build path associated with the given ``src_uri``."""
-
-    async def get_config_value(self, name: str) -> Optional[Any]:
-        """Return the requested configuration value, if available."""
-
-    async def get_diagnostics(self) -> Dict[Uri, List[Dict[str, Any]]]:
-        """Get the diagnostics for the project."""
-        ...
-
-    async def get_directives(self) -> List[Tuple[str, Optional[str]]]:
-        """Get all the directives known to Sphinx."""
-        ...
-
-    async def get_document_symbols(self, src_uri: Uri) -> List[types.Symbol]:
-        """Get the symbols for the given file."""
-        ...
-
-    async def find_symbols(self, **kwargs) -> List[types.Symbol]:
-        """Find symbols which match the given criteria."""
-        ...
-
-    async def get_workspace_symbols(
-        self, query: str
-    ) -> List[Tuple[str, str, int, str, str, str]]:
-        """Return all the workspace symbols matching the given query string"""
-        ...
-
     async def stop(self):
         """Stop the client."""

--- a/lib/esbonio/esbonio/server/features/sphinx_manager/client.py
+++ b/lib/esbonio/esbonio/server/features/sphinx_manager/client.py
@@ -5,14 +5,12 @@ import typing
 from typing import Protocol
 
 if typing.TYPE_CHECKING:
+    import pathlib
     from typing import Any
     from typing import Dict
     from typing import Generator
     from typing import List
     from typing import Optional
-    from typing import Tuple
-
-    import aiosqlite
 
     from esbonio.server import Uri
     from esbonio.sphinx_agent import types
@@ -50,7 +48,7 @@ class SphinxClient(Protocol):
         ...
 
     @property
-    def db(self) -> Optional[aiosqlite.Connection]:
+    def db(self) -> pathlib.Path:
         """Connection to the associated database."""
 
     @property

--- a/lib/esbonio/esbonio/server/features/sphinx_manager/client_subprocess.py
+++ b/lib/esbonio/esbonio/server/features/sphinx_manager/client_subprocess.py
@@ -5,11 +5,11 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+import pathlib
 import subprocess
 import sys
 import typing
 
-import aiosqlite
 from pygls.client import JsonRPCClient
 from pygls.protocol import JsonRPCProtocol
 
@@ -133,9 +133,12 @@ class SubprocessSphinxClient(JsonRPCClient):
         return Uri.for_file(self.sphinx_info.conf_dir)
 
     @property
-    def db(self) -> Optional[aiosqlite.Connection]:
+    def db(self) -> pathlib.Path:
         """Connection to the associated database."""
-        return None
+        if self.sphinx_info is None:
+            raise RuntimeError("sphinx_info is None, has the client been started?")
+
+        return pathlib.Path(self.sphinx_info.dbpath)
 
     @property
     def build_uri(self) -> Uri:

--- a/lib/esbonio/esbonio/server/features/sphinx_support/diagnostics.py
+++ b/lib/esbonio/esbonio/server/features/sphinx_support/diagnostics.py
@@ -3,18 +3,25 @@ from functools import partial
 from lsprotocol import types
 
 from esbonio.server import EsbonioLanguageServer
+from esbonio.server.features.project_manager import ProjectManager
 from esbonio.server.features.sphinx_manager import SphinxClient
 from esbonio.server.features.sphinx_manager import SphinxManager
 
 
 async def refresh_diagnostics(
-    server: EsbonioLanguageServer, client: SphinxClient, result
+    server: EsbonioLanguageServer,
+    projects: ProjectManager,
+    client: SphinxClient,
+    result,
 ):
     """Refresh sphinx diagnostics."""
+    if (project := projects.get_project(client.src_uri)) is None:
+        return
+
     # TODO: Per-client id.
     server.clear_diagnostics("sphinx")
 
-    collection = await client.get_diagnostics()
+    collection = await project.get_diagnostics()
     for uri, items in collection.items():
         diagnostics = [
             server.converter.structure(item, types.Diagnostic) for item in items
@@ -24,5 +31,11 @@ async def refresh_diagnostics(
     server.sync_diagnostics()
 
 
-def esbonio_setup(server: EsbonioLanguageServer, sphinx_manager: SphinxManager):
-    sphinx_manager.add_listener("build", partial(refresh_diagnostics, server))
+def esbonio_setup(
+    server: EsbonioLanguageServer,
+    sphinx_manager: SphinxManager,
+    project_manager: ProjectManager,
+):
+    sphinx_manager.add_listener(
+        "build", partial(refresh_diagnostics, server, project_manager)
+    )

--- a/lib/esbonio/tests/e2e/test_e2e_directives.py
+++ b/lib/esbonio/tests/e2e/test_e2e_directives.py
@@ -56,7 +56,6 @@ UNEXPECTED = {
     ],
 )
 @pytest.mark.asyncio(scope="session")
-@pytest.mark.xfail
 async def test_rst_directive_completions(
     client: LanguageClient,
     uri_for,
@@ -152,7 +151,6 @@ async def test_rst_directive_completions(
     ],
 )
 @pytest.mark.asyncio(scope="session")
-@pytest.mark.xfail
 async def test_myst_directive_completions(
     client: LanguageClient,
     uri_for,

--- a/lib/esbonio/tests/e2e/test_e2e_symbols.py
+++ b/lib/esbonio/tests/e2e/test_e2e_symbols.py
@@ -96,7 +96,6 @@ def document_symbol(
     ],
 )
 @pytest.mark.asyncio(scope="session")
-@pytest.mark.xfail
 async def test_document_symbols(
     client: LanguageClient,
     uri_for,
@@ -251,7 +250,6 @@ async def test_document_symbols(
     ],
 )
 @pytest.mark.asyncio(scope="session")
-@pytest.mark.xfail
 async def test_workspace_symbols(
     client: LanguageClient,
     query: str,

--- a/lib/esbonio/tests/sphinx-agent/conftest.py
+++ b/lib/esbonio/tests/sphinx-agent/conftest.py
@@ -5,7 +5,11 @@ import pytest_asyncio
 from lsprotocol.types import WorkspaceFolder
 from pygls.workspace import Workspace
 
+from esbonio.server.features.project_manager import Project
 from esbonio.server.features.sphinx_manager.client import ClientState
+from esbonio.server.features.sphinx_manager.client_subprocess import (
+    SubprocessSphinxClient,
+)
 from esbonio.server.features.sphinx_manager.client_subprocess import (
     make_test_sphinx_client,
 )
@@ -46,3 +50,11 @@ async def client(uri_for, tmp_path_factory):
     yield sphinx_client
 
     await sphinx_client.stop()
+
+
+@pytest_asyncio.fixture
+async def project(client: SubprocessSphinxClient):
+    project = Project(client.db)
+
+    yield project
+    await project.close()

--- a/lib/esbonio/tests/sphinx-agent/handlers/test_database.py
+++ b/lib/esbonio/tests/sphinx-agent/handlers/test_database.py
@@ -1,5 +1,6 @@
 import pytest
 
+from esbonio.server.features.project_manager import Project
 from esbonio.server.features.sphinx_manager.client_subprocess import (
     SubprocessSphinxClient,
 )
@@ -14,15 +15,13 @@ def anuri(base, *args):
 
 
 @pytest.mark.asyncio
-@pytest.mark.xfail
-async def test_files_table(client: SubprocessSphinxClient):
+async def test_files_table(client: SubprocessSphinxClient, project: Project):
     """Ensure that we can correctly index all the files in the Sphinx project."""
 
     src = client.src_uri
-    assert src is not None
 
-    assert client.db is not None
-    cursor = await client.db.execute("SELECT * FROM files")
+    db = await project.get_db()
+    cursor = await db.execute("SELECT * FROM files")
     results = await cursor.fetchall()
     actual = {r for r in results if "badfile" not in r[1]}
 


### PR DESCRIPTION
Instead of exposing the database via the `SphinxClient` interface,
this commit introduces the concept of a `Project`.  Projects are
simply the data exposed via the database created by the sphinx agent.

By separating the two, not only does the `SphinxClient` get to focus
solely on managing the underlying Sphinx process but we open up
interesting opportunities. For example, we can run the server without
an active Sphinx connection - a kind of "offline" mode.

Something that might be interesting to try as an initial vscode.dev
implementation of the server...