### PR TITLE
Introduce `CompletionTriggers`

### DIFF
--- a/lib/esbonio/changes/413.api.md
+++ b/lib/esbonio/changes/413.api.md
@@ -1,0 +1,1 @@
+In the server's context `LanguageFeatures` can now define a `CompletionTrigger` which among other things, allows them to declare trigger characters

--- a/lib/esbonio/changes/799.enhancement.md
+++ b/lib/esbonio/changes/799.enhancement.md
@@ -1,0 +1,1 @@
+The server now includes the `eval-rst` directive in its completion suggestions for MyST files

--- a/lib/esbonio/changes/800.fix.md
+++ b/lib/esbonio/changes/800.fix.md
@@ -1,0 +1,1 @@
+The server no longer raises `ValueErrors` when typing `:` characters in markdown files.

--- a/lib/esbonio/changes/823.api.md
+++ b/lib/esbonio/changes/823.api.md
@@ -1,0 +1,2 @@
+In the Sphinx process, it is now possible for extensions to declare a role target provider through the `app.esbonio.create_role_target_provider` and `app.esbonio.add_role` methods.
+**Note:** This does require an associated implementation of the target provider on the server side.

--- a/lib/esbonio/esbonio/server/__init__.py
+++ b/lib/esbonio/esbonio/server/__init__.py
@@ -4,6 +4,7 @@ from ._configuration import ConfigChangeEvent
 from .events import EventSource
 from .feature import CompletionConfig
 from .feature import CompletionContext
+from .feature import CompletionTrigger
 from .feature import LanguageFeature
 from .server import EsbonioLanguageServer
 from .server import EsbonioWorkspace
@@ -15,6 +16,7 @@ __all__ = (
     "ConfigChangeEvent",
     "CompletionConfig",
     "CompletionContext",
+    "CompletionTrigger",
     "EsbonioLanguageServer",
     "EsbonioWorkspace",
     "EventSource",

--- a/lib/esbonio/esbonio/server/features/myst/directives.py
+++ b/lib/esbonio/esbonio/server/features/myst/directives.py
@@ -23,7 +23,11 @@ class MystDirectives(server.LanguageFeature):
         self.directives = directives
         self._insert_behavior = "replace"
 
-    completion_triggers = [MYST_DIRECTIVE]
+    completion_trigger = server.CompletionTrigger(
+        patterns=[MYST_DIRECTIVE],
+        languages={"markdown"},
+        characters={".", "`", "/"},
+    )
 
     def initialized(self, params: types.InitializedParams):
         """Called once the initial handshake between client and server has finished."""
@@ -74,8 +78,9 @@ class MystDirectives(server.LanguageFeature):
     ) -> Optional[List[types.CompletionItem]]:
         """Return completion suggestions for the available directives."""
 
-        language = self.server.get_language_at(context.doc, context.position)
-        render_func = completion.get_directive_renderer(language, self._insert_behavior)
+        render_func = completion.get_directive_renderer(
+            context.language, self._insert_behavior
+        )
         if render_func is None:
             return None
 

--- a/lib/esbonio/esbonio/server/features/myst/directives.py
+++ b/lib/esbonio/esbonio/server/features/myst/directives.py
@@ -5,6 +5,7 @@ import typing
 from lsprotocol import types
 
 from esbonio import server
+from esbonio.server.features.directives import Directive
 from esbonio.server.features.directives import DirectiveFeature
 from esbonio.server.features.directives import completion
 from esbonio.sphinx_agent.types import MYST_DIRECTIVE
@@ -85,6 +86,12 @@ class MystDirectives(server.LanguageFeature):
             return None
 
         items = []
+
+        # Include the special `eval-rst` directive
+        eval_rst = Directive("eval-rst", implementation=None)
+        if (item := render_func(context, eval_rst)) is not None:
+            items.append(item)
+
         for directive in await self.directives.suggest_directives(context):
             if (item := render_func(context, directive)) is not None:
                 items.append(item)

