### PR TITLE
sphinx-agent: Only use a relative import

### DIFF
--- a/lib/esbonio/changes/782.fix.md
+++ b/lib/esbonio/changes/782.fix.md
@@ -1,0 +1,1 @@
+The language server should now launch the correct version of the sphinx agent, even if an installation of `esbonio` exists in the target environment

--- a/lib/esbonio/esbonio/sphinx_agent/__main__.py
+++ b/lib/esbonio/esbonio/sphinx_agent/__main__.py
@@ -1,8 +1,5 @@
 import asyncio
 
-try:
-    from esbonio.sphinx_agent.server import main
-except ImportError:
-    from .server import main
+from .server import main
 
 asyncio.run(main())


### PR DESCRIPTION
This *should* prevent any conflicts that may occur from an existing installation of `esbonio` in the target environment

Closes #782 