### PR TITLE
Add support for `:external:` role completions

### DIFF
--- a/lib/esbonio/changes/464.feature.md
+++ b/lib/esbonio/changes/464.feature.md
@@ -1,0 +1,1 @@
+The language server now generates completions for `:external:` roles and their corresponding targets

--- a/lib/esbonio/esbonio/sphinx_agent/app.py
+++ b/lib/esbonio/esbonio/sphinx_agent/app.py
@@ -16,14 +16,9 @@ from .log import DiagnosticFilter
 if typing.TYPE_CHECKING:
     from typing import IO
     from typing import Any
-    from typing import Dict
     from typing import List
     from typing import Optional
-    from typing import Set
     from typing import Tuple
-    from typing import Type
-
-    from sphinx.domains import Domain
 
     RoleDefinition = Tuple[str, Any, List[types.Role.TargetProvider]]
 
@@ -120,24 +115,3 @@ class Sphinx(_Sphinx):
     def add_role(self, name: str, role: Any, override: bool = False):
         super().add_role(name, role, override)
         self.esbonio.add_role(name, role)
-
-    def add_domain(self, domain: Type[Domain], override: bool = False) -> None:
-        super().add_domain(domain, override)
-
-        target_types: Dict[str, Set[str]] = {}
-
-        for obj_name, item_type in domain.object_types.items():
-            for role_name in item_type.roles:
-                target_type = f"{domain.name}:{obj_name}"
-                target_types.setdefault(role_name, set()).add(target_type)
-
-        for name, role in domain.roles.items():
-            providers = []
-            if (item_types := target_types.get(name)) is not None:
-                providers.append(
-                    self.esbonio.create_role_target_provider(
-                        "objects", obj_types=list(item_types)
-                    )
-                )
-
-            self.esbonio.add_role(f"{domain.name}:{name}", role, providers)

--- a/lib/esbonio/esbonio/sphinx_agent/database.py
+++ b/lib/esbonio/esbonio/sphinx_agent/database.py
@@ -93,8 +93,11 @@ class Database:
         parameters: List[Any] = []
 
         for param, value in kwargs.items():
-            where.append(f"{param} = ?")
-            parameters.append(value)
+            if value is None:
+                where.append(f"{param} is null")
+            else:
+                where.append(f"{param} = ?")
+                parameters.append(value)
 
         if where:
             conditions = " AND ".join(where)

--- a/lib/esbonio/esbonio/sphinx_agent/handlers/domains.py
+++ b/lib/esbonio/esbonio/sphinx_agent/handlers/domains.py
@@ -11,8 +11,25 @@ from ..util import as_json
 
 if typing.TYPE_CHECKING:
     from typing import Dict
+    from typing import List
     from typing import Optional
+    from typing import Set
     from typing import Tuple
+
+    from sphinx.domains import Domain
+    from sphinx.util.typing import Inventory
+
+
+PROJECTS_TABLE = Database.Table(
+    "intersphinx_projects",
+    [
+        Database.Column(name="id", dtype="TEXT"),
+        Database.Column(name="name", dtype="TEXT"),
+        Database.Column(name="version", dtype="TEXT"),
+        Database.Column(name="uri", dtype="TEXT"),
+    ],
+)
+
 
 OBJECTS_TABLE = Database.Table(
     "objects",
@@ -22,6 +39,7 @@ OBJECTS_TABLE = Database.Table(
         Database.Column(name="domain", dtype="TEXT"),
         Database.Column(name="objtype", dtype="TEXT"),
         Database.Column(name="docname", dtype="TEXT"),
+        Database.Column(name="project", dtype="TEXT"),
         Database.Column(name="description", dtype="TEXT"),
         Database.Column(name="location", dtype="JSON"),
     ],
@@ -36,13 +54,18 @@ class DomainObjects:
             Tuple[str, str, str, str], Tuple[Optional[str], Optional[str]]
         ] = {}
 
-        app.connect("builder-inited", self.init_db)
+        # Needs to run late, but before the handler in ./roles.py
+        app.connect("builder-inited", self.init_db, priority=998)
         app.connect("object-description-transform", self.object_defined)
         app.connect("build-finished", self.commit)
 
     def init_db(self, app: Sphinx):
         """Prepare the database."""
-        app.esbonio.db.ensure_table(OBJECTS_TABLE)
+        projects = index_intersphinx_projects(app)
+        project_names = [p[0] for p in projects]
+
+        for domain in app.env.domains.values():
+            index_domain(app, domain, project_names)
 
     def commit(self, app, exc):
         """Commit changes to the database.
@@ -54,7 +77,7 @@ class DomainObjects:
         I will be *very* surprised if this never becomes a performance issue, but we
         will have to think of a smarter approach when it comes to it.
         """
