### PR TITLE
Don't override sphinx's logging setup anymore

### DIFF
--- a/lib/esbonio/changes/695.fix.md
+++ b/lib/esbonio/changes/695.fix.md
@@ -1,0 +1,1 @@
+The server now respects Sphinx configuration values like `suppress_warnings`

--- a/lib/esbonio/esbonio/sphinx_agent/app.py
+++ b/lib/esbonio/esbonio/sphinx_agent/app.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
 import pathlib
-import typing
 
 from sphinx.application import Sphinx as _Sphinx
+from sphinx.util import console
 
 from .database import Database
-from .log import SphinxLogHandler
+from .log import DiagnosticFilter
 
 
 class Esbonio:
@@ -14,11 +14,11 @@ class Esbonio:
 
     db: Database
 
-    log: SphinxLogHandler
+    log: DiagnosticFilter
 
-    def __init__(self, dbpath: pathlib.Path):
+    def __init__(self, dbpath: pathlib.Path, app: _Sphinx):
         self.db = Database(dbpath)
-        self.log = typing.cast(SphinxLogHandler, None)
+        self.log = DiagnosticFilter(app)
 
 
 class Sphinx(_Sphinx):
@@ -27,7 +27,12 @@ class Sphinx(_Sphinx):
     esbonio: Esbonio
 
     def __init__(self, *args, **kwargs):
-        dbpath = pathlib.Path(kwargs["outdir"], "esbonio.db").resolve()
-        self.esbonio = Esbonio(dbpath)
+        # Disable color codes
+        console.nocolor()
+
+        self.esbonio = Esbonio(
+            dbpath=pathlib.Path(kwargs["outdir"], "esbonio.db").resolve(),
+            app=self,
+        )
 
         super().__init__(*args, **kwargs)

--- a/lib/esbonio/esbonio/sphinx_agent/config.py
+++ b/lib/esbonio/esbonio/sphinx_agent/config.py
@@ -1,6 +1,7 @@
 import dataclasses
 import inspect
 import pathlib
+import sys
 from typing import Any
 from typing import Dict
 from typing import List
@@ -152,9 +153,9 @@ class SphinxConfig:
             "outdir": str(build_dir),
             "parallel": self.parallel,
             "srcdir": str(src_dir),
-            "status": None,
+            "status": sys.stderr,
             "tags": self.tags,
             "verbosity": self.verbosity,
-            "warning": None,
+            "warning": sys.stderr,
             "warningiserror": self.warning_is_error,
         }

--- a/lib/esbonio/esbonio/sphinx_agent/handlers/__init__.py
+++ b/lib/esbonio/esbonio/sphinx_agent/handlers/__init__.py
@@ -187,6 +187,9 @@ class SphinxHandler:
                 id=request.id, code=-32603, message=f"sphinx-build failed: {message}"
             )
 
+        finally:
+            self.app._warncount = 0
+
     def notify_exit(self, request: types.ExitNotification):
         """Sent from the client to signal that the agent should exit."""
         sys.exit(0)

--- a/lib/esbonio/tests/sphinx-agent/test_sa_create_app.py
+++ b/lib/esbonio/tests/sphinx-agent/test_sa_create_app.py
@@ -89,8 +89,11 @@ async def test_create_application_error(uri_for, tmp_path_factory):
     resolved = config.resolve(test_uri, workspace, logger)
     assert resolved is not None
 
-    client = await SubprocessSphinxClient(resolved)
-    assert client.state == ClientState.Errored
+    try:
+        client = await SubprocessSphinxClient(resolved)
+        assert client.state == ClientState.Errored
 
-    message = "There is a programmable error in your configuration file:"
-    assert message in str(client.exception)
+        message = "There is a programmable error in your configuration file:"
+        assert message in str(client.exception)
+    finally:
+        await client.stop()


### PR DESCRIPTION
The sphinx agent no longer overrides Sphinx's logging setup and instead re-directs all output to `stderr`. The parent language server can monitor `stderr` and forward any output to the client. By not overriding Sphinx's logging setup, all features like `suppress_warnings` should now also work as expected. (Closes #695)

We can still extract the diagnostic info we need by converting the logging handler to a simple filter