--- a/lib/esbonio/esbonio/server/features/myst/roles.py
+++ b/lib/esbonio/esbonio/server/features/myst/roles.py
@@ -23,7 +23,11 @@ class MystRoles(server.LanguageFeature):
         self.roles = roles
         self._insert_behavior = "replace"
 
-    completion_triggers = [MYST_ROLE]
+    completion_trigger = server.CompletionTrigger(
+        patterns=[MYST_ROLE],
+        languages={"markdown"},
+        characters={"{", "`", "<", "/"},
+    )
 
     def initialized(self, params: types.InitializedParams):
         """Called once the initial handshake between client and server has finished."""
@@ -64,9 +68,8 @@ class MystRoles(server.LanguageFeature):
     async def complete_targets(self, context: server.CompletionContext):
         """Provide completion suggestions for role targets."""
 
-        language = self.server.get_language_at(context.doc, context.position)
         render_func = completion.get_role_target_renderer(
-            language, self._insert_behavior
+            context.language, self._insert_behavior
         )
         if render_func is None:
             return None
@@ -84,8 +87,9 @@ class MystRoles(server.LanguageFeature):
     ) -> Optional[List[types.CompletionItem]]:
         """Return completion suggestions for the available roles"""
 
-        language = self.server.get_language_at(context.doc, context.position)
-        render_func = completion.get_role_renderer(language, self._insert_behavior)
+        render_func = completion.get_role_renderer(
+            context.language, self._insert_behavior
+        )
         if render_func is None:
             return None
 

--- a/lib/esbonio/esbonio/server/features/rst/directives.py
+++ b/lib/esbonio/esbonio/server/features/rst/directives.py
@@ -23,7 +23,11 @@ class RstDirectives(server.LanguageFeature):
         self.directives = directives
         self._insert_behavior = "replace"
 
-    completion_triggers = [RST_DIRECTIVE]
+    completion_trigger = server.CompletionTrigger(
+        patterns=[RST_DIRECTIVE],
+        languages={"rst"},
+        characters={".", "`"},
+    )
 
     def initialized(self, params: types.InitializedParams):
         """Called once the initial handshake between client and server has finished."""
@@ -74,8 +78,9 @@ class RstDirectives(server.LanguageFeature):
     ) -> Optional[List[types.CompletionItem]]:
         """Return completion suggestions for the available directives."""
 
-        language = self.server.get_language_at(context.doc, context.position)
-        render_func = completion.get_directive_renderer(language, self._insert_behavior)
+        render_func = completion.get_directive_renderer(
+            context.language, self._insert_behavior
+        )
         if render_func is None:
             return None
 

--- a/lib/esbonio/esbonio/server/features/rst/roles.py
+++ b/lib/esbonio/esbonio/server/features/rst/roles.py
@@ -24,7 +24,11 @@ class RstRoles(server.LanguageFeature):
         self.roles = roles
         self._insert_behavior = "replace"
 
-    completion_triggers = [RST_ROLE]
+    completion_trigger = server.CompletionTrigger(
+        patterns=[RST_ROLE],
+        languages={"rst"},
+        characters={":", "`", "<", "/"},
+    )
 
     def initialized(self, params: types.InitializedParams):
         """Called once the initial handshake between client and server has finished."""
@@ -91,9 +95,8 @@ class RstRoles(server.LanguageFeature):
     ) -> Optional[List[types.CompletionItem]]:
         """Provide completion suggestions for role targets."""
 
-        language = self.server.get_language_at(context.doc, context.position)
         render_func = completion.get_role_target_renderer(
-            language, self._insert_behavior
+            context.language, self._insert_behavior
         )
         if render_func is None:
             return None
@@ -111,8 +114,9 @@ class RstRoles(server.LanguageFeature):
     ) -> Optional[List[types.CompletionItem]]:
         """Return completion suggestions for the available roles"""
 
