### PR TITLE
Reimplement language status items

### DIFF
--- a/code/changes/756.breaking.md
+++ b/code/changes/756.breaking.md
@@ -1,0 +1,1 @@
+The `esbonio.server.enabledInPyFiles` configuration option has been removed, use `esbonio.server.documentSelector` instead

--- a/code/changes/756.enhancement.md
+++ b/code/changes/756.enhancement.md
@@ -1,0 +1,1 @@
+Added the `esbonio.server.documentSelector` option, granting the user fine grained control over which files the server is enabled in.

--- a/code/package.json
+++ b/code/package.json
@@ -88,11 +88,28 @@
                         "default": true,
                         "description": "Enable/Disable the language server"
                     },
-                    "esbonio.server.enabledInPyFiles": {
+                    "esbonio.server.documentSelector": {
                         "scope": "window",
-                        "type": "boolean",
-                        "default": true,
-                        "description": "Enable/Disable the language server in Python files."
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "scheme": {
+                                    "type": "string",
+                                    "description": "The URI scheme that this selector applies to"
+                                },
+                                "language": {
+                                    "type": "string",
+                                    "description": "The language id this selector will select"
+                                },
+                                "pattern": {
+                                    "type": "string",
+                                    "description": "Only select uris that match the given pattern"
+                                }
+                            }
+                        },
+                        "default": [],
+                        "description": "Override the extension's default document selector"
                     },
                     "esbonio.server.startupModule": {
                         "scope": "window",

--- a/code/src/common/constants.ts
+++ b/code/src/common/constants.ts
@@ -1,5 +1,11 @@
 export namespace Server {
   export const REQUIRED_PYTHON = "3.8.0"
+
+  export const DEFAULT_SELECTOR = [
+    { scheme: 'file', language: 'restructuredtext' },
+    { scheme: 'file', language: 'markdown' },
+    // { scheme: 'file', language: 'python' }
+  ]
 }
 
 export namespace Commands {
@@ -27,5 +33,8 @@ export namespace Notifications {
   export const SCROLL_EDITOR = "editor/scroll"
   export const VIEW_SCROLL = "view/scroll"
 
+  export const SPHINX_CLIENT_CREATED = "sphinx/clientCreated"
+  export const SPHINX_CLIENT_ERRORED = "sphinx/clientErrored"
+  export const SPHINX_CLIENT_DESTROYED = "sphinx/clientDestroyed"
   export const SPHINX_APP_CREATED = "sphinx/appCreated"
 }

--- a/code/src/node/client.ts
+++ b/code/src/node/client.ts
@@ -15,15 +15,77 @@ import {
 
 import { OutputChannelLogger } from "../common/log";
 import { PythonManager } from "./python";
-import { Commands, Events, Notifications } from '../common/constants';
+import { Commands, Events, Notifications, Server } from '../common/constants';
 
+
+export interface SphinxClientConfig {
+
+  /**
+   * The python command used to launch the client
+   */
+  pythonCommand: string[]
+
+  /**
+   * The sphinx-build command in use
+   */
+  buildCommand: string[]
+
+  /**
+   * The working directory of the client
+   */
+  cwd: string
+
+}
+
+export interface ClientCreatedNotification {
+  /**
+   * A unique id for this client
+   */
+  id: string
+
+  /**
+   * The configuration scope at which the client was created
+   */
+  scope: string
+
+  /**
+   * The final configuration
+   */
+  config: SphinxClientConfig
+
+}
+
+/**
+ * The payload of a ``sphinx/clientErrored`` notification
+ */
+export interface ClientErroredNotification {
+
+  /**
+   * A unique id for the client
+   */
+  id: string
+
+  /**
+   * Short description of the error.
+   */
+  error: string
+
+  /**
+   * Detailed description of the error.
+   */
+  detail: string
+}
+
+
+export interface ClientDestroyedNotification {
+  /**
+   * A unique id for this client
+   */
+  id: string
+}
 
 export interface SphinxInfo {
 
-  /**
-   * A unique id used to refer to this Sphinx application instance.
-   */
-  id: string
 
   /**
    * Sphinx's version number
@@ -53,6 +115,18 @@ export interface SphinxInfo {
   src_dir: string
 }
 
+export interface AppCreatedNotification {
+
+  /**
+   * A unique id for this client
+   */
+  id: string
+
+  /**
+   * Details about the created application.
+   */
+  application: SphinxInfo
+}
 
 export class EsbonioClient {
 
@@ -244,6 +318,9 @@ export class EsbonioClient {
     let methods = [
       Notifications.SCROLL_EDITOR,
       Notifications.SPHINX_APP_CREATED,
+      Notifications.SPHINX_CLIENT_CREATED,
+      Notifications.SPHINX_CLIENT_ERRORED,
+      Notifications.SPHINX_CLIENT_DESTROYED,
     ]
 
     for (let method of methods) {
@@ -259,15 +336,11 @@ export class EsbonioClient {
    */
   private getLanguageClientOptions(config: vscode.WorkspaceConfiguration): LanguageClientOptions {
 
-    let defaultDocumentSelector: TextDocumentFilter[] = [
-      { scheme: 'file', language: 'restructuredtext' },
-      { scheme: 'file', language: 'markdown' },
-      // { scheme: 'file', language: 'python' }
-    ]
+
 
     let documentSelector = config.get<TextDocumentFilter[]>("server.documentSelector")
     if (!documentSelector || documentSelector.length === 0) {
-      documentSelector = defaultDocumentSelector
+      documentSelector = Server.DEFAULT_SELECTOR
     }
 
     let clientOptions: LanguageClientOptions = {

--- a/code/src/node/client.ts
+++ b/code/src/node/client.ts
@@ -9,7 +9,8 @@ import {
   LanguageClientOptions,
   ResponseError,
   ServerOptions,
-  State
+  State,
+  TextDocumentFilter
 } from "vscode-languageclient/node";
 
 import { OutputChannelLogger } from "../common/log";
@@ -258,15 +259,15 @@ export class EsbonioClient {
    */
   private getLanguageClientOptions(config: vscode.WorkspaceConfiguration): LanguageClientOptions {
 
-    let documentSelector = [
+    let defaultDocumentSelector: TextDocumentFilter[] = [
       { scheme: 'file', language: 'restructuredtext' },
       { scheme: 'file', language: 'markdown' },
+      // { scheme: 'file', language: 'python' }
     ]
 
-    if (config.get<boolean>('server.enabledInPyFiles')) {
-      documentSelector.push(
-        { scheme: 'file', language: 'python' }
-      )
+    let documentSelector = config.get<TextDocumentFilter[]>("server.documentSelector")
+    if (!documentSelector || documentSelector.length === 0) {
+      documentSelector = defaultDocumentSelector
     }
 
     let clientOptions: LanguageClientOptions = {

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,85 +3,42 @@ Esbonio
 
 .. rubric:: esbonio -- (v.) to explain
 
-Esbonio aims to make it easier to work with `reStructuredText`_ tools such as
-`Sphinx`_ by providing a `Language Server`_ to enhance your editing experience.
+Esbonio is a `Language Server`_ for `Sphinx`_ documentation projects.
 
-Language Server
----------------
+Esbonio aids the writing process by resolving references, providing completion suggestions and highlighting errors.
+It ensures your local build is always up to date, allowing you to preview your changes in (almost!) real-time.
+The server itself can even be extended to better suit the needs of your project.
 
-Here is a quick summary of the features implemented by the language server.
+The primary goal of Esbonio is to reduce the friction that comes from trying to remember the specifics of a markup language, so that you can focus on your content and not your tooling.
 
-.. collection:: features
+.. grid:: 2
+   :gutter: 2
 
-   .. collection-item:: Completion
+   .. grid-item-card:: Getting Started
+      :text-align: center
+      :link: lsp-getting-started
+      :link-type: ref
 
-      The language server implements :lsp:`textDocument/completion` and can
-      offer suggestions in a variety of contexts.
+      Using Esbonio for the first time within VSCode.
 
-      .. figure:: ../resources/images/completion-demo.gif
-         :align: center
-         :target: /_images/completion-demo.gif
+   .. grid-item-card:: How-To Guides
+      :text-align: center
 
-   .. collection-item:: Definition
+      Step-by-step guides on integrating Esbonio with other text editors.
 
-      The language server implements :lsp:`textDocument/definition` to provide the
-      location of items referenced by certain roles. Currently only the ``:ref:``
-      and ``:doc:`` roles are supported.
+   .. grid-item-card:: Reference
+      :text-align: center
+      :link: lsp-reference
+      :link-type: ref
 
-      .. figure:: ../resources/images/definition-demo.gif
-         :align: center
-         :target: /_images/definition-demo.gif
+      Configuration options, API documentation, architecture diagrams and more.
 
-   .. collection-item:: Diagnostics
+   .. grid-item-card:: Extending
+      :text-align: center
+      :link: lsp-extending
+      :link-type: ref
 
-      The language server implements :lsp:`textDocument/publishDiagnostics` to
-      report errors/warnings enountered during a build.
-
-      .. figure:: ../resources/images/diagnostic-sphinx-errors-demo.png
-         :align: center
-         :target: /_images/diagnostic-sphinx-errors-demo.png
-
-   .. collection-item:: Document Links
-
-      The language server implements :lsp:`textDocument/documentLink` to make references to other files "Ctrl + Clickable"
-
-      .. figure:: ../resources/images/document-links-demo.png
-         :align: center
-         :target: /_images/document-links-demo.png
-
-   .. collection-item:: Document Symbols
-
-      The language server implements :lsp:`textDocument/documentSymbol` which
-      powers features like the "Outline" view in VSCode.
-
-      .. figure:: ../resources/images/document-symbols-demo.png
-         :align: center
-         :target: /_images/document-symbols-demo.png
-
-   .. collection-item:: Hover
-
-      The language server implements :lsp:`textDocument/hover` to provide easy access to documentation for roles and directives.
-
-      .. figure:: ../resources/images/hover-demo.png
-         :align: center
-         :target: /_images/hover-demo.png
-
-   .. collection-item:: Implementation
-
-      The language server implements :lsp:`textDocument/implementation` so you can easily find the implementation of a given role or directive.
-
-      .. figure:: ../resources/images/implementation-demo.gif
-         :align: center
-         :target: /_images/implementation-demo.gif
-
-- See the :ref:`lsp_getting_started` guide for details on how to get up and
-  running.
-
-- For further details on more advanced use cases, see the :ref:`lsp-advanced` section.
-
-- Interested in adding support for your own Sphinx extensions?
-  See the section on :ref:`lsp-extending` for more information.
-
+      Documentation on extending the language server
 
 .. toctree::
    :glob:
@@ -90,7 +47,6 @@ Here is a quick summary of the features implemented by the language server.
    :maxdepth: 2
 
    lsp/getting-started
-   lsp/advanced-usage
    lsp/extending
    lsp/howto
    lsp/reference

--- a/docs/lsp/getting-started.rst
+++ b/docs/lsp/getting-started.rst
@@ -1,4 +1,4 @@
-.. _lsp_getting_started:
+.. _lsp-getting-started:
 
 Getting Started
 ===============

--- a/docs/lsp/reference.rst
+++ b/docs/lsp/reference.rst
@@ -1,3 +1,5 @@
+.. _lsp-reference:
+
 Reference
 =========
 

--- a/docs/lsp/reference/notifications.rst
+++ b/docs/lsp/reference/notifications.rst
@@ -1,0 +1,18 @@
+Notifications
+=============
+
+In addition to the language server protocol, Esbonio will emit the following notifications
+
+.. currentmodule:: esbonio.server.features.sphinx_manager.manager
+
+.. autoclass:: ClientCreatedNotification
+   :members:
+
+.. autoclass:: AppCreatedNotification
+   :members:
+
+.. autoclass:: ClientErroredNotification
+   :members:
+
+.. autoclass:: ClientDestroyedNotification
+   :members:

--- a/lib/esbonio/changes/756.enhancement.md
+++ b/lib/esbonio/changes/756.enhancement.md
@@ -1,0 +1,1 @@
+The server now emits `sphinx/clientCreated`, `sphinx/clientErrored` and `sphinx/clientDestroyed` notifications that correspond to the lifecycle of the underlying Sphinx process

--- a/lib/esbonio/esbonio/server/_configuration.py
+++ b/lib/esbonio/esbonio/server/_configuration.py
@@ -233,7 +233,7 @@ class Configuration:
             self.logger.error(
                 "Error in async configuration handler '%s'\n%s",
                 subscription.callback,
-                traceback.format_exception(type(exc), exc, exc.__traceback__),
+                "".join(traceback.format_exception(type(exc), exc, exc.__traceback__)),
             )
 
     def get(self, section: str, spec: Type[T], scope: Optional[Uri] = None) -> T:

--- a/lib/esbonio/esbonio/server/events.py
+++ b/lib/esbonio/esbonio/server/events.py
@@ -44,7 +44,7 @@ class EventSource:
                 "Error in '%s' async handler '%s'\n%s",
                 event,
                 listener_name,
-                traceback.format_exception(type(exc), exc, exc.__traceback__),
+                "".join(traceback.format_exception(type(exc), exc, exc.__traceback__)),
             )
 
     def trigger(self, event: str, *args, **kwargs):

--- a/lib/esbonio/esbonio/server/features/sphinx_manager/client_subprocess.py
+++ b/lib/esbonio/esbonio/server/features/sphinx_manager/client_subprocess.py
@@ -9,6 +9,7 @@ import pathlib
 import subprocess
 import sys
 import typing
+from uuid import uuid4
 
 from pygls.client import JsonRPCClient
 from pygls.protocol import JsonRPCProtocol
@@ -60,6 +61,9 @@ class SubprocessSphinxClient(JsonRPCClient):
     ):
         super().__init__(protocol_cls=protocol_cls, *args, **kwargs)  # type: ignore[misc]
 
+        self.id = str(uuid4())
+        """The client's id."""
+
         self.config = config
         """Configuration values."""
 
@@ -102,14 +106,6 @@ class SubprocessSphinxClient(JsonRPCClient):
     @property
     def converter(self):
         return self.protocol._converter
-
-    @property
-    def id(self) -> str:
-        """The id of the Sphinx instance."""
-        if self.sphinx_info is None:
-            raise RuntimeError("sphinx_info is None, has the client been started?")
-
-        return self.sphinx_info.id
 
     @property
     def builder(self) -> str:

--- a/lib/esbonio/esbonio/server/features/sphinx_manager/client_subprocess.py
+++ b/lib/esbonio/esbonio/server/features/sphinx_manager/client_subprocess.py
@@ -214,6 +214,8 @@ class SubprocessSphinxClient(JsonRPCClient):
     def _set_state(self, new_state: ClientState):
         """Change the state of the client."""
         old_state, self.state = self.state, new_state
+
+        self.logger.debug("SphinxClient[%s]: %s -> %s", self.id, old_state, new_state)
         self._events.trigger("state-change", self, old_state, new_state)
 
     async def stop(self):

--- a/lib/esbonio/esbonio/sphinx_agent/handlers/__init__.py
+++ b/lib/esbonio/esbonio/sphinx_agent/handlers/__init__.py
@@ -13,7 +13,6 @@ from typing import List
 from typing import Optional
 from typing import Tuple
 from typing import Type
-from uuid import uuid4
 
 import sphinx.application
 from sphinx import __version__ as __sphinx_version__
@@ -138,7 +137,6 @@ class SphinxHandler:
         response = types.CreateApplicationResponse(
             id=request.id,
             result=types.SphinxInfo(
-                id=str(uuid4()),
                 version=__sphinx_version__,
                 conf_dir=str(self.app.confdir),
                 build_dir=str(self.app.outdir),

--- a/lib/esbonio/esbonio/sphinx_agent/types.py
+++ b/lib/esbonio/esbonio/sphinx_agent/types.py
@@ -534,9 +534,6 @@ class CreateApplicationRequest:
 class SphinxInfo:
     """Represents information about an instance of the Sphinx application."""
 
-    id: str
-    """A unique id representing a particular Sphinx application instance."""
-
     version: str
     """The version of Sphinx being used."""
 

--- a/lib/esbonio/tox.ini
+++ b/lib/esbonio/tox.ini
@@ -9,6 +9,9 @@ description = "Run the test suite for the server component of esbonio"
 package = wheel
 wheel_build_env = .pkg
 deps =
+
+    py38: importlib-resources>6,<6.2
+
     coverage[toml]
     pytest
     pytest-lsp>=0.3.1


### PR DESCRIPTION
![Screenshot_20240314_194757](https://github.com/swyddfa/esbonio/assets/2675694/6b64235f-bc63-4a68-bbe0-debd834ba781)
![Screenshot_20240314_195658](https://github.com/swyddfa/esbonio/assets/2675694/003097eb-a18f-4d84-9ab7-4617de43e227)


- Instead of having a separate status item showing confdir, builddir etc, there is now a single sphinx related status item showing the version and the current active build command.
- There is now also a Python status item showing the current active interpreter - with the option to change it.
- The sphinx related status item will indicate when the sphinx process has crashed.

This is unlikely to be perfect, but hopefully it's a step towards resolving #736 