### PR TITLE
Introduce configuration variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 .env
 .ipynb_checkpoints
 .tox
+.vscode/extensions/esbonio
 .vscode-test
 
 *.pyc

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
   - id: trailing-whitespace
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.4.10
+  rev: v0.5.0
   hooks:
   - id: ruff
     args: [--fix]
@@ -17,7 +17,7 @@ repos:
   - id: ruff-format
 
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: 'v1.10.0'
+  rev: 'v1.10.1'
   hooks:
   - id: mypy
     name: mypy (scripts)

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -33,6 +33,9 @@
                 "--folder-uri=${workspaceRoot}/docs",
                 "--folder-uri=${workspaceRoot}/lib/esbonio/tests/workspaces/demo"
             ],
+            "env": {
+                "TZ": "UTC"
+            },
             "outFiles": [
                 "${workspaceRoot}/code/dist/node/**/*.js"
             ],

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
     "[python]": {
-        "editor.defaultFormatter": "ms-python.black-formatter",
+        "editor.defaultFormatter": "charliermarsh.ruff",
         "editor.codeActionsOnSave": {
             "source.organizeImports": "explicit"
         },

--- a/code/Makefile
+++ b/code/Makefile
@@ -2,7 +2,7 @@ include ../.devcontainer/tools.mk
 
 ESBONIO ?= --pre esbonio
 
-.PHONY: dist dev-deps release-deps release
+.PHONY: dist dev-deps release-deps release install
 
 watch: dev-deps $(NPM)
 	-test -d dist && rm -r dist
@@ -11,6 +11,10 @@ watch: dev-deps $(NPM)
 compile: dev-deps $(NPM)
 	-test -d dist && rm -r dist
 	$(NPM) run compile
+
+install: compile
+	-test -d ../.vscode/extensions || mkdir -p ../.vscode/extensions
+	test -L ../.vscode/extensions/esbonio || ln -s $(PWD) ../.vscode/extensions/esbonio
 
 dist: release-deps $(NPM)
 	-test -d dist && rm -r dist

--- a/code/package.json
+++ b/code/package.json
@@ -24,7 +24,7 @@
         "package": "vsce package --pre-release --baseImagesUrl https://github.com/swyddfa/esbonio/raw/release/code/",
         "vscode:prepublish": "npm run compile"
     },
