### PR TITLE
Re-implement `esbonio.sphinx.configOverrides`

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -30,6 +30,21 @@
         "**/.ruff_cache": true
     },
     "esbonio.server.showDeprecationWarnings": true,
+    "esbonio.sphinx.configOverrides": {
+        // "extensions": [
+        //     "sphinx.ext.autodoc",
+        //     "sphinx.ext.intersphinx",
+        //     "sphinx.ext.napoleon",
+        //     "sphinx.ext.viewcode",
+        //     "sphinx_design",
+        //     "myst_parser",
+        //     "cli_help",
+        //     "collection_items",
+        //     "domain",
+        // ],
+        // "html_theme": "alabaster",
+        // "html_theme_options": {},
+    },
     "python.testing.pytestArgs": [
         "lib/esbonio/tests"
     ],

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -26,7 +26,8 @@
         "**/.ipynb_checkpoints": true,
         "**/.coverage": true,
         "**/.vscode-test": true,
-        "**/.mypy_cache": true
+        "**/.mypy_cache": true,
+        "**/.ruff_cache": true
     },
     "esbonio.server.showDeprecationWarnings": true,
     "python.testing.pytestArgs": [

--- a/code/changes/785.enhancement.md
+++ b/code/changes/785.enhancement.md
@@ -1,0 +1,1 @@
+Expose the `esbonio.sphinx.configOverrides` option

--- a/code/package.json
+++ b/code/package.json
@@ -165,6 +165,12 @@
                         "default": null,
                         "description": "The sphinx-build command to use."
                     },
+                    "esbonio.sphinx.configOverrides": {
+                        "scope": "resource",
+                        "type": "object",
+                        "default": null,
+                        "description": "Overrides to apply to Sphinx's configuration."
+                    },
                     "esbonio.sphinx.pythonCommand": {
                         "scope": "resource",
                         "type": "array",

--- a/docs/lsp/reference/configuration.rst
+++ b/docs/lsp/reference/configuration.rst
@@ -252,7 +252,7 @@ The following options control the creation of the Sphinx application object mana
 
    A list of environment variables to pass through to the Sphinx process.
 
-.. esbonio:config:: sphinx.configOverrides
+.. esbonio:config:: esbonio.sphinx.configOverrides
    :scope: project
    :type: object
 

--- a/lib/esbonio/changes/785.enhancement.md
+++ b/lib/esbonio/changes/785.enhancement.md
@@ -1,0 +1,1 @@
+Re-implemented the `esbonio.sphinx.configOverrides` option

--- a/lib/esbonio/esbonio/server/features/sphinx_manager/client_subprocess.py
+++ b/lib/esbonio/esbonio/server/features/sphinx_manager/client_subprocess.py
@@ -211,6 +211,7 @@ class SubprocessSphinxClient(JsonRPCClient):
 
             params = types.CreateApplicationParams(
                 command=self.config.build_command,
+                config_overrides=self.config.config_overrides,
             )
             self.sphinx_info = await self.protocol.send_request_async(
                 "sphinx/createApp", params

--- a/lib/esbonio/esbonio/server/features/sphinx_manager/config.py
+++ b/lib/esbonio/esbonio/server/features/sphinx_manager/config.py
@@ -4,6 +4,7 @@ import hashlib
 import importlib.util
 import logging
 import pathlib
+from typing import Any
 from typing import Optional
 
 import attrs
@@ -51,6 +52,9 @@ class SphinxConfig:
 
     build_command: list[str] = attrs.field(factory=list)
     """The sphinx-build command to use."""
+
+    config_overrides: dict[str, Any] = attrs.field(factory=dict)
+    """Overrides to apply to Sphinx's configuration."""
 
     env_passthrough: list[str] = attrs.field(factory=list)
     """List of environment variables to pass through to the Sphinx subprocess"""
@@ -104,6 +108,7 @@ class SphinxConfig:
 
         return SphinxConfig(
             enable_dev_tools=self.enable_dev_tools,
+            config_overrides=self.config_overrides,
             cwd=cwd,
             env_passthrough=self.env_passthrough,
             python_command=self.python_command,

--- a/lib/esbonio/esbonio/sphinx_agent/handlers/__init__.py
+++ b/lib/esbonio/esbonio/sphinx_agent/handlers/__init__.py
@@ -110,6 +110,7 @@ class SphinxHandler:
         if sphinx_config is None:
             raise ValueError("Invalid build command")
 
+        sphinx_config.config_overrides.update(request.params.config_overrides)
         sphinx_args = sphinx_config.to_application_args()
         self.app = Sphinx(**sphinx_args)
 

--- a/lib/esbonio/esbonio/sphinx_agent/types/__init__.py
+++ b/lib/esbonio/esbonio/sphinx_agent/types/__init__.py
@@ -10,6 +10,7 @@ import dataclasses
 import os
 import pathlib
 import re
+from typing import Any
 from typing import Callable
 from typing import Optional
 from typing import Union
@@ -465,6 +466,9 @@ class CreateApplicationParams:
 
     command: list[str]
     """The ``sphinx-build`` command to base the app instance on."""
+
+    config_overrides: dict[str, Any]
+    """Overrides to apply to the application's configuration."""
 
 
 @dataclasses.dataclass

--- a/lib/esbonio/hatch.toml
+++ b/lib/esbonio/hatch.toml
@@ -27,7 +27,6 @@ sphinx = ["8"]
 
 [envs.hatch-test.overrides]
 matrix.sphinx.dependencies = [
-    "furo",
     "sphinx-design",
     "myst-parser",
     { value = "sphinx>=6,<7", if = ["6"] },

--- a/lib/esbonio/tests/e2e/conftest.py
+++ b/lib/esbonio/tests/e2e/conftest.py
@@ -46,6 +46,10 @@ async def client(lsp_client: LanguageClient, uri_for, tmp_path_factory):
                         workspace_uri.fs_path,
                         str(build_dir),
                     ],
+                    "configOverrides": {
+                        "html_theme": "alabaster",
+                        "html_theme_options": {},
+                    },
                     "pythonCommand": [sys.executable],
                 },
             },

--- a/lib/esbonio/tests/e2e/test_e2e_diagnostics.py
+++ b/lib/esbonio/tests/e2e/test_e2e_diagnostics.py
@@ -121,6 +121,10 @@ async def pub_client(lsp_client: LanguageClient, uri_for, tmp_path_factory):
                         workspace_uri.fs_path,
                         str(build_dir),
                     ],