-        language = self.server.get_language_at(context.doc, context.position)
-        render_func = completion.get_role_renderer(language, self._insert_behavior)
+        render_func = completion.get_role_renderer(
+            context.language, self._insert_behavior
+        )
         if render_func is None:
             return None
 

--- a/lib/esbonio/esbonio/server/setup.py
+++ b/lib/esbonio/esbonio/server/setup.py
@@ -8,12 +8,12 @@ from typing import Any
 from typing import Dict
 from typing import Iterable
 from typing import List
+from typing import Set
 from typing import Type
 
 from lsprotocol import types
 
 from . import Uri
-from .feature import CompletionContext
 
 if typing.TYPE_CHECKING:
     from .server import EsbonioLanguageServer
@@ -39,10 +39,13 @@ def create_language_server(
     for module in modules:
         _load_module(server, module)
 
-    return _configure_lsp_methods(server)
+    _configure_lsp_methods(server)
+    _configure_completion(server)
+
+    return server
 
 
-def _configure_lsp_methods(server: EsbonioLanguageServer) -> EsbonioLanguageServer:
+def _configure_lsp_methods(server: EsbonioLanguageServer):
     """Configure method handlers for the portions of the LSP spec we support."""
 
     @server.feature(types.INITIALIZE)
@@ -89,81 +92,6 @@ def _configure_lsp_methods(server: EsbonioLanguageServer) -> EsbonioLanguageServ
         doc.saved_version = doc.version or 0
 
         await call_features(ls, "document_save", params)
-
-    @server.feature(
-        types.TEXT_DOCUMENT_COMPLETION,
-        types.CompletionOptions(
-            trigger_characters=[">", ".", ":", "`", "<", "/", "{", "}"],
-            resolve_provider=True,
-        ),
-    )
-    async def on_completion(ls: EsbonioLanguageServer, params: types.CompletionParams):
-        uri = params.text_document.uri
-        pos = params.position
-        doc = ls.workspace.get_text_document(uri)
-
-        try:
-            line = doc.lines[pos.line]
-        except IndexError:
-            line = ""
-
-        items = []
-
-        for cls, feature in ls:
-            for pattern in feature.completion_triggers:
-                for match in pattern.finditer(line):
-                    if not match:
-                        continue
-
-                    # Only trigger completions if the position of the request is within
-                    # the match.
-                    start, stop = match.span()
-                    if not (start <= pos.character <= stop):
-                        continue
-
-                    context = CompletionContext(
-                        uri=Uri.parse(uri),
-                        doc=doc,
-                        match=match,
-                        position=pos,
-                        capabilities=ls.client_capabilities,
-                    )
-
-                    ls.logger.debug("%s", context)
-                    name = f"{cls.__name__}"
-
-                    try:
-                        result = feature.completion(context)
-                        if inspect.isawaitable(result):
-                            result = await result
-                    except Exception:
-                        ls.logger.error(
-                            "Error in '%s.complete' handler", name, exc_info=True
-                        )
-                        continue
-
-                    for item in result or []:
-                        item.data = {"source_feature": name, **(item.data or {})}  # type: ignore
-                        items.append(item)
-
-        if len(items) > 0:
-            return types.CompletionList(is_incomplete=False, items=items)
-
-    @server.feature(types.COMPLETION_ITEM_RESOLVE)
-    def on_completion_resolve(
-        ls: EsbonioLanguageServer, item: types.CompletionItem
-    ) -> types.CompletionItem:
-        # source = (item.data or {}).get("source_feature", "")  # type: ignore
-        # feature = ls.get_feature(source)
-
-        # if not feature:
-        #     ls.logger.error(
-        #         "Unable to resolve completion item, unknown source: '%s'", source
-        #     )
-        #     return item
-
-        # return feature.completion_resolve(item)
-        return item
 
     @server.feature(
         types.TEXT_DOCUMENT_DIAGNOSTIC,
@@ -248,7 +176,81 @@ def _configure_lsp_methods(server: EsbonioLanguageServer) -> EsbonioLanguageServ
         paths = [pathlib.Path(Uri.parse(event.uri)) for event in params.changes]
         await ls.configuration.update_file_configuration(paths)
 
-    return server
+
+def _configure_completion(server: EsbonioLanguageServer):
+    """Configuration completion handlers."""
+
+    trigger_characters: Set[str] = set()
+
+    for _, feature in server:
+        if feature.completion_trigger is None:
+            continue
+
+        trigger_characters.update(feature.completion_trigger.characters)
+
+    @server.feature(
+        types.TEXT_DOCUMENT_COMPLETION,
+        types.CompletionOptions(
+            trigger_characters=list(trigger_characters),
+            resolve_provider=True,
+        ),
+    )
+    async def on_completion(ls: EsbonioLanguageServer, params: types.CompletionParams):
+        uri = params.text_document.uri
+        pos = params.position
+        doc = ls.workspace.get_text_document(uri)
+        language = ls.get_language_at(doc, pos)
+
+        items = []
+
+        for cls, feature in ls:
+            if not feature.completion_trigger:
+                continue
+
+            context = feature.completion_trigger(
+                uri=Uri.parse(uri),
+                params=params,
+                document=doc,
+                language=language,
+                client_capabilities=ls.client_capabilities,
+            )
+
+            if context is None:
+                continue
+
+            ls.logger.debug("%s", context)
+            name = f"{cls.__name__}"
+
+            try:
+                result = feature.completion(context)
+                if inspect.isawaitable(result):
+                    result = await result
+            except Exception:
+                ls.logger.exception("Error in '%s.complete' handler", name)
+                continue
+
+            for item in result or []:
+                item.data = {"source_feature": name, **(item.data or {})}  # type: ignore
+                items.append(item)
+
+        if len(items) > 0:
+            return types.CompletionList(is_incomplete=False, items=items)
+
+    @server.feature(types.COMPLETION_ITEM_RESOLVE)
+    def on_completion_resolve(
+        ls: EsbonioLanguageServer, item: types.CompletionItem
+    ) -> types.CompletionItem:
+        # source = (item.data or {}).get("source_feature", "")  # type: ignore
+        # feature = ls.get_feature(source)
+
+        # if not feature:
+        #     ls.logger.error(
+        #         "Unable to resolve completion item, unknown source: '%s'", source
+        #     )
+        #     return item
+
+        # return feature.completion_resolve(item)
+        return item
 
 
 async def call_features(ls: EsbonioLanguageServer, method: str, *args, **kwargs):

--- a/lib/esbonio/tests/e2e/test_e2e_directives.py
+++ b/lib/esbonio/tests/e2e/test_e2e_directives.py
@@ -27,32 +27,38 @@ EXPECTED = {
     "std:option",
 }
 
+RST_EXPECTED = EXPECTED.copy()
+MYST_EXPECTED = {"eval-rst", *EXPECTED}
+
 UNEXPECTED = {
     "macro",
     "restructuredtext-test-directive",
 }
+
+RST_UNEXPECTED = {"eval-rst", *UNEXPECTED}
+MYST_UNEXPECTED = UNEXPECTED.copy()
 
 
 @pytest.mark.parametrize(
     "text, expected, unexpected",
     [
         (".", None, None),
-        ("..", EXPECTED, UNEXPECTED),
-        (".. ", EXPECTED, UNEXPECTED),
-        (".. d", EXPECTED, UNEXPECTED),
-        (".. code-b", EXPECTED, UNEXPECTED),
+        ("..", RST_EXPECTED, RST_UNEXPECTED),
+        (".. ", RST_EXPECTED, RST_UNEXPECTED),
+        (".. d", RST_EXPECTED, RST_UNEXPECTED),
+        (".. code-b", RST_EXPECTED, RST_UNEXPECTED),
         (".. codex-block:: ", None, None),
-        (".. c:", EXPECTED, UNEXPECTED),
+        (".. c:", RST_EXPECTED, RST_UNEXPECTED),
         (".. _some_label:", None, None),
         ("   .", None, None),
-        ("   ..", EXPECTED, UNEXPECTED),
-        ("   .. ", EXPECTED, UNEXPECTED),
-        ("   .. d", EXPECTED, UNEXPECTED),
+        ("   ..", RST_EXPECTED, RST_UNEXPECTED),
+        ("   .. ", RST_EXPECTED, RST_UNEXPECTED),
+        ("   .. d", RST_EXPECTED, RST_UNEXPECTED),
         ("   .. doctest:: ", None, None),
-        ("   .. code-b", EXPECTED, UNEXPECTED),
+        ("   .. code-b", RST_EXPECTED, RST_UNEXPECTED),
         ("   .. codex-block:: ", None, None),
         ("   .. _some_label:", None, None),
-        ("   .. c:", EXPECTED, UNEXPECTED),
+        ("   .. c:", RST_EXPECTED, RST_UNEXPECTED),
     ],
 )
 @pytest.mark.asyncio(scope="session")
@@ -133,21 +139,21 @@ async def test_rst_directive_completions(
     [
         ("`", None, None),
         ("``", None, None),
-        ("```", EXPECTED, UNEXPECTED),
-        ("```{", EXPECTED, UNEXPECTED),
-        ("```{d", EXPECTED, UNEXPECTED),
-        ("```{code-b", EXPECTED, UNEXPECTED),
+        ("```", MYST_EXPECTED, MYST_UNEXPECTED),
+        ("```{", MYST_EXPECTED, MYST_UNEXPECTED),
+        ("```{d", MYST_EXPECTED, MYST_UNEXPECTED),
+        ("```{code-b", MYST_EXPECTED, MYST_UNEXPECTED),
         ("```{codex-block} ", None, None),
-        ("```{c:", EXPECTED, UNEXPECTED),
+        ("```{c:", MYST_EXPECTED, MYST_UNEXPECTED),
         ("   `", None, None),
         ("   ``", None, None),
-        ("   ```", EXPECTED, UNEXPECTED),
-        ("   ```{", EXPECTED, UNEXPECTED),
-        ("   ```{d", EXPECTED, UNEXPECTED),
+        ("   ```", MYST_EXPECTED, MYST_UNEXPECTED),
+        ("   ```{", MYST_EXPECTED, MYST_UNEXPECTED),
+        ("   ```{d", MYST_EXPECTED, MYST_UNEXPECTED),
         ("   ```{doctest}", None, None),
-        ("   ```{code-b", EXPECTED, UNEXPECTED),
+        ("   ```{code-b", MYST_EXPECTED, MYST_UNEXPECTED),
         ("   ```{codex-block}", None, None),
-        ("   ```{c:", EXPECTED, UNEXPECTED),
+        ("   ```{c:", MYST_EXPECTED, MYST_UNEXPECTED),
     ],
 )
 @pytest.mark.asyncio(scope="session")

--- a/lib/esbonio/tests/server/feature/test_completion.py
+++ b/lib/esbonio/tests/server/feature/test_completion.py
@@ -1,0 +1,221 @@
+from __future__ import annotations
+
+import re
+import typing
+
+import pytest
+from lsprotocol import types
+from pygls.workspace import TextDocument
+
+from esbonio import server
+
+if typing.TYPE_CHECKING:
+    from typing import Optional
+    from typing import Set
+
+
+@pytest.mark.parametrize(
+    "language, languages, expected",
+    [
+        ("rst", set(), True),
+        ("markdown", set(), True),
+        ("rst", {"markdown"}, False),
+        ("rst", {"rst", "python"}, True),
+    ],
+)
+def test_completion_trigger_languages(
+    language: str, languages: Set[str], expected: bool
+):
+    """Ensure that ``CompletionTrigger`` responds to the given language correctly."""
+
+    uri = server.Uri.parse("file:///test.txt")
+    params = types.CompletionParams(
+        position=types.Position(line=0, character=0),
+        text_document=types.TextDocumentIdentifier(uri=str(uri)),
+    )
+    document = TextDocument(uri=str(uri), source="some text")
+
+    trigger = server.CompletionTrigger(patterns=[re.compile(".*")], languages=languages)
+    result = trigger(uri, params, document, language, types.ClientCapabilities())
+
+    assert (result is not None) == expected
+
+
+@pytest.mark.parametrize(
+    "context, characters, expected",
+    [
+        # No context, or a non-trigger character request should still trigger
+        (None, set(), True),
+        (None, {">", "."}, True),
+        (types.CompletionContext(types.CompletionTriggerKind.Invoked), set(), True),
+        (
+            types.CompletionContext(types.CompletionTriggerKind.Invoked),
+            {".", "<"},
+            True,
+        ),
+        (
+            types.CompletionContext(
+                types.CompletionTriggerKind.TriggerForIncompleteCompletions
+            ),
+            set(),
+            True,
+        ),
+        (
+            types.CompletionContext(
+                types.CompletionTriggerKind.TriggerForIncompleteCompletions
+            ),
+            {".", "<"},
+            True,
+        ),
+        (
+            types.CompletionContext(
+                types.CompletionTriggerKind.TriggerCharacter,
+            ),
+            set(),
+            True,
+        ),
+        (
+            types.CompletionContext(
+                types.CompletionTriggerKind.TriggerCharacter,
+            ),
+            {".", "<"},
+            True,
+        ),
+        (
+            types.CompletionContext(
+                types.CompletionTriggerKind.TriggerCharacter, trigger_character="."
+            ),
+            set(),
+            True,
+        ),
+        (
+            types.CompletionContext(
+                types.CompletionTriggerKind.TriggerCharacter, trigger_character="."
+            ),
+            {".", ":"},
+            True,
+        ),
+        (
+            types.CompletionContext(
+                types.CompletionTriggerKind.TriggerCharacter, trigger_character="."
+            ),
+            {":"},
+            False,
+        ),
+    ],
+)
+def test_completion_trigger_characters(
+    context: Optional[types.CompletionContext], characters: Set[str], expected: bool
+):
+    """Ensure that ``CompletionTrigger`` responds to the trigger character correctly."""
+
+    uri = server.Uri.parse("file:///test.txt")
+    params = types.CompletionParams(
+        position=types.Position(line=0, character=0),
+        text_document=types.TextDocumentIdentifier(uri=str(uri)),
+        context=context,
+    )
+    document = TextDocument(uri=str(uri), source="some text")
+
+    trigger = server.CompletionTrigger(
+        patterns=[re.compile(".*")], characters=characters
+    )
+    result = trigger(uri, params, document, "rst", types.ClientCapabilities())
+
+    assert (result is not None) == expected
+
+
+def test_completion_trigger_pattern_no_match():
+    """Ensure that if none of the ``CompletionTrigger`` patterns match, the trigger does
+    not fire."""
+
+    uri = server.Uri.parse("file:///test.txt")
+    params = types.CompletionParams(
+        position=types.Position(line=0, character=0),
+        text_document=types.TextDocumentIdentifier(uri=str(uri)),
+    )
+    document = TextDocument(uri=str(uri), source="some text")
+
+    trigger = server.CompletionTrigger(patterns=[re.compile("xx"), re.compile("yy")])
+    assert trigger(uri, params, document, "rst", types.ClientCapabilities()) is None
+
+
+def test_completion_trigger_pattern_match_wrong_pos():
+    """Ensure that if one of the ``CompletionTrigger`` patterns match, the trigger does
+    not fire if the match is outside of the requested location."""
+
+    uri = server.Uri.parse("file:///test.txt")
+    params = types.CompletionParams(
+        position=types.Position(line=0, character=0),
+        text_document=types.TextDocumentIdentifier(uri=str(uri)),
+    )
+    document = TextDocument(uri=str(uri), source="some xx text")
+
+    trigger = server.CompletionTrigger(patterns=[re.compile("xx"), re.compile("yy")])
+    assert trigger(uri, params, document, "rst", types.ClientCapabilities()) is None
+
+
+def test_completion_trigger_pattern_match():
+    """Ensure that if one of the ``CompletionTrigger`` patterns match, the trigger returns
+    the completion context with the correct fields."""
+
+    uri = server.Uri.parse("file:///test.txt")
+    params = types.CompletionParams(
+        position=types.Position(line=0, character=6),
+        text_document=types.TextDocumentIdentifier(uri=str(uri)),
+    )
+    document = TextDocument(uri=str(uri), source="some xx text")
+    client_capabilities = types.ClientCapabilities(
+        text_document=types.TextDocumentClientCapabilities(
+            completion=types.CompletionClientCapabilities(
+                context_support=True,
+            ),
+        ),
+    )
+
+    trigger = server.CompletionTrigger(patterns=[re.compile("xx"), re.compile("yy")])
+    result = trigger(uri, params, document, "rst", client_capabilities)
+
+    assert result is not None
+    assert result.uri == uri
+    assert result.doc == document
+    assert result.position == params.position
+    assert result.language == "rst"
+    assert result.capabilities == client_capabilities
+
+    assert result.match.group(0) == "xx"
+
+
+def test_completion_trigger_pattern_first_match():
+    """Ensure that if more than one of the ``CompletionTrigger`` patterns match, the
+    trigger returns the first match."""
+
+    uri = server.Uri.parse("file:///test.txt")
+    params = types.CompletionParams(
+        position=types.Position(line=0, character=6),
+        text_document=types.TextDocumentIdentifier(uri=str(uri)),
+    )
+    document = TextDocument(uri=str(uri), source="some yy xx text")
+    client_capabilities = types.ClientCapabilities(
+        text_document=types.TextDocumentClientCapabilities(
+            completion=types.CompletionClientCapabilities(
+                context_support=True,
+            ),
+        ),
+    )
+
+    trigger = server.CompletionTrigger(
+        patterns=[re.compile("some.*xx"), re.compile("yy.*text")]
+    )
+    result = trigger(uri, params, document, "rst", client_capabilities)
+
+    assert result is not None
+    assert result.match.group(0) == "some yy xx"
+
+    trigger = server.CompletionTrigger(
+        patterns=[re.compile("yy.*text"), re.compile("some.*xx")]
+    )
+    result = trigger(uri, params, document, "rst", client_capabilities)
+
+    assert result is not None
+    assert result.match.group(0) == "yy xx text"

--- a/lib/esbonio/tests/server/features/test_directive_completion.py
+++ b/lib/esbonio/tests/server/features/test_directive_completion.py
@@ -690,6 +690,7 @@ def test_render_directive_completion(
         doc=TextDocument(uri=uri),
         match=match,
         position=types.Position(line=line, character=character),
+        language=language,
         capabilities=client_capabilities(client),
     )
 

--- a/lib/esbonio/tests/server/features/test_role_completion.py
+++ b/lib/esbonio/tests/server/features/test_role_completion.py
@@ -263,6 +263,7 @@ def test_render_role_completion(
         doc=TextDocument(uri=uri),
         match=match,
         position=types.Position(line=line, character=character),
+        language=language,
         capabilities=client_capabilities(client),
     )
 


### PR DESCRIPTION
Replacing the previous list of `re.Patterns`, language features now need to declare a `CompletionTrigger` which describes the conditions required before completions should be triggered.

This allows features to declare, in addition to the patterns, the language and trigger characters they require. (Closes #413)

By limiting the existing features to the languages they support fixes #800 

Lastly, the server will now include `eval-rst` in its list of completion suggestions for MyST files (Closes #799)
