### PR TITLE
Preview improvements

### DIFF
--- a/code/changes/780.breaking.md
+++ b/code/changes/780.breaking.md
@@ -1,0 +1,1 @@
+The `Open Preview to the Side` and `Open Preview` commands have been renamed to `Preview Documentation in Split Window` and `Preview Documentation` respectively.

--- a/code/changes/780.enhancement.md
+++ b/code/changes/780.enhancement.md
@@ -1,0 +1,1 @@
+Esbonio now adds an icon to the editor toolbar that opens the preview in markdown files.

--- a/code/changes/793.enhancement.md
+++ b/code/changes/793.enhancement.md
@@ -1,0 +1,2 @@
+The preview pane will now show a "No Content Found" message if the file could not be previewed.
+The message contains troubleshooting steps on how the preview might be fixed.

--- a/code/package.json
+++ b/code/package.json
@@ -64,14 +64,14 @@
         "commands": [
             {
                 "command": "esbonio.preview.open",
-                "title": "Open Preview",
-                "icon": "$(preview)",
+                "title": "Preview Documentation",
+                "icon": "$(open-preview)",
                 "category": "Esbonio"
             },
             {
                 "command": "esbonio.preview.openSide",
-                "title": "Open Preview to the Side",
-                "icon": "$(open-preview)",
+                "title": "Preview Documentation in Split Window",
+                "icon": "$(book)",
                 "category": "Esbonio"
             },
             {
@@ -418,7 +418,7 @@
                     "command": "esbonio.preview.openSide",
                     "alt": "esbonio.preview.open",
                     "group": "navigation",
-                    "when": "resourceLangId == restructuredtext"
+                    "when": "resourceLangId == restructuredtext || resourceLangId == markdown"
                 }
             ]
         },

--- a/code/src/node/client.ts
+++ b/code/src/node/client.ts
@@ -9,6 +9,7 @@ import {
   LanguageClientOptions,
   ResponseError,
   ServerOptions,
+  ShowDocumentParams,
   State,
   TextDocumentFilter
 } from "vscode-languageclient/node";
@@ -363,6 +364,13 @@ export class EsbonioClient {
               this.stripNulls(config)
             })
             return result
+          }
+        },
+        window: {
+          showDocument: async (params: ShowDocumentParams, next) => {
+            this.logger.debug(`window/showDocument: ${JSON.stringify(params, undefined, 2)}`)
+            this.callHandlers("window/showDocument", { params: params, default: next })
+            return { success: true }
           }
         }
       },

