### PR TITLE
Re-implement role completions

### DIFF
--- a/lib/esbonio/775.feature.md
+++ b/lib/esbonio/775.feature.md
@@ -1,0 +1,1 @@
+Add support for role completions in MyST documents

--- a/lib/esbonio/esbonio/server/cli.py
+++ b/lib/esbonio/esbonio/server/cli.py
@@ -73,6 +73,7 @@ def main(argv: Optional[Sequence[str]] = None):
         "esbonio.server.features.sphinx_support.diagnostics",
         "esbonio.server.features.sphinx_support.symbols",
         "esbonio.server.features.sphinx_support.directives",
+        "esbonio.server.features.sphinx_support.roles",
     ]
 
     for mod in args.included_modules:

--- a/lib/esbonio/esbonio/server/cli.py
+++ b/lib/esbonio/esbonio/server/cli.py
@@ -69,6 +69,7 @@ def main(argv: Optional[Sequence[str]] = None):
         "esbonio.server.features.sphinx_manager",
         "esbonio.server.features.preview_manager",
         "esbonio.server.features.directives",
+        "esbonio.server.features.roles",
         "esbonio.server.features.sphinx_support.diagnostics",
         "esbonio.server.features.sphinx_support.symbols",
         "esbonio.server.features.sphinx_support.directives",

--- a/lib/esbonio/esbonio/server/features/directives/__init__.py
+++ b/lib/esbonio/esbonio/server/features/directives/__init__.py
@@ -45,6 +45,8 @@ class DirectiveProvider:
 
 
 class DirectiveFeature(server.LanguageFeature):
+    """Support for directives."""
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
@@ -80,7 +82,7 @@ class DirectiveFeature(server.LanguageFeature):
     async def completion(
         self, context: server.CompletionContext
     ) -> Optional[List[types.CompletionItem]]:
-        """Provide auto-completion suggestions for directives."""
+        """Provide completion suggestions for directives."""
 
         groups = context.match.groupdict()
 

