### PR TITLE
Reload Sphinx when the configuration changes

### DIFF
--- a/code/changes/703.fix.md
+++ b/code/changes/703.fix.md
@@ -1,0 +1,1 @@
+The extension will now notify the server when the user changes Python environment via the Python extension

--- a/code/src/common/constants.ts
+++ b/code/src/common/constants.ts
@@ -16,6 +16,8 @@ export namespace Commands {
 export namespace Events {
   export const SERVER_START = "server/start"
   export const SERVER_STOP = "server/stop"
+
+  export const PYTHON_ENV_CHANGE = "python/envChange"
 }
 
 /**

--- a/code/src/node/client.ts
+++ b/code/src/node/client.ts
@@ -1,5 +1,6 @@
 import { execSync } from "child_process";
 import * as vscode from 'vscode';
+import { ActiveEnvironmentPathChangeEvent } from '@vscode/python-extension';
 import { join } from "path";
 import {
   CancellationToken,
@@ -81,6 +82,11 @@ export class EsbonioClient {
         }
       })
     )
+
+    // React to environment changes in the Python extension
+    python.addHandler(Events.PYTHON_ENV_CHANGE, (_event: ActiveEnvironmentPathChangeEvent) => {
+      this.client?.sendNotification("workspace/didChangeConfiguration", { settings: null })
+    })
   }
 
   public addHandler(event: string, handler: any) {

--- a/code/src/node/preview.ts
+++ b/code/src/node/preview.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode'
 import { OutputChannelLogger } from '../common/log'
 import { EsbonioClient } from './client'
-import { Commands, Events, Notifications, Server } from '../common/constants'
+import { Commands, Events, Notifications } from '../common/constants'
 
 interface PreviewFileParams {
   uri: string

--- a/lib/esbonio/changes/750.enhancement.md
+++ b/lib/esbonio/changes/750.enhancement.md
@@ -1,0 +1,1 @@
+The server will now automatically restart the underlying Sphinx process when it detects a change in its configuration

--- a/lib/esbonio/esbonio/server/features/log.py
+++ b/lib/esbonio/esbonio/server/features/log.py
@@ -334,7 +334,8 @@ class LogManager(server.LanguageFeature):
         # Replay any captured messages against the new config.
         for record in records:
             logger = logging.getLogger(record.name)
-            logger.handle(record)
+            if logger.isEnabledFor(record.levelno):
+                logger.handle(record)
 
 
 def dump(obj) -> str:

--- a/lib/esbonio/esbonio/server/features/sphinx_manager/client_subprocess.py
+++ b/lib/esbonio/esbonio/server/features/sphinx_manager/client_subprocess.py
@@ -227,7 +227,8 @@ class SubprocessSphinxClient(JsonRPCClient):
             self.protocol.notify("exit", None)
 
         # Give the agent a little time to close.
-        # await asyncio.sleep(0.5)
+        await asyncio.sleep(0.5)
+
         self.logger.debug(self._async_tasks)
         await super().stop()
 

--- a/lib/esbonio/esbonio/server/features/sphinx_manager/manager.py
+++ b/lib/esbonio/esbonio/server/features/sphinx_manager/manager.py
@@ -188,7 +188,7 @@ class SphinxManager(server.LanguageFeature):
 
         # If there was a previous client, stop it.
         if (previous_client := self.clients.pop(event.scope, None)) is not None:
-            await previous_client.stop()
+            self.server.run_task(previous_client.stop())
 
         resolved = config.resolve(
             Uri.parse(event.scope), self.server.workspace, self.logger


### PR DESCRIPTION
The server will now automatically reload Sphinx when it detects changes to the configuration. 
**Note:** This is not #647, but instead changes to the `esbonio.sphinx` config namespace.

This also updates the VSCode extension so that it notifies the server when the user's Python environment changes. Closes #703 