--- a/code/src/node/preview.ts
+++ b/code/src/node/preview.ts
@@ -175,7 +175,8 @@ export class PreviewManager {
         content="default-src 'none'; style-src 'nonce-${cssNonce}'; script-src 'nonce-${scriptNonce}'; frame-src http://localhost:*/" />
 
   <style nonce="${cssNonce}">
-    * { box-sizing: border-box; }
+    * { box-sizing: border-box;}
+    :not(progress) { border: none;}
 
     body {
       height: 100vh;
@@ -198,6 +199,14 @@ export class PreviewManager {
       display: flex;
       align-items: center;
       gap: 1rem;
+      padding: 0.5rem;
+    }
+
+    #no-content {
+      font-size: 1.2em;
+      line-height: 1.5;
+      height: 100%;
+      overflow-y: auto;
       padding: 0.5rem;
     }
 
@@ -259,6 +268,7 @@ export class PreviewManager {
     const vscode = acquireVsCodeApi()
 
     const viewer = document.getElementById("viewer")
+    const noContent = document.getElementById("no-content")
     const status = document.getElementById("status")
 
     console.debug(window.location)
@@ -275,7 +285,15 @@ export class PreviewManager {
 
       // Control messages coming from the webview hosting this page
       if (event.origin.startsWith("vscode-webview://")) {
-        if (message.show) {
+
+        if (message.show === "<nothing>") {
+          status.style.display = "none"
+
+          // Only show the "no content" message if there is not a previous page already being shown
+          if (!viewer.src) {
+            noContent.style.display = "block"
+          }
+        } else if (message.show) {
           status.style.display = "flex"
           noContent.style.display = "none"
           viewer.src = message.show
@@ -289,6 +307,7 @@ export class PreviewManager {
       if (event.origin.startsWith("http://localhost:")) {
         if (message.ready) {
           status.style.display = "none"
+          noContent.style.display = "none"
           vscode.postMessage({ ready: true })
         }
       }

--- a/lib/esbonio/changes/783.fix.md
+++ b/lib/esbonio/changes/783.fix.md
@@ -1,0 +1,1 @@
+The server should once again automatically trigger a build when previewing a file, when necessary

--- a/lib/esbonio/changes/793.enhancement.md
+++ b/lib/esbonio/changes/793.enhancement.md
@@ -1,0 +1,3 @@
+If the client supports it, the server will now send `window/showDocument` requests when previewing a file.
+
+The server will automatically react to changes to ``esbonio.preview.*`` configuration options.

--- a/lib/esbonio/esbonio/server/features/preview_manager/__init__.py
+++ b/lib/esbonio/esbonio/server/features/preview_manager/__init__.py
@@ -95,24 +95,20 @@ class PreviewManager(server.LanguageFeature):
     def update_configuration(self, event: server.ConfigChangeEvent[PreviewConfig]):
         """Called when the user's configuration is updated."""
         config = event.value
-        show_result = False
 
         # (Re)create the websocket server
         if self.webview is None:
             self.webview = make_ws_server(self.server, config)
-            show_result = True
 
         elif (
             config.bind != self.webview.config.bind
             or config.ws_port != self.webview.config.ws_port
         ):
             self.webview.stop()
-            show_result = True
             self.webview = make_ws_server(self.server, config)
 
         # (Re)create the http server
         if self.preview is None:
-            show_result = True
             self.preview = make_http_server(self.server, config)
             self.preview.build_uri = self.build_uri
 
@@ -120,15 +116,12 @@ class PreviewManager(server.LanguageFeature):
             config.bind != self.preview.config.bind
             or config.http_port != self.preview.config.http_port
         ):
-            show_result = True
             self.preview.stop()
             self.preview = make_http_server(self.server, config)
             self.preview.build_uri = self.build_uri
 
         self.config = config
-
-        if show_result:
-            self.server.run_task(self.show_preview_uri())
+        self.server.run_task(self.show_preview_uri())
 
     async def on_build(self, client: SphinxClient, result):
         """Called whenever a sphinx build completes."""

--- a/lib/esbonio/esbonio/server/features/preview_manager/config.py
+++ b/lib/esbonio/esbonio/server/features/preview_manager/config.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import attrs
+
+
+@attrs.define
+class PreviewConfig:
+    """Configuration settings for previews."""
+
+    bind: str = attrs.field(default="localhost")
+    """The network interface to bind to, defaults to ``localhost``"""
+
+    http_port: int = attrs.field(default=0)
+    """The port to host the HTTP server on. If ``0`` a random port number will be
+    chosen"""
+
+    ws_port: int = attrs.field(default=0)
+    """The port to host the WebSocket server on. If ``0`` a random port number will be
+    chosen"""
+
+    show_line_markers: bool = attrs.field(default=False)
+    """If set, render the source line markers in the preview"""

--- a/lib/esbonio/esbonio/server/features/preview_manager/preview.py
+++ b/lib/esbonio/esbonio/server/features/preview_manager/preview.py
@@ -119,9 +119,12 @@ class PreviewServer:
 
     def stop(self):
         """Stop the server."""
-        if self._server:
+        if self._server is not None:
             self.logger.debug("Shutting down preview HTTP server")
             self._server.shutdown()
+
+        if self._future is not None:
+            self.logger.debug("Cancelling HTTP future: %s", self._future.cancel())
 
 
 def make_http_server(

--- a/lib/esbonio/esbonio/server/features/preview_manager/preview.py
+++ b/lib/esbonio/esbonio/server/features/preview_manager/preview.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+import typing
+from http.server import HTTPServer
+from http.server import SimpleHTTPRequestHandler
+
+from esbonio import server
+from esbonio.server import Uri
+
+if typing.TYPE_CHECKING:
+    from typing import Any
+    from typing import Optional
+
+    from .config import PreviewConfig
+
+
+class RequestHandler(SimpleHTTPRequestHandler):
+    def __init__(self, *args, logger: logging.Logger, directory: str, **kwargs) -> None:
+        self.logger = logger
+        super().__init__(*args, directory=directory, **kwargs)
+
+    def translate_path(self, path: str) -> str:
+        result = super().translate_path(path)
+        # self.logger.debug("Translate: '%s' -> '%s'", path, result)
+        return result
+
+    def log_message(self, format: str, *args: Any) -> None:
+        self.logger.debug(format, *args)
+
+
+class RequestHandlerFactory:
+    """Class for dynamically producing request handlers.
+
+    ``HTTPServer`` works by taking a "request handler" class and creating an instance of
+    it for every request it receives. By making this class callable, we can dynamically
+    produce a request handler based on the current situation.
+    """
+
+    def __init__(self, logger: logging.Logger, build_uri: Optional[Uri] = None):
+        self.logger = logger
+        self.build_uri = build_uri
+
+    def __call__(self, *args, **kwargs):
+        if self.build_uri is None:
+            raise ValueError("No build directory set")
+
+        if (build_dir := self.build_uri.fs_path) is None:
+            raise ValueError(
+                "Unable to determine build dir from uri: '%s'", self.build_uri
+            )
+
+        return RequestHandler(*args, logger=self.logger, directory=build_dir, **kwargs)
+
+
+class PreviewServer:
+    """The http server that serves the built content."""
+
+    def __init__(self, logger: logging.Logger, config: PreviewConfig, executor: Any):
+
+        self.config = config
+        """The current configuration."""
+
+        self.logger = logger.getChild("PreviewServer")
+        """The logger instance to use."""
+
+        self._handler_factory = RequestHandlerFactory(self.logger)
+        """Factory for producing http request handlers."""
+
+        self._startup_task: Optional[asyncio.Task] = None
+        """Task that resolves once the server is ready."""
+
+        self._executor: Any = executor
+        """The executor in which to run the http server."""
+
+        self._future: Optional[asyncio.Future] = None
+        """The future representing the http server's "task"."""
+
+        self._server: Optional[HTTPServer] = None
+        """The http server itself."""
+
+    def __await__(self):
+        """Makes the server await-able"""
+        if self._startup_task is None:
+            self._startup_task = asyncio.create_task(self.start())
+
+        return self._startup_task.__await__()
+
+    @property
+    def port(self):
+        if self._server is None:
+            return 0
+
+        return self._server.server_port
+
+    @property
+    def build_uri(self):
+        return self._handler_factory.build_uri
+
+    @build_uri.setter
+    def build_uri(self, value):
+        self._handler_factory.build_uri = value
+
+    async def start(self):
+        """Start the server."""
+
+        # Yes, this method does not need to be async. However, making it async means it
+        # aligns well with the pattern we've established in other components.
+
+        self._server = HTTPServer(
+            (self.config.bind, self.config.http_port), self._handler_factory
+        )
+
+        loop = asyncio.get_running_loop()
+        self._future = loop.run_in_executor(self._executor, self._server.serve_forever)
+
+        return self
+
+    def stop(self):
+        """Stop the server."""
+        if self._server:
+            self.logger.debug("Shutting down preview HTTP server")
+            self._server.shutdown()
+
+
+def make_http_server(
+    esbonio: server.EsbonioLanguageServer, config: PreviewConfig
+) -> PreviewServer:
+    return PreviewServer(esbonio.logger, config, esbonio.thread_pool_executor)


### PR DESCRIPTION
The PR contains a collection of improvements to previews in both the language server and the VSCode extension

- The server will once again, automatically trigger a build if needed (Closes #783)
- The server will automatically react to changes in `esbonio.preview.*` options
- If the client supports it, the server will send `window/showDocument` requests when previewing a file
- The VSCode extension will now show a "No Content Found" message containing troubleshooting steps in the preview window, when appropriate
- The VSCode extension now adds a button to the toolbar for markdown files that opens the preview pane 