### PR TITLE
lsp: Resolve `SphinxConfig` relative to the given uri

### DIFF
--- a/lib/esbonio/changes/779.fix.md
+++ b/lib/esbonio/changes/779.fix.md
@@ -1,0 +1,1 @@
+The server should once again, correctly guess a reasonable basic `sphinx-build` build command for projects located in a sub-folder of the workspace


### PR DESCRIPTION
Resolving the config relative to the configuration scope causes the server to miss Sphinx projects located in sub folders of the workspace, if the given scope happens to be higher in the folder hierarchy than the project itself.

Closes #779 