-        app.esbonio.db.clear_table(OBJECTS_TABLE)
+        app.esbonio.db.clear_table(OBJECTS_TABLE, project=None)
         rows = []
 
         for name, domain in app.env.domains.items():
@@ -62,8 +85,12 @@ class DomainObjects:
                 desc, location = self._info.get(
                     (objname, name, objtype, docname), (None, None)
                 )
+
+                if objname == (display := str(dispname)):
+                    display = "-"
+
                 rows.append(
-                    (objname, str(dispname), name, objtype, docname, desc, location)
+                    (objname, display, name, objtype, docname, None, desc, location)
                 )
 
         app.esbonio.db.insert_values(OBJECTS_TABLE, rows)
@@ -110,6 +137,118 @@ class DomainObjects:
 
         key = (name, domain, objtype, docname)
         self._info[key] = (description, location)
+
+
+def index_domain(app: Sphinx, domain: Domain, projects: Optional[List[str]]):
+    """Index the roles in the given domain.
+
+    Parameters
+    ----------
+    app
+       The application instance
+
+    domain
+       The domain to index
+
+    projects
+       The list of known intersphinx projects
+    """
+    target_types: Dict[str, Set[str]] = {}
+
+    for obj_name, item_type in domain.object_types.items():
+        for role_name in item_type.roles:
+            target_type = f"{domain.name}:{obj_name}"
+            target_types.setdefault(role_name, set()).add(target_type)
+
+    for name, role in domain.roles.items():
+        if (item_types := target_types.get(name)) is None:
+            app.esbonio.add_role(f"{domain.name}:{name}", role, [])
+            continue
+
+        # Add an entry for the local project.
+        provider = app.esbonio.create_role_target_provider(
+            "objects", obj_types=list(item_types), projects=None
+        )
+        app.esbonio.add_role(f"{domain.name}:{name}", role, [provider])
+
+        if projects is None or len(projects) == 0:
+            continue
+
+        # Add an entry referencing all external projects
+        provider = app.esbonio.create_role_target_provider(
+            "objects", obj_types=list(item_types), projects=projects
+        )
+        app.esbonio.add_role(f"external:{domain.name}:{name}", role, [provider])
+
+        # Add an entry dedicated to each external project
+        for project in projects:
+            provider = app.esbonio.create_role_target_provider(
+                "objects", obj_types=list(item_types), projects=[project]
+            )
+            app.esbonio.add_role(
+                f"external+{project}:{domain.name}:{name}", role, [provider]
+            )
+
+
+def index_intersphinx_projects(app: Sphinx) -> List[Tuple[str, str, str, str]]:
+    """Index all the projects known to intersphinx.
+
+    Parameters
+    ----------
+    app
+       The application instance
+
+    Returns
+    -------
+    List[Tuple[str, str, str, str]]
+       The list of discovered projects
+    """
+    app.esbonio.db.ensure_table(OBJECTS_TABLE)
+    app.esbonio.db.ensure_table(PROJECTS_TABLE)
+    app.esbonio.db.clear_table(PROJECTS_TABLE)
+
+    projects: List[Tuple[str, str, str, str]] = []
+    objects = []
+
+    mapping = getattr(app.config, "intersphinx_mapping", {})
+    inventory = getattr(app.env, "intersphinx_named_inventory", {})
+
+    for id_, (_, (uri, _)) in mapping.items():
+        if (project := inventory.get(id_, None)) is None:
+            continue
+
+        app.esbonio.db.clear_table(OBJECTS_TABLE, project=id_)
+
+        # We just need an entry to be able to extract the project name and version
+        (name, version, _, _) = next(iter(next(iter(project.values())).values()))
+
+        projects.append((id_, name, version, uri))
+        objects.extend(index_intersphinx_objects(id_, uri, project))
+
+    app.esbonio.db.insert_values(PROJECTS_TABLE, projects)
+    app.esbonio.db.insert_values(OBJECTS_TABLE, objects)
+
+    return projects
+
+
+def index_intersphinx_objects(project_name: str, uri: str, project: Inventory):
+    """Index all the objects in the given project."""
+
+    objects = []
+
+    for objtype, items in project.items():
+        domain = None
+        if ":" in objtype:
+            domain, *parts = objtype.split(":")
+            objtype = ":".join(parts)
+
+        for objname, (_, _, item_uri, display) in items.items():
+            docname = item_uri.replace(uri, "")
+            objects.append(
+                (objname, display, domain, objtype, docname, project_name, None, None)
+            )
+
+    return objects
 
 
 def setup(app: Sphinx):

