### PR TITLE
Fix diagnostics

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -31,13 +31,11 @@
         "**/.vscode-test": true,
         "**/.mypy_cache": true
     },
-    "esbonio.sphinx.buildDir": "${confDir}/_build",
     "esbonio.server.showDeprecationWarnings": true,
     "isort.args": [
         "--settings-file",
         "./lib/esbonio/pyproject.toml"
     ],
-    "python.defaultInterpreterPath": "${workspaceRoot}/.env/bin/python",
     "python.testing.pytestArgs": [
         "lib/esbonio/tests"
     ],

--- a/docs/lsp/editors/nvim-lspconfig/init.vim
+++ b/docs/lsp/editors/nvim-lspconfig/init.vim
@@ -85,8 +85,11 @@ lspconfig.esbonio.setup {
   -- VSCode style output window.
   cmd = { 'lsp-devtools', 'agent', '--port', LSP_DEVTOOLS_PORT, '--', 'esbonio' },
   init_options = {
-    server = {
-      logLevel = 'debug',
+    logging = {
+      level = 'debug',
+      -- Redirect logging output to window/logMessage notifications so that lsp-devtools can capture it.
+      stderr = false,
+      window = true,
     }
   },
   settings = {

--- a/flake.lock
+++ b/flake.lock
@@ -10,11 +10,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1704650820,
-        "narHash": "sha256-dRztpidI5eMB7u13IT4zD4ku6isWgQlheKSM1piPop4=",
+        "lastModified": 1712600859,
+        "narHash": "sha256-1a2djQq73lSl3MCQvNBGXrBWXbjr8uvqulRC47RG2ow=",
         "owner": "swyddfa",
         "repo": "lsp-devtools",
-        "rev": "13e5cfd55753e87157bc0a1beb7ce587b1bc8410",
+        "rev": "9bb50d3a19b12f0c4f98a5a8f564dee89d0c54cb",
         "type": "github"
       },
       "original": {
@@ -25,11 +25,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1704161960,
-        "narHash": "sha256-QGua89Pmq+FBAro8NriTuoO/wNaUtugt29/qqA8zeeM=",
+        "lastModified": 1713128889,
+        "narHash": "sha256-aB90ZqzosyRDpBh+rILIcyP5lao8SKz8Sr2PSWvZrzk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "63143ac2c9186be6d9da6035fa22620018c85932",
+        "rev": "2748d22b45a99fb2deafa5f11c7531c212b2cefa",
         "type": "github"
       },
       "original": {
@@ -66,11 +66,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1701680307,
-        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
         "type": "github"
       },
       "original": {

--- a/lib/esbonio/esbonio/server/features/sphinx_manager/client_subprocess.py
+++ b/lib/esbonio/esbonio/server/features/sphinx_manager/client_subprocess.py
@@ -273,8 +273,7 @@ async def forward_stderr(server: asyncio.subprocess.Process):
 
     # EOF is signalled with an empty bytestring
     while (line := await server.stderr.readline()) != b"":
-        sys.stderr.buffer.write(line)
-        sys.stderr.buffer.flush()
+        sphinx_logger.info(line.decode())
 
 
 def make_subprocess_sphinx_client(

--- a/lib/esbonio/esbonio/server/features/sphinx_manager/manager.py
+++ b/lib/esbonio/esbonio/server/features/sphinx_manager/manager.py
@@ -289,6 +289,7 @@ class SphinxManager(server.LanguageFeature):
                     traceback.format_exception(type(exc), exc, exc.__traceback__)
                 )
 
+            self.server.lsp.show_message(error, lsp.MessageType.Error)
             self.server.lsp.notify(
                 "sphinx/clientErrored",
                 ClientErroredNotification(id=client.id, error=error, detail=detail),

--- a/lib/esbonio/esbonio/server/features/sphinx_manager/manager.py
+++ b/lib/esbonio/esbonio/server/features/sphinx_manager/manager.py
@@ -186,8 +186,8 @@ class SphinxManager(server.LanguageFeature):
             doc_version = doc.version or 0
             saved_version = getattr(doc, "saved_version", 0)
 
-            if saved_version < doc_version and (fs_path := src_uri.fs_path) is not None:
-                content_overrides[fs_path] = doc.source
+            if saved_version < doc_version:
+                content_overrides[str(src_uri)] = doc.source
 
         await self.start_progress(client)
 

--- a/lib/esbonio/esbonio/sphinx_agent/app.py
+++ b/lib/esbonio/esbonio/sphinx_agent/app.py
@@ -1,12 +1,30 @@
 from __future__ import annotations
 
+import logging
 import pathlib
+from typing import IO
 
 from sphinx.application import Sphinx as _Sphinx
 from sphinx.util import console
+from sphinx.util import logging as sphinx_logging_module
+from sphinx.util.logging import NAMESPACE as SPHINX_LOG_NAMESPACE
 
 from .database import Database
 from .log import DiagnosticFilter
+
+sphinx_logger = logging.getLogger(SPHINX_LOG_NAMESPACE)
+sphinx_log_setup = sphinx_logging_module.setup
+
+
+def setup_logging(app: Sphinx, status: IO, warning: IO):
+
+    # Run the usual setup
+    sphinx_log_setup(app, status, warning)
+
+    # Attach our diagnostic filter to the warning handler.
+    for handler in sphinx_logger.handlers:
+        if handler.level == logging.WARNING:
+            handler.addFilter(app.esbonio.log)
 
 
 class Esbonio:
@@ -19,6 +37,9 @@ class Esbonio:
     def __init__(self, dbpath: pathlib.Path, app: _Sphinx):
         self.db = Database(dbpath)
         self.log = DiagnosticFilter(app)
+
+        # Override sphinx's usual logging setup function
+        sphinx_logging_module.setup = setup_logging  # type: ignore
 
 
 class Sphinx(_Sphinx):

--- a/lib/esbonio/esbonio/sphinx_agent/handlers/diagnostics.py
+++ b/lib/esbonio/esbonio/sphinx_agent/handlers/diagnostics.py
@@ -22,8 +22,8 @@ def init_db(app: Sphinx, config: Config):
 
 def clear_diagnostics(app: Sphinx, docname: str, source):
     """Clear the diagnostics assocated with the given file."""
-    filepath = app.env.doc2path(docname, base=True)
-    app.esbonio.log.diagnostics.pop(filepath, None)
+    uri = Uri.for_file(app.env.doc2path(docname, base=True))
+    app.esbonio.log.diagnostics.pop(uri, None)
 
 
 def sync_diagnostics(app: Sphinx, exc: Optional[Exception]):
@@ -32,10 +32,9 @@ def sync_diagnostics(app: Sphinx, exc: Optional[Exception]):
     results = []
     diagnostics = app.esbonio.log.diagnostics
 
-    for fpath, items in diagnostics.items():
-        uri = str(Uri.for_file(fpath).resolve())
+    for uri, items in diagnostics.items():
         for item in items:
-            results.append((uri, as_json(item)))
+            results.append((str(uri), as_json(item)))
 
     app.esbonio.db.insert_values(DIAGNOSTICS_TABLE, results)
 

--- a/lib/esbonio/esbonio/sphinx_agent/log.py
+++ b/lib/esbonio/esbonio/sphinx_agent/log.py
@@ -8,6 +8,7 @@ import sys
 import typing
 
 from . import types
+from .types import Uri
 from .util import logger
 
 if typing.TYPE_CHECKING:
@@ -35,7 +36,7 @@ class DiagnosticFilter(logging.Filter):
         super().__init__(*args, **kwargs)
 
         self.app = app
-        self.diagnostics: Dict[str, Set[types.Diagnostic]] = {}
+        self.diagnostics: Dict[Uri, Set[types.Diagnostic]] = {}
 
     def get_location(self, location: str) -> Tuple[str, Optional[int]]:
         if not location:
@@ -143,5 +144,5 @@ class DiagnosticFilter(logging.Filter):
             ),
         )
 
-        self.diagnostics.setdefault(doc, set()).add(diagnostic)
+        self.diagnostics.setdefault(Uri.for_file(doc), set()).add(diagnostic)
         return True

--- a/lib/esbonio/esbonio/sphinx_agent/types.py
+++ b/lib/esbonio/esbonio/sphinx_agent/types.py
@@ -216,6 +216,41 @@ class Uri:
                 "Paths without an authority cannot start with two slashes '//'"
             )
 
+    def __eq__(self, other):
+        if type(other) is not type(self):
+            return False
+
+        if self.scheme != other.scheme:
+            return False
+
+        if self.authority != other.authority:
+            return False
+
+        if self.query != other.query:
+            return False
+
+        if self.fragment != other.fragment:
+            return False
+
+        if IS_WIN and self.scheme == "file":
+            # Filepaths on windows are case in-sensitive
+            if self.path.lower() != other.path.lower():
+                return False
+
+        elif self.path != other.path:
+            return False
+
+        return True
+
+    def __hash__(self):
+        if IS_WIN and self.scheme == "file":
+            # Filepaths on windows are case in-sensitive
+            path = self.path.lower()
+        else:
+            path = self.path
+
+        return hash((self.scheme, self.authority, path, self.query, self.fragment))
+
     def __fspath__(self):
         """Return the file system representation of this uri.
 

--- a/lib/esbonio/tests/e2e/conftest.py
+++ b/lib/esbonio/tests/e2e/conftest.py
@@ -37,7 +37,7 @@ async def client(lsp_client: LanguageClient, uri_for, tmp_path_factory):
                 ),
             ),
             initialization_options={
-                "server": {"logLevel": "debug"},
+                "logging": {"level": "debug"},
                 "sphinx": {
                     "buildCommand": [
                         "sphinx-build",
@@ -67,7 +67,7 @@ async def client(lsp_client: LanguageClient, uri_for, tmp_path_factory):
         )
     )
 
-    await lsp_client.wait_for_notification("sphinx/clientCreated")
+    await lsp_client.wait_for_notification("sphinx/appCreated")
 
     # Save the document to trigger a build
     lsp_client.text_document_did_save(

--- a/lib/esbonio/tests/sphinx-agent/handlers/test_database.py
+++ b/lib/esbonio/tests/sphinx-agent/handlers/test_database.py
@@ -28,11 +28,21 @@ async def test_files_table(client: SubprocessSphinxClient, project: Project):
     expected = {
         (anuri(src, "index.rst"), "index", "index.html"),
         (anuri(src, "rst", "directives.rst"), "rst/directives", "rst/directives.html"),
+        (
+            anuri(src, "rst", "diagnostics.rst"),
+            "rst/diagnostics",
+            "rst/diagnostics.html",
+        ),
         (anuri(src, "rst", "symbols.rst"), "rst/symbols", "rst/symbols.html"),
         (
             anuri(src, "myst", "directives.md"),
             "myst/directives",
             "myst/directives.html",
+        ),
+        (
+            anuri(src, "myst", "diagnostics.md"),
+            "myst/diagnostics",
+            "myst/diagnostics.html",
         ),
         (anuri(src, "myst", "symbols.md"), "myst/symbols", "myst/symbols.html"),
         (anuri(src, "demo_rst.rst"), "demo_rst", "demo_rst.html"),

--- a/lib/esbonio/tests/sphinx-agent/handlers/test_diagnostics.py
+++ b/lib/esbonio/tests/sphinx-agent/handlers/test_diagnostics.py
@@ -4,7 +4,6 @@ from typing import Dict
 from typing import List
 
 import pytest
-from pygls import IS_WIN
 from pygls.protocol import default_converter
 
 from esbonio.server import Uri
@@ -21,11 +20,7 @@ def check_diagnostics(
 ):
     """Ensure that two sets of diagnostics are equal."""
     converter = default_converter()
-
-    if IS_WIN:
-        assert {str(k).lower() for k in actual} == {str(k).lower() for k in expected}
-    else:
-        assert set(actual.keys()) == set(expected.keys())
+    assert set(actual.keys()) == set(expected.keys())
 
     for k, ex_diags in expected.items():
         actual_diags = [converter.structure(d, types.Diagnostic) for d in actual[k]]
@@ -69,7 +64,9 @@ async def test_diagnostics(client: SubprocessSphinxClient, project: Project, uri
 
     await client.build(
         content_overrides={
-            rst_diagnostics_uri.fs_path: "My Custom Title\n===============\n\nThere are no images here"
+            str(
+                rst_diagnostics_uri
+            ): "My Custom Title\n===============\n\nThere are no images here"
         }
     )
 
@@ -82,7 +79,7 @@ async def test_diagnostics(client: SubprocessSphinxClient, project: Project, uri
     #       trick Sphinx into re-building the file.
     await client.build(
         content_overrides={
-            rst_diagnostics_uri.fs_path: pathlib.Path(rst_diagnostics_uri).read_text()
+            str(rst_diagnostics_uri): pathlib.Path(rst_diagnostics_uri).read_text()
         }
     )
     actual = await project.get_diagnostics()

--- a/lib/esbonio/tests/sphinx-agent/test_sa_build.py
+++ b/lib/esbonio/tests/sphinx-agent/test_sa_build.py
@@ -57,9 +57,7 @@ async def test_build_content_override(client: SubprocessSphinxClient, uri_for):
     assert expected in index_html.read_text()
 
     await client.build(
-        content_overrides={
-            (src / "index.rst").fs_path: "My Custom Title\n==============="
-        }
+        content_overrides={str(src / "index.rst"): "My Custom Title\n==============="}
     )
 
     # Ensure the override was applied

--- a/lib/esbonio/tests/workspaces/demo/conf.py
+++ b/lib/esbonio/tests/workspaces/demo/conf.py
@@ -35,7 +35,6 @@ html_theme_options = {
     "source_branch": "develop",
     "source_directory": "lib/esbonio/tests/workspaces/demo/",
 }
-html_static_path = ["_static"]
 
 
 def lsp_role(name, rawtext, text, lineno, inliner, options={}, content=[]):

--- a/lib/esbonio/tests/workspaces/demo/myst/diagnostics.md
+++ b/lib/esbonio/tests/workspaces/demo/myst/diagnostics.md
@@ -1,0 +1,6 @@
+# Diagnostics
+
+The language server has support for diagnostics, highlighting errors/warnings reported by Sphinx.
+
+```{image} /not-an-image.png
+```

--- a/lib/esbonio/tests/workspaces/demo/rst/diagnostics.rst
+++ b/lib/esbonio/tests/workspaces/demo/rst/diagnostics.rst
@@ -1,0 +1,6 @@
+Diagnostics
+===========
+
+The language server has support for diagnostics, highlighting errors/warnings reported by Sphinx.
+
+.. image:: /not-an-image.png

--- a/scripts/sphinx-app.py
+++ b/scripts/sphinx-app.py
@@ -32,19 +32,24 @@ The HTML pages are in docs/_build.
 
 import inspect
 import pathlib
+import pdb
 import time
 
 from esbonio.sphinx_agent import types
 from esbonio.sphinx_agent.app import Sphinx
 
-root = pathlib.Path(__file__).parent.parent
-
-app = Sphinx(
-    srcdir=root / "docs",
-    confdir=root / "docs",
-    outdir=root / "docs" / "_build",
-    doctreedir=root / "docs" / "_build" / "doctrees",
-    buildername="html",
-    freshenv=True,  # Have Sphinx reload everything on first build.
-)
-app.build()
+try:
+    root = pathlib.Path(__file__).parent.parent
+    # project = root / "docs"
+    project = root / "lib" / "esbonio" / "tests" / "workspaces" / "demo"
+    app = Sphinx(
+        srcdir=project,
+        confdir=project,
+        outdir=project / "_build",
+        doctreedir=project / "_build" / "doctrees",
+        buildername="html",
+        freshenv=True,  # Have Sphinx reload everything on first build.
+    )
+    app.build()
+except Exception:
+    pdb.post_mortem()


### PR DESCRIPTION
The previous PR #767 broke diagnostics, so we do in fact, have to override Sphinx's logging setup (assuming we want to be able to see errors during initial setup). This time however, our setup is a _lot_ less invasive - only adding an additional filter to the warning handler rather than replacing everything.

This also updates and re-enables the test cases related to diagnostics which had been disabled for some time.