-    "main": "dist/node/extension",
+    "main": "dist/node/extension.js",
     "extensionDependencies": [
         "ms-python.python",
         "chrisjsewell.myst-tml-syntax"

--- a/lib/esbonio/changes/711.fix.md
+++ b/lib/esbonio/changes/711.fix.md
@@ -1,0 +1,1 @@
+`esbonio.sphinx.buildCommand` settings provided in a `pyproject.toml` file are now resolved relative to the file's location

--- a/lib/esbonio/esbonio/server/__init__.py
+++ b/lib/esbonio/esbonio/server/__init__.py
@@ -1,6 +1,7 @@
 from esbonio.sphinx_agent.types import Uri
 
 from ._configuration import ConfigChangeEvent
+from ._configuration import ConfigurationContext
 from .events import EventSource
 from .feature import CompletionConfig
 from .feature import CompletionContext
@@ -14,6 +15,7 @@ from .setup import create_language_server
 __all__ = (
     "__version__",
     "ConfigChangeEvent",
+    "ConfigurationContext",
     "CompletionConfig",
     "CompletionContext",
     "CompletionTrigger",

--- a/lib/esbonio/esbonio/server/features/sphinx_manager/config.py
+++ b/lib/esbonio/esbonio/server/features/sphinx_manager/config.py
@@ -54,7 +54,7 @@ class SphinxConfig:
     env_passthrough: List[str] = attrs.field(factory=list)
     """List of environment variables to pass through to the Sphinx subprocess"""
 
-    cwd: str = attrs.field(default="")
+    cwd: str = attrs.field(default="${scopeFsPath}")
     """The working directory to use."""
 
     python_path: List[pathlib.Path] = attrs.field(factory=list)
@@ -133,8 +133,7 @@ class SphinxConfig:
            The working directory to launch the sphinx agent in.
            If ``None``, the working directory could not be determined.
         """
-
-        if self.cwd:
+        if self.cwd and self.cwd != "${scopeFsPath}":
             return self.cwd
 
         candidates = [Uri.parse(f) for f in workspace.folders.keys()]

--- a/lib/esbonio/hatch.toml
+++ b/lib/esbonio/hatch.toml
@@ -35,4 +35,4 @@ value = ["tests/sphinx-agent", "tests/e2e"]
 
 [envs.hatch-static-analysis]
 config-path = "ruff_defaults.toml"
-dependencies = ["ruff==0.4.10"]
+dependencies = ["ruff==0.5.0"]

--- a/lib/esbonio/ruff_defaults.toml
+++ b/lib/esbonio/ruff_defaults.toml
@@ -14,9 +14,11 @@ select = [
   "ARG003",
   "ARG004",
   "ARG005",
-  "ASYNC100",
-  "ASYNC101",
-  "ASYNC102",
+  "ASYNC210",
+  "ASYNC220",
+  "ASYNC221",
+  "ASYNC230",
+  "ASYNC251",
   "B002",
   "B003",
   "B004",
@@ -463,11 +465,6 @@ select = [
   "TID251",
   "TID252",
   "TID253",
-  "TRIO100",
-  "TRIO105",
-  "TRIO109",
-  "TRIO110",
-  "TRIO115",
   "TRY002",
   "TRY003",
   "TRY004",
@@ -534,17 +531,8 @@ select = [
 ]
 
 [lint.per-file-ignores]
-"**/scripts/*" = [
-  "INP001",
-  "T201",
-]
-"**/tests/**/*" = [
-  "PLC1901",
-  "PLR2004",
-  "PLR6301",
-  "S",
-  "TID252",
-]
+"**/scripts/*" = ["INP001", "T201"]
+"**/tests/**/*" = ["PLC1901", "PLR2004", "PLR6301", "S", "TID252"]
 
 [lint.flake8-tidy-imports]
 ban-relative-imports = "all"

--- a/lib/esbonio/tests/server/features/test_sphinx_config.py
+++ b/lib/esbonio/tests/server/features/test_sphinx_config.py
@@ -175,4 +175,5 @@ def test_resolve(
     expected
        The expected outcome
     """
-    assert config.resolve(Uri.parse(uri), workspace, logger) == expected
+    actual = config.resolve(Uri.parse(uri), workspace, logger)
+    assert actual == expected

--- a/lib/esbonio/tests/server/test_configuration.py
+++ b/lib/esbonio/tests/server/test_configuration.py
@@ -26,6 +26,12 @@ class ExampleConfig:
     log_names: List[str] = attrs.field(factory=list)
 
 
+@attrs.define
+class ColorConfig:
+    color: str
+    scope: str = attrs.field(default="${scope}")
+
+
 @pytest.fixture
 def server(event_loop):
     """Return a server instance for testing."""
@@ -232,6 +238,188 @@ def server(event_loop):
             "file:///c:/path/to/workspace/docs/file.txt",
             ExampleConfig(log_level="debug", log_names=["file"]),
             id="workspace-file-override[win]",
+            marks=pytest.mark.skipif(not IS_WIN, reason="windows only"),
+        ),
+        pytest.param(  # Check that we can expand config variables correctly
+            {},
+            {
+                "file:///path/to/workspace": dict(
+                    esbonio=dict(colors=dict(color="red"))
+                ),
+            },
+            {},
+            "esbonio.colors",
+            ColorConfig,
+            "file:///path/to/workspace/docs/file.txt",
+            ColorConfig(color="red", scope="file:///path/to/workspace"),
+            id="scope-variable[workspace][unix]",
+            marks=pytest.mark.skipif(IS_WIN, reason="windows"),
+        ),
+        pytest.param(  # Check that we can expand config variables correctly
+            {},
+            {
+                "file:///c%3A/path/to/workspace": dict(
+                    esbonio=dict(colors=dict(color="red"))
+                ),
+            },
+            {},
+            "esbonio.colors",
+            ColorConfig,
+            "file:///c:/path/to/workspace/docs/file.txt",
+            ColorConfig(color="red", scope="file:///c%3A/path/to/workspace"),
+            id="scope-variable[workspace][win]",
+            marks=pytest.mark.skipif(not IS_WIN, reason="windows only"),
+        ),
+        pytest.param(  # Check that we can expand config variables correctly
+            {},
+            {
+                "file:///path/to/workspace": dict(
+                    esbonio=dict(colors=dict(color="red"))
+                ),
+            },
+            {
+                "file:///path/to/workspace/docs": dict(
+                    esbonio=dict(colors=dict(color="blue"))
+                ),
+            },
+            "esbonio.colors",
+            ColorConfig,
+            "file:///path/to/workspace/docs/file.txt",
+            ColorConfig(color="red", scope="file:///path/to/workspace/docs"),
+            id="scope-variable[workspace+file][unix]",
+            marks=pytest.mark.skipif(IS_WIN, reason="windows"),
+        ),
+        pytest.param(  # Check that we can expand config variables correctly
+            {},
+            {
+                "file:///c%3A/path/to/workspace": dict(
+                    esbonio=dict(colors=dict(color="red"))
+                ),
+            },
+            {
+                "file:///c%3A/path/to/workspace/docs": dict(
+                    esbonio=dict(colors=dict(color="blue"))
+                ),
+            },
+            "esbonio.colors",
+            ColorConfig,
+            "file:///c:/path/to/workspace/docs/file.txt",
+            ColorConfig(color="red", scope="file:///c%3A/path/to/workspace/docs"),
+            id="scope-variable[workspace+file][win]",
+            marks=pytest.mark.skipif(not IS_WIN, reason="windows only"),
+        ),
+        pytest.param(  # The user should still be able to override them
+            {},
+            {
+                "file:///path/to/workspace": dict(
+                    esbonio=dict(colors=dict(color="red"))
+                ),
+            },
+            {
+                "file:///path/to/workspace/docs": dict(
+                    esbonio=dict(colors=dict(color="blue", scope="file:///my/scope"))
+                ),
+            },
+            "esbonio.colors",
+            ColorConfig,
+            "file:///path/to/workspace/docs/file.txt",
+            ColorConfig(color="red", scope="file:///my/scope"),
+            id="scope-variable-override[unix]",
+            marks=pytest.mark.skipif(IS_WIN, reason="windows"),
+        ),
+        pytest.param(  # The user should still be able to override them
+            {},
+            {
+                "file:///c%3A/path/to/workspace": dict(
+                    esbonio=dict(colors=dict(color="red"))
+                ),
+            },
+            {
+                "file:///c%3A/path/to/workspace/docs": dict(
+                    esbonio=dict(colors=dict(color="blue", scope="file:///my/scope"))
+                ),
+            },
+            "esbonio.colors",
+            ColorConfig,
+            "file:///c:/path/to/workspace/docs/file.txt",
+            ColorConfig(color="red", scope="file:///my/scope"),
+            id="scope-variable-override[win]",
+            marks=pytest.mark.skipif(not IS_WIN, reason="windows only"),
+        ),
+        pytest.param(
+            {},
+            {
+                "file:///path/to/workspace": dict(
+                    esbonio=dict(colors=dict(color="red"))
+                ),
+            },
+            {
+                "file:///path/to/workspace/docs": dict(
+                    esbonio=dict(colors=dict(color="blue", scope="${scopePath}"))
+                ),
+            },
+            "esbonio.colors",
+            ColorConfig,
+            "file:///path/to/workspace/docs/file.txt",
+            ColorConfig(color="red", scope="/path/to/workspace/docs"),
+            id="scope-path-variable[unix]",
+            marks=pytest.mark.skipif(IS_WIN, reason="windows"),
+        ),
+        pytest.param(
+            {},
+            {
+                "file:///c%3A/path/to/workspace": dict(
+                    esbonio=dict(colors=dict(color="red"))
+                ),
+            },
+            {
+                "file:///c%3A/path/to/workspace/docs": dict(
+                    esbonio=dict(colors=dict(color="blue", scope="${scopePath}"))
+                ),
+            },
+            "esbonio.colors",
+            ColorConfig,
+            "file:///c:/path/to/workspace/docs/file.txt",
+            ColorConfig(color="red", scope="/c:/path/to/workspace/docs"),
+            id="scope-path-variable[win]",
+            marks=pytest.mark.skipif(not IS_WIN, reason="windows only"),
+        ),
+        pytest.param(
+            {},
+            {
+                "file:///path/to/workspace": dict(
+                    esbonio=dict(colors=dict(color="red"))
+                ),
+            },
+            {
+                "file:///path/to/workspace/docs": dict(
+                    esbonio=dict(colors=dict(color="blue", scope="${scopeFsPath}"))
+                ),
+            },
+            "esbonio.colors",
+            ColorConfig,
+            "file:///path/to/workspace/docs/file.txt",
+            ColorConfig(color="red", scope="/path/to/workspace/docs"),
+            id="scope-fspath-variable[unix]",
+            marks=pytest.mark.skipif(IS_WIN, reason="windows"),
+        ),
+        pytest.param(
+            {},
+            {
+                "file:///c%3A/path/to/workspace": dict(
+                    esbonio=dict(colors=dict(color="red"))
+                ),
+            },
+            {
+                "file:///c%3A/path/to/workspace/docs": dict(
+                    esbonio=dict(colors=dict(color="blue", scope="${scopeFsPath}"))
+                ),
+            },
+            "esbonio.colors",
+            ColorConfig,
+            "file:///c:/path/to/workspace/docs/file.txt",
+            ColorConfig(color="red", scope="c:\\path\\to\\workspace\\docs"),
+            id="scope-fspath-variable[win]",
             marks=pytest.mark.skipif(not IS_WIN, reason="windows only"),
         ),
     ],


### PR DESCRIPTION
Configuration objects can now accept variables of the form
`${variable}` and have them expanded by the configuration system at
runtime.

This commit adds support for the following variables

- `${scope}`: The full uri of the scope at which the configuration
  object was requested

- `${scopePath}`: The path component of the scope uri

- `${scopeFsPath}`: The path component of the scope uri as a
  filesystem path

Currently these configuration variables will only be expanded if they
appear in a field that is a simple string.

Additionaly, this commit sets the default value for `SphinxConfig.cwd`
to be `${scopeFsPath}`. This should mean that any
`esbonio.sphinx.buildCommand` values in a `pyproject.toml` file will
be evaluated relative to the file's location. Closes #711