--- a/lib/esbonio/esbonio/server/features/directives/completion.py
+++ b/lib/esbonio/esbonio/server/features/directives/completion.py
@@ -71,12 +71,13 @@ def render_rst_directive_with_insert_text(
     context
        The context in which the completion is being generated.
 
-    name
-       The name of the directive, as it appears in an rst file.
-
     directive
-       The class implementing the directive.
+       The directive.
 
+    Returns
+    -------
+    Optional[types.CompletionItem]
+       The rendered completion item, or ``None`` if the directive should be skipped
     """
     insert_text = f".. {directive.name}::"
     user_text = context.match.group(0).strip()
@@ -153,7 +154,7 @@ def render_rst_directive_with_text_edit(
     Returns
     -------
     Optional[types.CompletionItem]
-       The rendered completion item
+       The rendered completion item, or ``None`` if the directive should be skipped
     """
     match = context.match
 

--- a/lib/esbonio/esbonio/server/features/project_manager/project.py
+++ b/lib/esbonio/esbonio/server/features/project_manager/project.py
@@ -76,6 +76,14 @@ class Project:
         cursor = await db.execute(query)
         return await cursor.fetchall()  # type: ignore[return-value]
 
+    async def get_roles(self) -> List[Tuple[str, Optional[str]]]:
+        """Get the roles known to Sphinx."""
+        db = await self.get_db()
+
+        query = "SELECT name, implementation FROM roles"
+        cursor = await db.execute(query)
+        return await cursor.fetchall()  # type: ignore[return-value]
+
     async def get_document_symbols(self, src_uri: Uri) -> List[types.Symbol]:
         """Get the symbols for the given file."""
         db = await self.get_db()

--- a/lib/esbonio/esbonio/server/features/roles/__init__.py
+++ b/lib/esbonio/esbonio/server/features/roles/__init__.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+import inspect
+import typing
+
+import attrs
+from lsprotocol import types
+
+from esbonio import server
+from esbonio.sphinx_agent.types import RST_DIRECTIVE
+from esbonio.sphinx_agent.types import RST_ROLE
+
+from . import completion
+
+if typing.TYPE_CHECKING:
+    from typing import Any
+    from typing import Coroutine
+    from typing import Dict
+    from typing import List
+    from typing import Optional
+    from typing import Union
+
+
+@attrs.define
+class Role:
+    """Represents a role."""
+
+    name: str
+    """The name of the role, as the user would type in an rst file."""
+
+    implementation: Optional[str]
+    """The dotted name of the role's implementation."""
+
+
+class RoleProvider:
+    """Base class for role providers."""
+
+    def suggest_roles(
+        self, context: server.CompletionContext
+    ) -> Union[Optional[List[Role]], Coroutine[Any, Any, Optional[List[Role]]]]:
+        """Givem a completion context, suggest roles that may be used."""
+        return None
+
+
+class RolesFeature(server.LanguageFeature):
+    """Support for roles."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self._providers: Dict[int, RoleProvider] = {}
+        self._insert_behavior = "replace"
+
+    def add_provider(self, provider: RoleProvider):
+        """Register a role provider.
+
+        Parameters
+        ----------
+        provider
+           The role provider
+        """
+        self._providers[id(provider)] = provider
+
+    def initialized(self, params: types.InitializedParams):
+        """Called once the initial handshake between client and server has finished."""
+        self.configuration.subscribe(
+            "esbonio.server.completion",
+            server.CompletionConfig,
+            self.update_configuration,
+        )
+
+    def update_configuration(
+        self, event: server.ConfigChangeEvent[server.CompletionConfig]
+    ):
+        """Called when the user's configuration is updated."""
+        self._insert_behavior = event.value.preferred_insert_behavior
+
+    completion_triggers = [RST_ROLE]
+
+    async def completion(
+        self, context: server.CompletionContext
+    ) -> Optional[List[types.CompletionItem]]:
+        """Provide completion suggestions for roles."""
+
+        groups = context.match.groupdict()
+        target = groups["target"]
+
+        # All text matched by the regex
+        text = context.match.group(0)
+        start, end = context.match.span()
+
+        if target:
+            target_index = start + text.find(target)
+
+            # Only trigger target completions if the request was made from within
+            # the target part of the role.
+            if target_index <= context.position.character <= end:
+                return await self.complete_targets(context)
+
+        # If there's no indent, then this can only be a role definition
+        indent = context.match.group(1)
+        if indent == "":
+            return await self.complete_roles(context)
+
+        # Otherwise, search backwards until we find a blank line or an unindent
+        # so that we can determine the appropriate context.
+        linum = context.position.line - 1
+
+        try:
+            line = context.doc.lines[linum]
+        except IndexError:
+            return await self.complete_roles(context)
+
+        while linum >= 0 and line.startswith(indent):
+            linum -= 1
+            line = context.doc.lines[linum]
+
+        # Unless we are within a directive's options block, we should offer role
+        # suggestions
+        if RST_DIRECTIVE.match(line):
+            return []
+
+        return await self.complete_roles(context)
+
+    async def complete_targets(self, context: server.CompletionContext):
+        return None
+
+    async def complete_roles(
+        self, context: server.CompletionContext
+    ) -> Optional[List[types.CompletionItem]]:
+        """Return completion suggestions for the available roles"""
+
+        language = self.server.get_language_at(context.doc, context.position)
+        render_func = completion.get_role_renderer(language, self._insert_behavior)
+        if render_func is None:
+            return None
+
+        items = []
+        for role in await self.suggest_roles(context):
+            if (item := render_func(context, role)) is not None:
+                items.append(item)
+
+        if len(items) > 0:
+            return items
+
+        return None
+
+    async def suggest_roles(self, context: server.CompletionContext) -> List[Role]:
+        """Suggest roles that may be used, given a completion context.
+
+        Parameters
+        ----------
+        context
+           The completion context
+        """
+        items: List[Role] = []
+
+        for provider in self._providers.values():
+            try:
+                result: Optional[List[Role]] = None
+
+                aresult = provider.suggest_roles(context)
+                if inspect.isawaitable(aresult):
+                    result = await aresult
+
+                if result:
+                    items.extend(result)
+            except Exception:
+                name = type(provider).__name__
+                self.logger.error("Error in '%s.suggest_roles'", name, exc_info=True)
+
+        return items
+
+
+def esbonio_setup(server: server.EsbonioLanguageServer):
+    roles = RolesFeature(server)
+    server.add_feature(roles)

--- a/lib/esbonio/esbonio/server/features/roles/completion.py
+++ b/lib/esbonio/esbonio/server/features/roles/completion.py
@@ -1,0 +1,157 @@
+"""Helper functions for completion support."""
+
+from __future__ import annotations
+
+import re
+import typing
+
+from lsprotocol import types
+
+from esbonio import server
+
+if typing.TYPE_CHECKING:
+    from typing import Callable
+    from typing import Dict
+    from typing import Optional
+    from typing import Tuple
+
+    from . import Role
+
+    RoleRenderer = Callable[
+        [server.CompletionContext, Role], Optional[types.CompletionItem]
+    ]
+
+
+WORD = re.compile("[a-zA-Z]+")
+_ROLE_RENDERERS: Dict[Tuple[str, str], RoleRenderer] = {}
+"""CompletionItem rendering functions for roles."""
+
+
+def renderer(*, language: str, insert_behavior: str):
+    """Define a new rendering function."""
+
+    def fn(f: RoleRenderer) -> RoleRenderer:
+        _ROLE_RENDERERS[(language, insert_behavior)] = f
+        return f
+
+    return fn
+
+
+def get_role_renderer(language: str, insert_behavior: str) -> Optional[RoleRenderer]:
+    """Return the role renderer to use.
+
+    Parameters
+    ----------
+    language
+       The source language the completion item will be inserted into
+
+    insert_behavior
+       How the completion should behave when inserted.
+
+    Returns
+    -------
+    Optional[RoleRenderer]
+       The rendering function to use that matches the given criteria, if available.
+    """
+    return _ROLE_RENDERERS.get((language, insert_behavior), None)
+
+
+@renderer(language="rst", insert_behavior="insert")
+def render_rst_role_with_insert_text(
+    context: server.CompletionContext, role: Role
+) -> Optional[types.CompletionItem]:
+    """Render a ``CompletionItem`` using ``insertText``.
+
+    This implements the ``insert`` insert behavior for roles.
+
+    Parameters
+    ----------
+    context
+       The context in which the completion is being generated.
+
+    role
+       The role.
+
+    Returns
+    -------
+    Optional[types.CompletionItem]
+       The rendered completion item, or ``None`` if the directive should be skipped
+    """
+
+    insert_text = f":{role.name}:"
+    user_text = context.match.group(0).strip()
+
+    # Since we can't replace any existing text, it only makes sense
+    # to offer completions that align with what the user has already written.
+    if not insert_text.startswith(user_text):
+        return None
+
+    # If the existing text ends with a delimiter, then we should simply remove the
+    # entire prefix
+    if user_text.endswith((":", "-", " ")):
+        start_index = len(user_text)
+
+    # Look for groups of word chars, replace text until the start of the final group
+    else:
+        start_indices = [m.start() for m in WORD.finditer(user_text)] or [
+            len(user_text)
+        ]
+        start_index = max(start_indices)
+
+    item = _render_role_common(role)
+    item.insert_text = insert_text[start_index:]
+    item.insert_text_format = types.InsertTextFormat.PlainText
+    return item
+
+
+@renderer(language="rst", insert_behavior="replace")
+def render_rst_role_with_text_edit(
+    context: server.CompletionContext, role: Role
+) -> Optional[types.CompletionItem]:
+    """Render a role's ``CompletionItem`` using ``textEdit``.
+
+    This implements the ``replace`` insert behavior for roles.
+
+    Parameters
+    ----------
+    context
+       The context in which the completion is being generated.
+
+    role
+       The role.
+
+    Returns
+    -------
+    Optional[types.CompletionItem]
+       The rendered completion item, or ``None`` if the directive should be skipped
+    """
+    match = context.match
+    groups = match.groupdict()
+
+    # Insert text starting from the starting ':' character of the role.
+    start = match.span()[0] + match.group(0).find(":")
+    end = start + len(groups["role"])
+
+    range_ = types.Range(
+        start=types.Position(line=context.position.line, character=start),
+        end=types.Position(line=context.position.line, character=end),
+    )
+
+    insert_text = f":{role.name}:"
+
+    item = _render_role_common(role)
+    item.filter_text = insert_text
+    item.insert_text_format = types.InsertTextFormat.PlainText
+    item.text_edit = types.TextEdit(range=range_, new_text=insert_text)
+
+    return item
+
+
+def _render_role_common(role: Role) -> types.CompletionItem:
+    """Render the common fields of a role's completion item."""
+    return types.CompletionItem(
+        label=role.name,
+        detail=role.implementation,
+        kind=types.CompletionItemKind.Function,
+        data={"completion_type": "role"},
+    )

--- a/lib/esbonio/esbonio/server/features/sphinx_manager/client_subprocess.py
+++ b/lib/esbonio/esbonio/server/features/sphinx_manager/client_subprocess.py
@@ -273,7 +273,7 @@ async def forward_stderr(server: asyncio.subprocess.Process):
 
     # EOF is signalled with an empty bytestring
     while (line := await server.stderr.readline()) != b"":
-        sphinx_logger.info(line.decode())
+        sphinx_logger.info(line.decode().strip())
 
 
 def make_subprocess_sphinx_client(

--- a/lib/esbonio/esbonio/server/features/sphinx_support/roles.py
+++ b/lib/esbonio/esbonio/server/features/sphinx_support/roles.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import typing
+
+from lsprotocol import types
+
+from esbonio import server
+from esbonio.server.features import roles
+from esbonio.server.features.project_manager import ProjectManager
+
+if typing.TYPE_CHECKING:
+    from typing import List
+    from typing import Optional
+
+
+class SphinxRoles(roles.RoleProvider):
+    """Support for roles in a sphinx project."""
+
+    def __init__(self, manager: ProjectManager):
+        self.manager = manager
+
+    async def suggest_roles(
+        self, context: server.CompletionContext
+    ) -> Optional[List[roles.Role]]:
+        """Given a completion context, suggest roles that may be used."""
+
+        if (project := self.manager.get_project(context.uri)) is None:
+            return None
+
+        # Does the document have a default domain set?
+        results = await project.find_symbols(
+            uri=str(context.uri.resolve()),
+            kind=types.SymbolKind.Class.value,
+            detail="default-domain",
+        )
+        if len(results) > 0:
+            default_domain = results[0][1]
+        else:
+            default_domain = None
+
+        primary_domain = await project.get_config_value("primary_domain")
+        active_domain = default_domain or primary_domain or "py"
+
+        result: List[roles.Role] = []
+        for name, implementation in await project.get_roles():
+            # std: directives can be used unqualified
+            if name.startswith("std:"):
+                short_name = name.replace("std:", "")
+                result.append(
+                    roles.Role(name=short_name, implementation=implementation)
+                )
+
+            # Also suggest unqualified versions of directives from the currently active domain.
+            elif name.startswith(f"{active_domain}:"):
+                short_name = name.replace(f"{active_domain}:", "")
+                result.append(
+                    roles.Role(name=short_name, implementation=implementation)
+                )
+
+            result.append(roles.Role(name=name, implementation=implementation))
+
+        return result
+
+
+def esbonio_setup(
+    project_manager: ProjectManager,
+    roles_feature: roles.RolesFeature,
+):
+    provider = SphinxRoles(project_manager)
+    roles_feature.add_provider(provider)

--- a/lib/esbonio/esbonio/server/setup.py
+++ b/lib/esbonio/esbonio/server/setup.py
@@ -93,7 +93,8 @@ def _configure_lsp_methods(server: EsbonioLanguageServer) -> EsbonioLanguageServ
     @server.feature(
         types.TEXT_DOCUMENT_COMPLETION,
         types.CompletionOptions(
-            trigger_characters=[">", ".", ":", "`", "<", "/"], resolve_provider=True
+            trigger_characters=[">", ".", ":", "`", "<", "/", "{", "}"],
+            resolve_provider=True,
         ),
     )
     async def on_completion(ls: EsbonioLanguageServer, params: types.CompletionParams):

--- a/lib/esbonio/esbonio/sphinx_agent/handlers/__init__.py
+++ b/lib/esbonio/esbonio/sphinx_agent/handlers/__init__.py
@@ -33,6 +33,7 @@ sphinx.application.builtin_extensions += (
     f"{__name__}.diagnostics",
     f"{__name__}.symbols",
     f"{__name__}.directives",
+    f"{__name__}.roles",
 )
 
 

--- a/lib/esbonio/esbonio/sphinx_agent/handlers/roles.py
+++ b/lib/esbonio/esbonio/sphinx_agent/handlers/roles.py
@@ -1,0 +1,85 @@
+import inspect
+from typing import Any
+from typing import List
+from typing import Optional
+
+from docutils.parsers.rst import roles as docutils_roles
+
+from .. import types
+from ..app import Database
+from ..app import Sphinx
+from ..util import as_json
+
+ROLES_TABLE = Database.Table(
+    "roles",
+    [
+        Database.Column(name="name", dtype="TEXT"),
+        Database.Column(name="implementation", dtype="TEXT"),
+        Database.Column(name="location", dtype="JSON"),
+    ],
+)
+
+
+def get_impl_name(role: Any) -> str:
+    try:
+        return f"{role.__module__}.{role.__name__}"
+    except AttributeError:
+        return f"{role.__module__}.{role.__class__.__name__}"
+
+
+def get_impl_location(impl: Any) -> Optional[str]:
+    """Get the implementation location of the given directive"""
+
+    try:
+        if (filepath := inspect.getsourcefile(impl)) is None:
+            return None
+
+        uri = types.Uri.for_file(filepath).resolve()
+        source, line = inspect.getsourcelines(impl)
+
+        location = types.Location(
+            uri=str(uri),
+            range=types.Range(
+                start=types.Position(line=line - 1, character=0),
+                end=types.Position(line=line + len(source), character=0),
+            ),
+        )
+
+        return as_json(location)
+    except Exception:
+        # TODO: Log the error somewhere..
+        return None
+
+
+def index_roles(app: Sphinx):
+    """Index all the roles that are available to this app."""
+
+    roles: List[types.Directive] = []
+    found_roles = {
+        **docutils_roles._roles,  # type: ignore[attr-defined]
+        **docutils_roles._role_registry,  # type: ignore[attr-defined]
+    }
+
+    for name, role in found_roles.items():
+        if role == docutils_roles.unimplemented_role:
+            continue
+
+        roles.append((name, get_impl_name(role), None))
+
+    for prefix, domain in app.env.domains.items():
+        for name, role in domain.roles.items():
+            roles.append(
+                (
+                    f"{prefix}:{name}",
+                    get_impl_name(role),
+                    None,
+                )
+            )
+
+    app.esbonio.db.ensure_table(ROLES_TABLE)
+    app.esbonio.db.clear_table(ROLES_TABLE)
+    app.esbonio.db.insert_values(ROLES_TABLE, roles)
+
+
+def setup(app: Sphinx):
+    app.connect("builder-inited", index_roles)

--- a/lib/esbonio/esbonio/sphinx_agent/types.py
+++ b/lib/esbonio/esbonio/sphinx_agent/types.py
@@ -37,6 +37,52 @@ This does **not** include any options or content that may be included with the
 initial declaration.
 """
 
+MYST_ROLE: "re.Pattern" = re.compile(
+    r"""
+    ([^\w`]|^\s*)                     # roles cannot be preceeded by letter chars
+    (?P<role>
+      {                               # roles start with a '{'
+      (?P<name>[:\w-]+)?              # roles have a name
+      }?                              # roles end with a '}'
+    )
+    (?P<target>
+      `                               # targets begin with a '`' character
+      ((?P<alias>[^<`>]*?)<)?         # targets may specify an alias
+      (?P<modifier>[!~])?             # targets may have a modifier
+      (?P<label>[^<`>]*)?             # targets contain a label
+      >?                              # labels end with a '>' when there's an alias
+      `?                              # targets end with a '`' character
+    )?
+    """,
+    re.VERBOSE,
+)
+"""A regular expression to detect and parse parial and complete roles.
+
+I'm not sure if there are offical names for the components of a role, but the
+language server breaks a role down into a number of parts::
+
+                 vvvvvv label
+                v modifier(optional)
+               vvvvvvvv target
+   {c:function}`!malloc`
+   ^^^^^^^^^^^^ role
+    ^^^^^^^^^^ name
+
+The language server sometimes refers to the above as a "plain" role, in that the
+role's target contains just the label of the object it is linking to. However it's
+also possible to define "aliased" roles, where the link text in the final document
+is overriden, for example::
+
+                vvvvvvvvvvvvvvvvvvvvvvvv alias
+                                          vvvvvv label
+                                         v modifier (optional)
+               vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv target
+   {c:function}`used to allocate memory <~malloc>`
+   ^^^^^^^^^^^^ role
+    ^^^^^^^^^^ name
+
+"""
+
 
 RST_DIRECTIVE: "re.Pattern" = re.compile(
     r"""
@@ -147,7 +193,7 @@ is overriden, for example::
                 vvvvvvvvvvvvvvvvvvvvvvvv alias
                                           vvvvvv label
                                          v modifier (optional)
-               vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv target
+               vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv target
    :c:function:`used to allocate memory <~malloc>`
    ^^^^^^^^^^^^ role
     ^^^^^^^^^^ name

--- a/lib/esbonio/esbonio/sphinx_agent/types.py
+++ b/lib/esbonio/esbonio/sphinx_agent/types.py
@@ -114,8 +114,7 @@ RST_ROLE = re.compile(
     (?P<role>
       :                               # roles begin with a ':' character
       (?!:)                           # the next character cannot be a ':'
-      ((?P<domain>[\w]+):(?=\w))?     # roles may include a domain (that must be followed by a word character)
-      ((?P<name>[\w-]+):?)?           # roles have a name
+      ((?P<name>\w([:\w-]*\w)?):?)?   # roles have a name
     )
     (?P<target>
       `                               # targets begin with a '`' character
@@ -138,8 +137,7 @@ language server breaks a role down into a number of parts::
                vvvvvvvv target
    :c:function:`!malloc`
    ^^^^^^^^^^^^ role
-      ^^^^^^^^ name
-    ^ domain (optional)
+    ^^^^^^^^^^ name
 
 The language server sometimes refers to the above as a "plain" role, in that the
 role's target contains just the label of the object it is linking to. However it's
@@ -152,8 +150,7 @@ is overriden, for example::
                vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv target
    :c:function:`used to allocate memory <~malloc>`
    ^^^^^^^^^^^^ role
-      ^^^^^^^^ name
-    ^ domain (optional)
+    ^^^^^^^^^^ name
 
 """
 

--- a/lib/esbonio/tests/e2e/test_e2e_roles.py
+++ b/lib/esbonio/tests/e2e/test_e2e_roles.py
@@ -1,0 +1,210 @@
+from __future__ import annotations
+
+import pathlib
+import typing
+
+import pytest
+from lsprotocol import types
+from pytest_lsp import LanguageClient
+
+if typing.TYPE_CHECKING:
+    from typing import Optional
+    from typing import Set
+
+
+EXPECTED = {
+    "ref",
+    "doc",
+    "option",
+    "func",
+    "class",
+    "c:macro",
+    "c:func",
+    "py:func",
+    "py:class",
+    "std:ref",
+    "std:doc",
+}
+
+UNEXPECTED = {
+    "macro",
+    "restructuredtext-unimplemented-role",
+}
+
+
+@pytest.mark.parametrize(
+    "text, expected, unexpected",
+    [
+        ("::", None, None),
+        (":", EXPECTED, UNEXPECTED),
+        (":r", EXPECTED, UNEXPECTED),
+        (":c:func", EXPECTED, UNEXPECTED),
+        (":c:func: ", None, None),
+        ("  ::", None, None),
+        ("  :", EXPECTED, UNEXPECTED),
+        ("  :r", EXPECTED, UNEXPECTED),
+        ("  :c:func", EXPECTED, UNEXPECTED),
+        ("  :c:func: ", None, None),
+        ("(:", EXPECTED, UNEXPECTED),
+        ("(:r", EXPECTED, UNEXPECTED),
+        ("(:c:func", EXPECTED, UNEXPECTED),
+    ],
+)
+@pytest.mark.asyncio(scope="session")
+async def test_rst_role_completions(
+    client: LanguageClient,
+    uri_for,
+    text: str,
+    expected: Optional[Set[str]],
+    unexpected: Optional[Set[str]],
+):
+    """Ensure that the language server can offer role completions in rst documents."""
+    test_uri = uri_for("workspaces", "demo", "rst", "roles.rst")
+
+    uri = str(test_uri)
+    fpath = pathlib.Path(test_uri)
+    contents = fpath.read_text()
+    linum = contents.splitlines().index(".. Add your reference here...")
+
+    # Open the file
+    client.text_document_did_open(
+        types.DidOpenTextDocumentParams(
+            text_document=types.TextDocumentItem(
+                uri=uri,
+                language_id="restructuredtext",
+                version=1,
+                text=contents,
+            )
+        )
+    )
+
+    # Write some text
+    #
+    # This should replace the '.. Add your note here...' comment in
+    # 'demo/rst/directives.rst' with the provided text
+    client.text_document_did_change(
+        types.DidChangeTextDocumentParams(
+            text_document=types.VersionedTextDocumentIdentifier(uri=uri, version=2),
+            content_changes=[
+                types.TextDocumentContentChangeEvent_Type1(
+                    text=text,
+                    range=types.Range(
+                        start=types.Position(line=linum, character=0),
+                        end=types.Position(line=linum + 1, character=0),
+                    ),
+                )
+            ],
+        )
+    )
+
+    # Make the completion request
+    results = await client.text_document_completion_async(
+        types.CompletionParams(
+            text_document=types.TextDocumentIdentifier(uri=uri),
+            position=types.Position(line=linum, character=len(text)),
+        )
+    )
+
+    # Close the document - without saving!
+    client.text_document_did_close(
+        types.DidCloseTextDocumentParams(
+            text_document=types.TextDocumentIdentifier(uri=uri)
+        )
+    )
+
+    if expected is None:
+        assert results is None
+    else:
+        items = {item.label for item in results.items}
+        unexpected = unexpected or set()
+
+        assert expected == items & expected
+        assert set() == items & unexpected
+
+
+@pytest.mark.parametrize(
+    "text, expected, unexpected",
+    [
+        ("{", EXPECTED, UNEXPECTED),
+        ("{r", EXPECTED, UNEXPECTED),
+        ("{c:func", EXPECTED, UNEXPECTED),
+        ("{c:func} ", None, None),
+        ("  {", EXPECTED, UNEXPECTED),
+        ("  {r", EXPECTED, UNEXPECTED),
+        ("  {c:func", EXPECTED, UNEXPECTED),
+        ("  {c:func} ", None, None),
+        ("({", EXPECTED, UNEXPECTED),
+        ("({r", EXPECTED, UNEXPECTED),
+        ("({c:func", EXPECTED, UNEXPECTED),
+    ],
+)
+@pytest.mark.asyncio(scope="session")
+async def test_myst_directive_completions(
+    client: LanguageClient,
+    uri_for,
+    text: str,
+    expected: Optional[Set[str]],
+    unexpected: Optional[Set[str]],
+):
+    """Ensure that the language server can offer completions in MyST documents."""
+    test_uri = uri_for("workspaces", "demo", "myst", "roles.md")
+
+    uri = str(test_uri)
+    fpath = pathlib.Path(test_uri)
+    contents = fpath.read_text()
+    linum = contents.splitlines().index("% Add your reference here...")
+
+    # Open the file
+    client.text_document_did_open(
+        types.DidOpenTextDocumentParams(
+            text_document=types.TextDocumentItem(
+                uri=uri,
+                language_id="markdown",
+                version=1,
+                text=contents,
+            )
+        )
+    )
+
+    # Write some text
+    #
+    # This should replace the '% Add your note here...' comment in
+    # 'demo/myst/directives.md' with the provided text
+    client.text_document_did_change(
+        types.DidChangeTextDocumentParams(
+            text_document=types.VersionedTextDocumentIdentifier(uri=uri, version=2),
+            content_changes=[
+                types.TextDocumentContentChangeEvent_Type1(
+                    text=text,
+                    range=types.Range(
+                        start=types.Position(line=linum, character=0),
+                        end=types.Position(line=linum + 1, character=0),
+                    ),
+                )
+            ],
+        )
+    )
+
+    # Make the completion request
+    results = await client.text_document_completion_async(
+        types.CompletionParams(
+            text_document=types.TextDocumentIdentifier(uri=uri),
+            position=types.Position(line=linum, character=len(text)),
+        )
+    )
+
+    # Close the document - without saving!
+    client.text_document_did_close(
+        types.DidCloseTextDocumentParams(
+            text_document=types.TextDocumentIdentifier(uri=uri)
+        )
+    )
+
+    if expected is None:
+        assert results is None
+    else:
+        items = {item.label for item in results.items}
+        unexpected = unexpected or set()
+
+        assert expected == items & expected
+        assert set() == items & unexpected

--- a/lib/esbonio/tests/server/features/test_role_completion.py
+++ b/lib/esbonio/tests/server/features/test_role_completion.py
@@ -1,0 +1,276 @@
+from __future__ import annotations
+
+import typing
+
+import pytest
+from lsprotocol import types
+from pygls.workspace import TextDocument
+from pytest_lsp import client_capabilities
+
+from esbonio import server
+from esbonio.server.features.roles import Role
+from esbonio.server.features.roles import completion
+from esbonio.server.testing import range_from_str
+from esbonio.sphinx_agent.types import RST_ROLE
+
+if typing.TYPE_CHECKING:
+    from typing import Literal
+    from typing import Optional
+
+
+VSCODE = "visual-studio-code"
+NVIM = "neovim"
+PATTERNS = {"rst": RST_ROLE}
+
+
+@pytest.mark.parametrize(
+    "client,language,insert_behavior,role,text,character,expected",
+    [
+        (
+            VSCODE,
+            "rst",
+            "replace",
+            Role("ref", "sphinx.roles.XRefRole"),
+            ":",
+            None,
+            types.CompletionItem(
+                label="ref",
+                detail="sphinx.roles.XRefRole",
+                kind=types.CompletionItemKind.Function,
+                filter_text=":ref:",
+                insert_text_format=types.InsertTextFormat.PlainText,
+                text_edit=types.TextEdit(
+                    range=range_from_str("0:0-0:1"), new_text=":ref:"
+                ),
+                data={"completion_type": "role"},
+            ),
+        ),
+        (
+            VSCODE,
+            "rst",
+            "replace",
+            Role("ref", "sphinx.roles.XRefRole"),
+            ":r",
+            None,
+            types.CompletionItem(
+                label="ref",
+                detail="sphinx.roles.XRefRole",
+                kind=types.CompletionItemKind.Function,
+                filter_text=":ref:",
+                insert_text_format=types.InsertTextFormat.PlainText,
+                text_edit=types.TextEdit(
+                    range=range_from_str("0:0-0:2"), new_text=":ref:"
+                ),
+                data={"completion_type": "role"},
+            ),
+        ),
+        (
+            VSCODE,
+            "rst",
+            "replace",
+            Role("ref", "sphinx.roles.XRefRole"),
+            ":doc",
+            None,
+            types.CompletionItem(
+                label="ref",
+                detail="sphinx.roles.XRefRole",
+                kind=types.CompletionItemKind.Function,
+                filter_text=":ref:",
+                insert_text_format=types.InsertTextFormat.PlainText,
+                text_edit=types.TextEdit(
+                    range=range_from_str("0:0-0:4"), new_text=":ref:"
+                ),
+                data={"completion_type": "role"},
+            ),
+        ),
+        (
+            VSCODE,
+            "rst",
+            "replace",
+            Role("cpp:func", "sphinx.domains.cpp.CPPXRefRole"),
+            ":c",
+            None,
+            types.CompletionItem(
+                label="cpp:func",
+                detail="sphinx.domains.cpp.CPPXRefRole",
+                kind=types.CompletionItemKind.Function,
+                filter_text=":cpp:func:",
+                insert_text_format=types.InsertTextFormat.PlainText,
+                text_edit=types.TextEdit(
+                    range=range_from_str("0:0-0:2"), new_text=":cpp:func:"
+                ),
+                data={"completion_type": "role"},
+            ),
+        ),
+        (
+            VSCODE,
+            "rst",
+            "replace",
+            Role("cpp:func", "sphinx.domains.cpp.CPPXRefRole"),
+            ":cpp:f",
+            None,
+            types.CompletionItem(
+                label="cpp:func",
+                detail="sphinx.domains.cpp.CPPXRefRole",
+                kind=types.CompletionItemKind.Function,
+                filter_text=":cpp:func:",
+                insert_text_format=types.InsertTextFormat.PlainText,
+                text_edit=types.TextEdit(
+                    range=range_from_str("0:0-0:6"), new_text=":cpp:func:"
+                ),
+                data={"completion_type": "role"},
+            ),
+        ),
+        (
+            VSCODE,
+            "rst",
+            "insert",
+            Role("ref", "sphinx.roles.XRefRole"),
+            ":",
+            None,
+            types.CompletionItem(
+                label="ref",
+                detail="sphinx.roles.XRefRole",
+                kind=types.CompletionItemKind.Function,
+                insert_text="ref:",
+                insert_text_format=types.InsertTextFormat.PlainText,
+                data={"completion_type": "role"},
+            ),
+        ),
+        (
+            VSCODE,
+            "rst",
+            "insert",
+            Role("ref", "sphinx.roles.XRefRole"),
+            ":r",
+            None,
+            types.CompletionItem(
+                label="ref",
+                detail="sphinx.roles.XRefRole",
+                kind=types.CompletionItemKind.Function,
+                insert_text="ref:",
+                insert_text_format=types.InsertTextFormat.PlainText,
+                data={"completion_type": "role"},
+            ),
+        ),
+        (
+            VSCODE,
+            "rst",
+            "insert",
+            Role("ref", "sphinx.roles.XRefRole"),
+            ":doc",
+            None,
+            None,
+        ),
+        (
+            VSCODE,
+            "rst",
+            "insert",
+            Role("cpp:func", "sphinx.domains.cpp.CPPXRefRole"),
+            ":c",
+            None,
+            types.CompletionItem(
+                label="cpp:func",
+                detail="sphinx.domains.cpp.CPPXRefRole",
+                kind=types.CompletionItemKind.Function,
+                insert_text="cpp:func:",
+                insert_text_format=types.InsertTextFormat.PlainText,
+                data={"completion_type": "role"},
+            ),
+        ),
+        (
+            VSCODE,
+            "rst",
+            "insert",
+            Role("cpp:func", "sphinx.domains.cpp.CPPXRefRole"),
+            ":cpp:",
+            None,
+            types.CompletionItem(
+                label="cpp:func",
+                detail="sphinx.domains.cpp.CPPXRefRole",
+                kind=types.CompletionItemKind.Function,
+                insert_text="func:",
+                insert_text_format=types.InsertTextFormat.PlainText,
+                data={"completion_type": "role"},
+            ),
+        ),
+        (
+            VSCODE,
+            "rst",
+            "insert",
+            Role("cpp:func", "sphinx.domains.cpp.CPPXRefRole"),
+            ":cpp:f",
+            None,
+            types.CompletionItem(
+                label="cpp:func",
+                detail="sphinx.domains.cpp.CPPXRefRole",
+                kind=types.CompletionItemKind.Function,
+                insert_text="func:",
+                insert_text_format=types.InsertTextFormat.PlainText,
+                data={"completion_type": "role"},
+            ),
+        ),
+    ],
+)
+def test_render_role_completion(
+    client: str,
+    language: Literal["rst", "markdown"],
+    insert_behavior: Literal["insert", "replace"],
+    role: Role,
+    text: str,
+    character: Optional[int],
+    expected: Optional[types.CompletionItem],
+):
+    """Ensure that we can render role completions correctly.
+
+    Parameters
+    ----------
+    client
+       The name of the client to use.
+
+       This will be passed to the ``client_capabilities`` function from ``pytest_lsp``
+       and controls which capabilities (e.g. snippet support) will be available.
+
+    language
+       The language in which the completion item will be inserted.
+
+    insert_behavior
+       How the completion item should behave when inserted
+
+    role
+       The role to generate the completion item for
+
+    text
+       The text used to help generate the completion context.
+
+    character
+       The character column at which the request is being made.
+       If ``None``, it will be assumed that the request is being made at the end of ``text``
+
+    expected
+       The expected result.
+    """
+    match = PATTERNS[language].match(text)
+    if not match:
+        raise ValueError(f"'{text}' is not valid in this context")
+
+    line = 0
+    character = len(text) if character is None else character
+    uri = "file:///test.txt"
+
+    context = server.CompletionContext(
+        uri=server.Uri.parse(uri),
+        doc=TextDocument(uri=uri),
+        match=match,
+        position=types.Position(line=line, character=character),
+        capabilities=client_capabilities(client),
+    )
+
+    render_func = completion.get_role_renderer(language, insert_behavior)
+    assert render_func is not None
+
+    item = render_func(context, role)
+    if expected is None:
+        assert item is None
+    else:
+        assert item == expected

--- a/lib/esbonio/tests/server/test_patterns.py
+++ b/lib/esbonio/tests/server/test_patterns.py
@@ -251,9 +251,12 @@ def test_directive_option_regex(string, expected):
         ("::", None),
         (":", {"role": ":"}),
         (":ref", {"name": "ref", "role": ":ref"}),
+        # The pattern should still work if the user adds a role in the middle of a line
+        (":ref for more details", {"name": "ref", "role": ":ref"}),
+        (":ref: for more details", {"name": "ref", "role": ":ref:"}),
         (":code-block", {"name": "code-block", "role": ":code-block"}),
-        (":c:func:", {"name": "func", "domain": "c", "role": ":c:func:"}),
-        (":cpp:func:", {"name": "func", "domain": "cpp", "role": ":cpp:func:"}),
+        (":c:func:", {"name": "c:func", "role": ":c:func:"}),
+        (":cpp:func:", {"name": "cpp:func", "role": ":cpp:func:"}),
         (":ref:`", {"name": "ref", "role": ":ref:", "target": "`"}),
         (
             ":code-block:`",
@@ -261,7 +264,7 @@ def test_directive_option_regex(string, expected):
         ),
         (
             ":c:func:`",
-            {"name": "func", "domain": "c", "role": ":c:func:", "target": "`"},
+            {"name": "c:func", "role": ":c:func:", "target": "`"},
         ),
         (
             ":ref:`some_label",
@@ -304,8 +307,7 @@ def test_directive_option_regex(string, expected):
         (
             ":c:func:`some_label",
             {
-                "name": "func",
-                "domain": "c",
+                "name": "c:func",
                 "role": ":c:func:",
                 "label": "some_label",
                 "target": "`some_label",
@@ -332,8 +334,7 @@ def test_directive_option_regex(string, expected):
         (
             ":c:func:`some_label`",
             {
-                "name": "func",
-                "domain": "c",
+                "name": "c:func",
                 "role": ":c:func:",
                 "label": "some_label",
                 "target": "`some_label`",
@@ -360,8 +361,7 @@ def test_directive_option_regex(string, expected):
         (
             ":c:func:`see more <",
             {
-                "name": "func",
-                "domain": "c",
+                "name": "c:func",
                 "role": ":c:func:",
                 "alias": "see more ",
                 "target": "`see more <",
@@ -412,8 +412,7 @@ def test_directive_option_regex(string, expected):
         (
             ":c:func:`see more <some_label",
             {
-                "name": "func",
-                "domain": "c",
+                "name": "c:func",
                 "role": ":c:func:",
                 "alias": "see more ",
                 "label": "some_label",
@@ -443,8 +442,7 @@ def test_directive_option_regex(string, expected):
         (
             ":c:func:`see more <some_label>",
             {
-                "name": "func",
-                "domain": "c",
+                "name": "c:func",
                 "role": ":c:func:",
                 "alias": "see more ",
                 "label": "some_label",
@@ -474,8 +472,7 @@ def test_directive_option_regex(string, expected):
         (
             ":c:func:`see more <some_label>`",
             {
-                "name": "func",
-                "domain": "c",
+                "name": "c:func",
                 "role": ":c:func:",
                 "alias": "see more ",
                 "label": "some_label",

--- a/lib/esbonio/tests/server/test_patterns.py
+++ b/lib/esbonio/tests/server/test_patterns.py
@@ -1,6 +1,7 @@
 import pytest
 
 from esbonio.sphinx_agent.types import MYST_DIRECTIVE
+from esbonio.sphinx_agent.types import MYST_ROLE
 from esbonio.sphinx_agent.types import RST_DEFAULT_ROLE
 from esbonio.sphinx_agent.types import RST_DIRECTIVE
 from esbonio.sphinx_agent.types import RST_DIRECTIVE_OPTION
@@ -57,6 +58,280 @@ def test_myst_directive_regex(string, expected):
 
         for name, value in expected.items():
             assert match.groupdict().get(name, None) == value, name
+
+
+@pytest.mark.parametrize(
+    "string, expected",
+    [
+        ("`{", None),
+        ("d{", None),
+        ("{", {"role": "{"}),
+        ("{ref", {"name": "ref", "role": "{ref"}),
+        # The pattern should still work if the user adds a role in the middle of a line
+        ("{ref for more details", {"name": "ref", "role": "{ref"}),
+        ("{ref} for more details", {"name": "ref", "role": "{ref}"}),
+        ("{code-block", {"name": "code-block", "role": "{code-block"}),
+        ("{c:func}", {"name": "c:func", "role": "{c:func}"}),
+        ("{cpp:func}", {"name": "cpp:func", "role": "{cpp:func}"}),
+        ("{ref}`", {"name": "ref", "role": "{ref}", "target": "`"}),
+        (
+            "{code-block}`",
+            {"name": "code-block", "role": "{code-block}", "target": "`"},
+        ),
+        (
+            "{c:func}`",
+            {"name": "c:func", "role": "{c:func}", "target": "`"},
+        ),
+        (
+            "{ref}`some_label",
+            {
+                "name": "ref",
+                "role": "{ref}",
+                "label": "some_label",
+                "target": "`some_label",
+            },
+        ),
+        (
+            "{ref}`!some_label",
+            {
+                "name": "ref",
+                "role": "{ref}",
+                "label": "some_label",
+                "target": "`!some_label",
+                "modifier": "!",
+            },
+        ),
+        (
+            "{ref}`~some_label",
+            {
+                "name": "ref",
+                "role": "{ref}",
+                "label": "some_label",
+                "target": "`~some_label",
+                "modifier": "~",
+            },
+        ),
+        (
+            "{code-block}`some_label",
+            {
+                "name": "code-block",
+                "role": "{code-block}",
+                "label": "some_label",
+                "target": "`some_label",
+            },
+        ),
+        (
+            "{c:func}`some_label",
+            {
+                "name": "c:func",
+                "role": "{c:func}",
+                "label": "some_label",
+                "target": "`some_label",
+            },
+        ),
+        (
+            "{ref}`some_label`",
+            {
+                "name": "ref",
+                "role": "{ref}",
+                "label": "some_label",
+                "target": "`some_label`",
+            },
+        ),
+        (
+            "{code-block}`some_label`",
+            {
+                "name": "code-block",
+                "role": "{code-block}",
+                "label": "some_label",
+                "target": "`some_label`",
+            },
+        ),
+        (
+            "{c:func}`some_label`",
+            {
+                "name": "c:func",
+                "role": "{c:func}",
+                "label": "some_label",
+                "target": "`some_label`",
+            },
+        ),
+        (
+            "{ref}`see more <",
+            {
+                "name": "ref",
+                "role": "{ref}",
+                "alias": "see more ",
+                "target": "`see more <",
+            },
+        ),
+        (
+            "{code-block}`see more <",
+            {
+                "name": "code-block",
+                "role": "{code-block}",
+                "alias": "see more ",
+                "target": "`see more <",
+            },
+        ),
+        (
+            "{c:func}`see more <",
+            {
+                "name": "c:func",
+                "role": "{c:func}",
+                "alias": "see more ",
+                "target": "`see more <",
+            },
+        ),
+        (
+            "{ref}`see more <some_label",
+            {
+                "name": "ref",
+                "role": "{ref}",
+                "alias": "see more ",
+                "label": "some_label",
+                "target": "`see more <some_label",
+            },
+        ),
+        (
+            "{code-block}`see more <some_label",
+            {
+                "name": "code-block",
+                "role": "{code-block}",
+                "alias": "see more ",
+                "label": "some_label",
+                "target": "`see more <some_label",
+            },
+        ),
+        (
+            "{ref}`see more <!some_label",
+            {
+                "name": "ref",
+                "role": "{ref}",
+                "alias": "see more ",
+                "label": "some_label",
+                "target": "`see more <!some_label",
+                "modifier": "!",
+            },
+        ),
+        (
+            "{code-block}`see more <~some_label",
+            {
+                "name": "code-block",
+                "role": "{code-block}",
+                "alias": "see more ",
+                "label": "some_label",
+                "target": "`see more <~some_label",
+                "modifier": "~",
+            },
+        ),
+        (
+            "{c:func}`see more <some_label",
+            {
+                "name": "c:func",
+                "role": "{c:func}",
+                "alias": "see more ",
+                "label": "some_label",
+                "target": "`see more <some_label",
+            },
+        ),
+        (
+            "{ref}`see more <some_label>",
+            {
+                "name": "ref",
+                "role": "{ref}",
+                "alias": "see more ",
+                "label": "some_label",
+                "target": "`see more <some_label>",
+            },
+        ),
+        (
+            "{code-block}`see more <some_label>",
+            {
+                "name": "code-block",
+                "role": "{code-block}",
+                "alias": "see more ",
+                "label": "some_label",
+                "target": "`see more <some_label>",
+            },
+        ),
+        (
+            "{c:func}`see more <some_label>",
+            {
+                "name": "c:func",
+                "role": "{c:func}",
+                "alias": "see more ",
+                "label": "some_label",
+                "target": "`see more <some_label>",
+            },
+        ),
+        (
+            "{ref}`see more <some_label>`",
+            {
+                "name": "ref",
+                "role": "{ref}",
+                "alias": "see more ",
+                "label": "some_label",
+                "target": "`see more <some_label>`",
+            },
+        ),
+        (
+            "{code-block}`see more <some_label>`",
+            {
+                "name": "code-block",
+                "role": "{code-block}",
+                "alias": "see more ",
+                "label": "some_label",
+                "target": "`see more <some_label>`",
+            },
+        ),
+        (
+            "{c:func}`see more <some_label>`",
+            {
+                "name": "c:func",
+                "role": "{c:func}",
+                "alias": "see more ",
+                "label": "some_label",
+                "target": "`see more <some_label>`",
+            },
+        ),
+    ],
+)
+def test_myst_role_regex(string, expected):
+    """Ensure that the regular expression we use to detect and parse roles works as
+    expected.
+
+    As a general rule, it's better to write tests at the LSP protocol level as that
+    decouples the test cases from the implementation. However, roles and the
+    corresponding regular expression are complex enough to warrant a test case on its
+    own.
+
+    As with most test cases, this one is parameterized with the following arguments::
+
+        (":ref:", {"name": "ref"}),
+        (".. directive::", None)
+
+    The first argument is the string to test the pattern against, the second a
+    dictionary containing the groups we expect to see in the resulting match object.
+    Groups that appear in the resulting match object but not in the expected result will
+    **not** fail the test.
+
+    To test situations where the pattern should **not** match the input, pass ``None``
+    as the second argument.
+
+    To test situations where the pattern should match, but we don't expect to see any
+    groups pass an empty dictionary as the second argument.
+    """
+
+    match = MYST_ROLE.search(string)
+
+    if expected is None:
+        assert match is None
+    else:
+        assert match is not None
+
+        for name, value in expected.items():
+            assert match.groupdict().get(name, None) == value
 
 
 @pytest.mark.parametrize(
@@ -167,7 +442,7 @@ def test_myst_directive_regex(string, expected):
         ),
     ],
 )
-def test_directive_regex(string, expected):
+def test_rst_directive_regex(string, expected):
     """Ensure that the regular expression we use to detect and parse directives
     works as expected.
 
@@ -481,7 +756,7 @@ def test_directive_option_regex(string, expected):
         ),
     ],
 )
-def test_role_regex(string, expected):
+def test_rst_role_regex(string, expected):
     """Ensure that the regular expression we use to detect and parse roles works as
     expected.
 

--- a/lib/esbonio/tests/sphinx-agent/handlers/test_database.py
+++ b/lib/esbonio/tests/sphinx-agent/handlers/test_database.py
@@ -27,6 +27,7 @@ async def test_files_table(client: SubprocessSphinxClient, project: Project):
 
     expected = {
         (anuri(src, "index.rst"), "index", "index.html"),
+        (anuri(src, "rst", "roles.rst"), "rst/roles", "rst/roles.html"),
         (anuri(src, "rst", "directives.rst"), "rst/directives", "rst/directives.html"),
         (
             anuri(src, "rst", "diagnostics.rst"),
@@ -34,6 +35,7 @@ async def test_files_table(client: SubprocessSphinxClient, project: Project):
             "rst/diagnostics.html",
         ),
         (anuri(src, "rst", "symbols.rst"), "rst/symbols", "rst/symbols.html"),
+        (anuri(src, "myst", "roles.md"), "myst/roles", "myst/roles.html"),
         (
             anuri(src, "myst", "directives.md"),
             "myst/directives",

--- a/lib/esbonio/tests/workspaces/demo/myst/roles.md
+++ b/lib/esbonio/tests/workspaces/demo/myst/roles.md
@@ -1,0 +1,12 @@
+# Roles
+
+The language server has extensive support for roles.
+
+(myst-roles-completion)=
+## Completion
+
+The most obvious feature is the completion suggestions, try inserting a `{ref}` role on the next line that links to the ``Completion`` heading above.
+
+% Add your reference here...
+
+Notice how VSCode automatically presented you with a list of all the directives you can use in this Sphinx project?

--- a/lib/esbonio/tests/workspaces/demo/rst/roles.rst
+++ b/lib/esbonio/tests/workspaces/demo/rst/roles.rst
@@ -1,0 +1,15 @@
+Roles
+=====
+
+The language server has extensive support for roles.
+
+.. _rst-roles-completion:
+
+Completion
+----------
+
+The most obvious feature is the completion suggestions, try inserting a ``:ref:`` role on the next line that links to the ``Completion`` heading above.
+
+.. Add your reference here...
+
+Notice how VSCode automatically presented you with a list of all the roles you can use in this Sphinx project?


### PR DESCRIPTION
This re-implements completion suggestions for roles (as in `:ref:` or `{py:func}` ), completions for a role's target will come in a future PR.

- Completions for both reStructuredText and MyST are supported.
  **Note:** Only the syntax documented [here](https://myst-parser.readthedocs.io/en/latest/syntax/roles-and-directives.html#roles-an-in-line-extension-point) is currently supported. All the other "advanced(?)" features on [this page](https://myst-parser.readthedocs.io/en/latest/syntax/cross-referencing.html) has not been implemented
- Support for the `insert` and `replace`  style of completions is supported

Related: #312 