### PR TITLE
workflow: Prep for publishing to Open VSX

### DIFF
--- a/.github/workflows/vscode-release.yml
+++ b/.github/workflows/vscode-release.yml
@@ -7,11 +7,8 @@ on:
     - 'code/**'
 
 jobs:
-  release:
-    name: vscode release
+  build:
     runs-on: ubuntu-latest
-    environment:
-      name: vscode-marketplace
     steps:
     - uses: 'actions/checkout@v4'
 
@@ -63,13 +60,6 @@ jobs:
         path: code/*.vsix
         if-no-files-found: error
 
-    - name: 'Publish Extension'
-      run: |
-        cd code
-        npm run deploy
-      env:
-        VSCE_PAT: ${{ secrets.VSCODE_PAT }}
-
     - name: Create Release
       run: |
         gh release create "${RELEASE_TAG}" \
@@ -78,3 +68,61 @@ jobs:
           ./code/*.vsix
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  marketplace-release:
+    name: vscode release
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: vscode-marketplace
+    steps:
+    - uses: 'actions/checkout@v4'
+
+    - uses: 'actions/setup-node@v4'
+      with:
+        node-version: 18.x
+        cache: 'npm'
+        cache-dependency-path: 'code/package-lock.json'
+
+    - uses: actions/download-artifact@v4
+      name: 'Download Extension'
+      with:
+        name: 'vsix'
+        path: code
+
+    - name: 'Publish Extension'
+      run: |
+        cd code
+        npm ci --prefer-offline
+        npm run deploy-vsce
+      env:
+        VSCE_PAT: ${{ secrets.VSCODE_PAT }}
+
+  open-vsx-release:
+    name: open vsx release
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: open-vsx
+    steps:
+    - uses: 'actions/checkout@v4'
+
+    - uses: 'actions/setup-node@v4'
+      with:
+        node-version: 18.x
+        cache: 'npm'
+        cache-dependency-path: 'code/package-lock.json'
+
+    - uses: actions/download-artifact@v4
+      name: 'Download Extension'
+      with:
+        name: 'vsix'
+        path: code
+
+    - name: 'Publish Extension'
+      run: |
+        cd code
+        npm ci --prefer-offline
+        npm run deploy-ovsx
+      env:
+        OVSX_PAT: ${{ secrets.OVSX_PAT }}

--- a/code/package.json
+++ b/code/package.json
@@ -19,7 +19,8 @@
     "scripts": {
         "compile": "node esbuild.mjs",
         "watch": "tsc -p . --watch",
-        "deploy": "vsce publish --pre-release -i *.vsix --baseImagesUrl https://github.com/swyddfa/esbonio/raw/release/code/",
+        "deploy-vsce": "vsce publish --pre-release -i *.vsix --baseImagesUrl https://github.com/swyddfa/esbonio/raw/release/code/",
+        "deploy-ovsx": "ovsx publish --pre-release -i *.vsix --baseImagesUrl https://github.com/swyddfa/esbonio/raw/release/code/",
         "package": "vsce package --pre-release --baseImagesUrl https://github.com/swyddfa/esbonio/raw/release/code/",
         "vscode:prepublish": "npm run compile"
     },


### PR DESCRIPTION
This should take care of the technical requirements for publishing to Open VSX (#641) 
I'm hoping EclipseFdn/open-vsx.org#2516 will take care of the remaining process requirements.