--- a/lib/esbonio/esbonio/sphinx_agent/types/roles.py
+++ b/lib/esbonio/esbonio/sphinx_agent/types/roles.py
@@ -26,7 +26,7 @@ MYST_ROLE: re.Pattern = re.compile(
     ([^\w`]|^\s*)                     # roles cannot be preceeded by letter chars
     (?P<role>
       {                               # roles start with a '{'
-      (?P<name>[:\w-]+)?              # roles have a name
+      (?P<name>[:\w+-]+)?             # roles have a name
       }?                              # roles end with a '}'
     )
     (?P<target>
@@ -74,7 +74,7 @@ RST_ROLE = re.compile(
     (?P<role>
       :                               # roles begin with a ':' character
       (?!:)                           # the next character cannot be a ':'
-      ((?P<name>\w([:\w-]*\w)?):?)?   # roles have a name
+      ((?P<name>\w([:\w+-]*\w)?):?)?  # roles have a name
     )
     (?P<target>
       `                               # targets begin with a '`' character

--- a/lib/esbonio/tests/e2e/test_e2e_roles.py
+++ b/lib/esbonio/tests/e2e/test_e2e_roles.py
@@ -32,6 +32,14 @@ UNEXPECTED = {
 }
 
 
+LOCAL_PY_CLASSES = {
+    "counters.pattern.PatternCounter",
+    "counters.pattern.NoMatchesError",
+}
+PYTHON_PY_CLASSES = {"logging.Filter", "http.server.HTTPServer"}
+SPHINX_PY_CLASSES = {"sphinx.addnodes.desc"}
+
+
 @pytest.mark.parametrize(
     "text, expected, unexpected",
     [
@@ -131,13 +139,28 @@ async def test_rst_role_completions(
         (":std:doc:`", {"demo_myst", "demo_rst", "rst/domains/python"}, set()),
         (
             ":class:`",
-            {"counters.pattern.PatternCounter", "counters.pattern.NoMatchesError"},
-            set(),
+            LOCAL_PY_CLASSES,
+            PYTHON_PY_CLASSES | SPHINX_PY_CLASSES,
         ),
         (
             ":py:class:`",
-            {"counters.pattern.PatternCounter", "counters.pattern.NoMatchesError"},
-            set(),
+            LOCAL_PY_CLASSES,
+            PYTHON_PY_CLASSES | SPHINX_PY_CLASSES,
+        ),
+        (
+            ":external:py:class:`",
+            PYTHON_PY_CLASSES | SPHINX_PY_CLASSES,
+            LOCAL_PY_CLASSES,
+        ),
+        (
+            ":external+python:py:class:`",
+            PYTHON_PY_CLASSES,
+            LOCAL_PY_CLASSES | SPHINX_PY_CLASSES,
+        ),
+        (
+            ":external+sphinx:py:class:`",
+            SPHINX_PY_CLASSES,
+            LOCAL_PY_CLASSES | PYTHON_PY_CLASSES,
         ),
         (":func:`", {"counters.pattern.count_numbers"}, set()),
         (":py:func:`", {"counters.pattern.count_numbers"}, set()),
@@ -313,13 +336,28 @@ async def test_myst_role_completions(
         ("{std:doc}`", {"demo_myst", "demo_rst", "rst/domains/python"}, set()),
         (
             "{class}`",
-            {"counters.pattern.PatternCounter", "counters.pattern.NoMatchesError"},
-            set(),
+            LOCAL_PY_CLASSES,
+            PYTHON_PY_CLASSES | SPHINX_PY_CLASSES,
         ),
         (
             "{py:class}`",
-            {"counters.pattern.PatternCounter", "counters.pattern.NoMatchesError"},
-            set(),
+            LOCAL_PY_CLASSES,
+            PYTHON_PY_CLASSES | SPHINX_PY_CLASSES,
+        ),
+        (
+            "{external:py:class}`",
+            PYTHON_PY_CLASSES | SPHINX_PY_CLASSES,
+            LOCAL_PY_CLASSES,
+        ),
+        (
+            "{external+sphinx:py:class}`",
+            SPHINX_PY_CLASSES,
+            LOCAL_PY_CLASSES | PYTHON_PY_CLASSES,
+        ),
+        (
+            "{external+python:py:class}`",
+            PYTHON_PY_CLASSES,
+            LOCAL_PY_CLASSES | SPHINX_PY_CLASSES,
         ),
         ("{func}`", {"counters.pattern.count_numbers"}, set()),
         ("{py:func}`", {"counters.pattern.count_numbers"}, set()),

--- a/lib/esbonio/tests/server/test_patterns.py
+++ b/lib/esbonio/tests/server/test_patterns.py
@@ -73,6 +73,14 @@ def test_myst_directive_regex(string, expected):
         ("{code-block", {"name": "code-block", "role": "{code-block"}),
         ("{c:func}", {"name": "c:func", "role": "{c:func}"}),
         ("{cpp:func}", {"name": "cpp:func", "role": "{cpp:func}"}),
+        (
+            "{external:cpp:func}",
+            {"name": "external:cpp:func", "role": "{external:cpp:func}"},
+        ),
+        (
+            "{external+python:cpp:func}",
+            {"name": "external+python:cpp:func", "role": "{external+python:cpp:func}"},
+        ),
         ("{ref}`", {"name": "ref", "role": "{ref}", "target": "`"}),
         (
             "{code-block}`",
@@ -532,6 +540,14 @@ def test_directive_option_regex(string, expected):
         (":code-block", {"name": "code-block", "role": ":code-block"}),
         (":c:func:", {"name": "c:func", "role": ":c:func:"}),
         (":cpp:func:", {"name": "cpp:func", "role": ":cpp:func:"}),
+        (
+            ":external:cpp:func:",
+            {"name": "external:cpp:func", "role": ":external:cpp:func:"},
+        ),
+        (
+            ":external+python:cpp:func:",
+            {"name": "external+python:cpp:func", "role": ":external+python:cpp:func:"},
+        ),
         (":ref:`", {"name": "ref", "role": ":ref:", "target": "`"}),
         (
             ":code-block:`",

--- a/lib/esbonio/tests/sphinx-agent/handlers/test_domains.py
+++ b/lib/esbonio/tests/sphinx-agent/handlers/test_domains.py
@@ -7,6 +7,8 @@ import pytest
 from esbonio.server.features.project_manager import Project
 
 if typing.TYPE_CHECKING:
+    from typing import List
+
     from sphinx.application import Sphinx
 
 
@@ -23,7 +25,8 @@ async def test_python_domain_discovery(app: Sphinx, project: Project):
     actual = set()
     db = await project.get_db()
     cursor = await db.execute(
-        "SELECT name, objtype, docname FROM objects where domain = 'py'"
+        "SELECT name, objtype, docname FROM objects "
+        "WHERE domain = 'py' AND project IS NULL"
     )
 
     for item in await cursor.fetchall():
@@ -45,10 +48,39 @@ async def test_std_domain_discovery(app: Sphinx, project: Project):
     actual = set()
     db = await project.get_db()
     cursor = await db.execute(
-        "SELECT name, objtype, docname FROM objects where domain = 'std'"
+        "SELECT name, objtype, docname FROM objects "
+        "WHERE domain = 'std' AND project IS NULL"
     )
 
     for item in await cursor.fetchall():
         actual.add(item)
 
     assert expected == actual
+
+
+@pytest.mark.parametrize(
+    "projname, domain, objtype, expected",
+    [
+        ("python", "py", "class", ["logging.Filter"]),
+        ("sphinx", "py", "class", ["sphinx.addnodes.desc"]),
+    ],
+)
+@pytest.mark.asyncio
+async def test_intersphinx_domain_discovery(
+    project: Project, domain: str, objtype: str, projname: str, expected: List[str]
+):
+    """Ensure that we can correctly index all the objects associated with the Python
+    domain in intersphinx projects."""
+
+    db = await project.get_db()
+    cursor = await db.execute(
+        "SELECT name FROM objects " "WHERE domain = ? AND objtype = ? AND project = ?",
+        (domain, objtype, projname),
+    )
+
+    actual = set()
+    for (name,) in await cursor.fetchall():
+        actual.add(name)
+
+    for name in expected:
+        assert name in actual

--- a/lib/esbonio/tests/workspaces/demo/conf.py
+++ b/lib/esbonio/tests/workspaces/demo/conf.py
@@ -17,12 +17,19 @@ release = "1.0"
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 
 extensions = [
+    "sphinx.ext.intersphinx",
     "sphinx_design",
     "myst_parser",
 ]
 
 templates_path = ["_templates"]
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store", "env", ".tox", "README.md"]
+
+intersphinx_mapping = {
+    "python": ("https://docs.python.org/3/", None),
+    "sphinx": ("https://www.sphinx-doc.org/en/master", None),
+}
+
 
 linkcheck_allowed_redirects = {
     # All HTTP redirections from the source URI to the canonical URI will be treated as "working".

--- a/scripts/sphinx-app.py
+++ b/scripts/sphinx-app.py
@@ -35,6 +35,7 @@ import inspect
 import pathlib
 import pdb
 import time
+import traceback
 
 from esbonio.sphinx_agent import handlers, types
 from esbonio.sphinx_agent.app import Sphinx
@@ -53,4 +54,5 @@ try:
     )
     app.build()
 except Exception:
+    traceback.print_exc()
     pdb.post_mortem()


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/868f1fa3-f011-4864-b021-10914bd1704f)

While it works, this feels a little bit like a hack, since to enable the completions the sphinx agent generates a role definition for every combination of `external`, `+invname` and `domain:objtype`. I'm sure a future version of this can be smarter about it.

The role completions are also starting to feel perhaps a little clunky? The completions can get quite long... perhaps having the server return just `external` and then on the `+` return a list of `invnames` could be potential improvement to explore...

Closes #464, supersedes #514