### PR TITLE
Stop injecting Python interpreter and improve Sphinx Process tree

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -25,23 +25,6 @@
             ]
         },
         {
-            "label": "Build Tests",
-            "type": "npm",
-            "script": "compile-test",
-            "isBackground": false,
-            "options": {
-                "cwd": "${workspaceRoot}/code"
-            },
-            "group": "build",
-            "presentation": {
-                "panel": "dedicated",
-                "reveal": "never",
-            },
-            "problemMatcher": [
-                "$tsc-watch"
-            ]
-        },
-        {
             "label": "Build Docs",
             "type": "shell",
             "command": "source ${workspaceRoot}/.env/bin/activate && make html",

--- a/code/changes/881.enchancement.md
+++ b/code/changes/881.enchancement.md
@@ -1,0 +1,1 @@
+The Sphinx Process tree view now includes details including `esbonio.sphinx.pythonCommand`, `esbonio.sphinx.buildCommand`, the current builder and output files

--- a/code/changes/881.misc.md
+++ b/code/changes/881.misc.md
@@ -1,0 +1,7 @@
+**IMPORTANT!**
+
+The VSCode extension will no longer automatically inject the currently active Python interpreter into the configuration sent to the server.
+It is now required for all users to set the `esbonio.sphinx.pythonCommand` option, either in your VSCode settings, or in your project's `pyproject.toml` file.
+
+This makes VSCode's behavior more predicable and brings it in line with how other editors behave.
+It also encourages the sharing of project configuration settings, which is particuarly useful if you use an [environment manager](https://docs.esbon.io/en/latest/lsp/howto/use-esbonio-with.html)

--- a/code/guides/bring-your-own-sphinx.md
+++ b/code/guides/bring-your-own-sphinx.md
@@ -4,7 +4,4 @@ While the `esbonio` language server is bundled as part of the extension, it does
 
 This is because every Sphinx project is unique with its own set of dependencies and required extensions. In order to correctly understand your project `esbonio` needs to use the same Python environment that you use to build your documentation.
 
-The Esbonio extension supports two mechanisms for selecting your Python environment.
-
-1. If the official Python extension is available, by default Esbonio will attempt to use the same environment you have configured for your workspace.
-2. Alternatively, you can use the `esbonio.sphinx.pythonCommand` setting to override this behavior.
+You can tell Esbonio which environment to use by setting the `esbonio.sphinx.pythonCommand` option. See [this guide](https://docs.esbon.io/en/latest/lsp/howto/use-esbonio-with.html) for some examples

--- a/code/package.json
+++ b/code/package.json
@@ -35,7 +35,6 @@
         "vscode-languageclient": "^9.0.1"
     },
     "devDependencies": {
-        "@types/glob": "^8.1.0",
         "@types/node": "^18",
         "@types/vscode": "1.78.0",
         "@vscode/vsce": "^2.31.1",
@@ -439,7 +438,7 @@
             "view/item/context": [
                 {
                     "command": "esbonio.sphinx.restart",
-                    "when": "view == sphinxProcesses && viewItem == process",
+                    "when": "view == sphinxProcesses && viewItem == sphinxProcess",
                     "group": "inline"
                 }
             ]

--- a/code/src/node/client.ts
+++ b/code/src/node/client.ts
@@ -338,9 +338,6 @@ export class EsbonioClient {
    * transport.
    */
   private getLanguageClientOptions(config: vscode.WorkspaceConfiguration): LanguageClientOptions {
-
-
-
     let documentSelector = config.get<TextDocumentFilter[]>("server.documentSelector")
     if (!documentSelector || documentSelector.length === 0) {
       documentSelector = Server.DEFAULT_SELECTOR
@@ -361,8 +358,7 @@ export class EsbonioClient {
               return result
             }
 
-            result.forEach(async (config, i) => {
-              await this.injectPython(params, i, config)
+            result.forEach((config) => {
               this.stripNulls(config)
             })
             return result
@@ -391,31 +387,6 @@ export class EsbonioClient {
       } else if (typeof config[k] === 'object') {
         this.stripNulls(config[k])
       }
-    }
-  }
-
-  /**
-   * Inject the user's configured Python interpreter into the configuration.
-   */
-  private async injectPython(params: ConfigurationParams, index: number, config: any) {
-    if (params.items[index].section !== "esbonio") {
-      return
-    }
-
-    if (config?.sphinx?.pythonCommand?.length > 0) {
-      return
-    }
-
-    // User has not explictly configured a Python command, try and inject the
-    // Python interpreter they have configured for this resource.
-    let scopeUri: vscode.Uri | undefined
-    let scope = params.items[index].scopeUri
-    if (scope) {
-      scopeUri = vscode.Uri.parse(scope)
-    }
-    let python = await this.python.getCmd(scopeUri)
-    if (python) {
-      config.sphinx.pythonCommand = python
     }
   }
 

--- a/code/src/node/extension.ts
+++ b/code/src/node/extension.ts
@@ -22,7 +22,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
   let previewManager = new PreviewManager(logger, context, esbonio)
   context.subscriptions.push(vscode.window.registerTreeDataProvider(
-    'sphinxProcesses', new SphinxProcessProvider(esbonio)
+    'sphinxProcesses', new SphinxProcessProvider(logger, esbonio)
   ));
 
   let config = vscode.workspace.getConfiguration("esbonio.server")


### PR DESCRIPTION
In an attempt to simplify the first time setup (#733) this PR stops the VSCode extension from automatically injecting the currently active Python interpreter into the configuration sent to the server.

This will force users to have to set the `esbonio.sphinx.pythonCommand` setting, which while annoying to those who were relying on the previous behaviour I think will be an improvement in the long run.

- It's less "magic" and makes the setup instructions the same to all user's of Esbonio (not just those using VSCode!)
- It's [relatively easy](https://docs.esbon.io/en/latest/lsp/howto/use-esbonio-with.html) to set the setting, especially if you use an environment manager like `hatch` or `poetry`
- It should encourage people to save the setting to a `pyproject.toml` file, further simplifying the setup for the Nth user to a project.

----
This PR also includes some updates to the Sphinx Process tree!

![image](https://github.com/user-attachments/assets/f2246c45-588e-4d3a-bad7-cb73b917e1f2)

Each Sphinx process can be further expanded to include

- The command used to select the python environment
- The sphinx-build command used
- The builder name and a (simple!) tree view allowing the user to inspect the build folder