+                    "configOverrides": {
+                        "html_theme": "alabaster",
+                        "html_theme_options": {},
+                    },
                     "pythonCommand": [sys.executable],
                 },
             },

--- a/lib/esbonio/tests/e2e/test_sphinx_manager.py
+++ b/lib/esbonio/tests/e2e/test_sphinx_manager.py
@@ -94,6 +94,10 @@ async def test_get_client(
                 sphinx=dict(
                     pythonCommand=[sys.executable],
                     buildCommand=["sphinx-build", "-M", "dirhtml", ".", str(tmp_path)],
+                    configOverrides={
+                        "html_theme": "alabaster",
+                        "html_theme_options": {},
+                    },
                 ),
             ),
         ),
@@ -182,6 +186,10 @@ async def test_get_client_with_many_uris(
                 sphinx=dict(
                     pythonCommand=[sys.executable],
                     buildCommand=["sphinx-build", "-M", "dirhtml", ".", str(tmp_path)],
+                    configOverrides={
+                        "html_theme": "alabaster",
+                        "html_theme_options": {},
+                    },
                 ),
             ),
         ),
@@ -234,8 +242,14 @@ async def test_get_client_with_many_uris_in_many_projects(
     server, manager = server_manager(
         dict(
             esbonio=dict(
-                sphinx=dict(pythonCommand=[sys.executable]),
-                buildCommand=["sphinx-build", "-M", "dirhtml", ".", str(tmp_path)],
+                sphinx=dict(
+                    pythonCommand=[sys.executable],
+                    buildCommand=["sphinx-build", "-M", "dirhtml", ".", str(tmp_path)],
+                    configOverrides={
+                        "html_theme": "alabaster",
+                        "html_theme_options": {},
+                    },
+                ),
             ),
         ),
     )  # Ensure that the server is ready
@@ -286,6 +300,10 @@ async def test_updated_config(
                 sphinx=dict(
                     pythonCommand=[sys.executable],
                     buildCommand=["sphinx-build", "-M", "dirhtml", ".", str(tmp_path)],
+                    configOverrides={
+                        "html_theme": "alabaster",
+                        "html_theme_options": {},
+                    },
                 ),
             ),
         ),

--- a/lib/esbonio/tests/sphinx-agent/conftest.py
+++ b/lib/esbonio/tests/sphinx-agent/conftest.py
@@ -52,6 +52,10 @@ async def client(request, uri_for, build_dir):
             demo_workspace.fs_path,
             str(build_dir),
         ],
+        config_overrides={
+            "html_theme": "alabaster",
+            "html_theme_options": {},
+        },
     )
     resolved = config.resolve(test_uri, workspace, logger)
     assert resolved is not None
@@ -82,6 +86,10 @@ def app(client, build_dir):
         outdir=str(pathlib.Path(build_dir, "html")),
         doctreedir=str(pathlib.Path(build_dir, "doctrees")),
         buildername="html",
+        confoverrides={
+            "html_theme": "alabaster",
+            "html_theme_options": {},
+        },
     )
 
     sys.path.pop(0)

--- a/lib/esbonio/tests/sphinx-agent/test_sa_create_app.py
+++ b/lib/esbonio/tests/sphinx-agent/test_sa_create_app.py
@@ -31,7 +31,13 @@ async def test_create_application(uri_for):
             WorkspaceFolder(uri=str(demo_workspace), name="demo"),
         ],
     )
-    config = SphinxConfig(python_command=[sys.executable])
+    config = SphinxConfig(
+        python_command=[sys.executable],
+        config_overrides={
+            "html_theme": "alabaster",
+            "html_theme_options": {},
+        },
+    )
     resolved = config.resolve(test_uri, workspace, logger)
     assert resolved is not None
     client = None
@@ -85,6 +91,10 @@ async def test_create_application_error(uri_for, tmp_path_factory):
             demo_workspace.fs_path,
             str(build_dir),
         ],
+        config_overrides={
+            "html_theme": "alabaster",
+            "html_theme_options": {},
+        },
     )
     resolved = config.resolve(test_uri, workspace, logger)
     assert resolved is not None


### PR DESCRIPTION
The brings back the `sphinx.configOverrides` option from the `0.x` version of `esbonio`, offering a convenient way to override parts of a project's `conf.py` file

``` json
{
    "esbonio": {
        "sphinx": {
            "pythonCommand": ["/path/to/venv/bin/python"],
            "buildCommand": ["sphinx-build", "-M", "dirhtml", "docs/", "docs/_build"],
            "configOverrides": {
                "html_theme": "alabaster",
                "html_theme_options": {},
            }
        }
    }
}
```

Closes #785