### PR TITLE
Implement a `${defaultBuildDir}` placeholder variable

### DIFF
--- a/docs/lsp/howto/use-esbonio-with.rst
+++ b/docs/lsp/howto/use-esbonio-with.rst
@@ -1,3 +1,5 @@
+.. _lsp-use-with:
+
 How To Use Esbonio With...
 ==========================
 

--- a/docs/lsp/reference/configuration.rst
+++ b/docs/lsp/reference/configuration.rst
@@ -230,21 +230,42 @@ The following options control the creation of the Sphinx application object mana
    :scope: project
    :type: string[]
 
-   The ``sphinx-build`` command to use when invoking the Sphinx subprocess.
+   The ``sphinx-build`` command ``esbonio`` should use when building your documentation, for example::
+
+     ["sphinx-build", "-M", "dirhtml", "docs", "${defaultBuildDir}", "--fail-on-warning"]
+
+   This can contain any valid :external+sphinx:std:doc:`man/sphinx-build` argument however, the following arguments will be ignored and have no effect.
+
+   - ``--color``, ``-P``, ``--pdb``
+
+   Additionally, this option supports the following variables
+
+   - ``${defaultBuildDir}``: Expands to esbonio's default choice of build directory
 
 .. esbonio:config:: esbonio.sphinx.pythonCommand
    :scope: project
    :type: string[]
 
-   The command to use when launching the Python interpreter for the process hosting the Sphinx application.
-   Use this to select the Python environment you want to use when building your documentation.
+   Used to select the Python environment ``esbonio`` should use when building your documentation.
+   This can be as simple as the full path to the Python executable in your virtual environment::
+
+     ["/home/user/Projects/example/venv/bin/python"]
+
+   Or a complex command with a number of options and arguments::
+
+     ["hatch", "-e", "docs", "run", "python"]
+
+   For more examples see :ref:`lsp-use-with`
 
 .. esbonio:config:: esbonio.sphinx.cwd
    :scope: project
    :type: string
 
    The working directory from which to launch the Sphinx process.
-   If not set, this will default to the root of the workspace folder containing the project.
+   If not set
+
+   - ``esbonio`` will use the directory containing the "closest" ``pyproject.toml`` file.
+   - If no ``pyproject.toml`` file can be found, ``esbonio`` will use workspace folder containing the project.
 
 .. esbonio:config:: esbonio.sphinx.envPassthrough
    :scope: project

--- a/docs/pyproject.toml
+++ b/docs/pyproject.toml
@@ -12,8 +12,12 @@ dependencies = [
     "furo",
     "myst-parser",
     "platformdirs",
-    "pytest_lsp",
+    "pytest_lsp>=1.0b0",
+    "pygls>=2.0a0",
 ]
+
+[tool.hatch.envs.docs.env-vars]
+UV_PRERELEASE = "allow"
 
 [tool.hatch.envs.docs.scripts]
 build = "sphinx-build -M dirhtml . ./_build"

--- a/docs/pyproject.toml
+++ b/docs/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.esbonio.sphinx]
-# buildCommand = ["sphinx-build", "-M", "dirhtml", ".", "./_build"]
+buildCommand = ["sphinx-build", "-M", "dirhtml", ".", "${defaultBuildDir}"]
 pythonCommand = ["hatch", "-e", "docs", "run", "python"]
 
 [tool.hatch.envs.docs]

--- a/lib/esbonio/esbonio/server/features/sphinx_manager/client_subprocess.py
+++ b/lib/esbonio/esbonio/server/features/sphinx_manager/client_subprocess.py
@@ -11,6 +11,7 @@ import sys
 import typing
 from uuid import uuid4
 
+import platformdirs
 from pygls.client import JsonRPCClient
 from pygls.protocol import JsonRPCProtocol
 
@@ -212,6 +213,9 @@ class SubprocessSphinxClient(JsonRPCClient):
             params = types.CreateApplicationParams(
                 command=self.config.build_command,
                 config_overrides=self.config.config_overrides,
+                context={
+                    "cacheDir": platformdirs.user_cache_dir("esbonio", "swyddfa"),
+                },
             )
             self.sphinx_info = await self.protocol.send_request_async(
                 "sphinx/createApp", params

--- a/lib/esbonio/esbonio/server/features/sphinx_manager/config.py
+++ b/lib/esbonio/esbonio/server/features/sphinx_manager/config.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import hashlib
 import importlib.util
 import logging
 import pathlib
@@ -8,7 +7,6 @@ from typing import Any
 from typing import Optional
 
 import attrs
-import platformdirs
 from pygls.workspace import Workspace
 
 from esbonio.server import Uri
@@ -227,9 +225,12 @@ class SphinxConfig:
             conf_py = current / "conf.py"
             logger.debug("Trying path: %s", current)
             if conf_py.exists():
-                cache = platformdirs.user_cache_dir("esbonio", "swyddfa")
-                project = hashlib.md5(str(current).encode()).hexdigest()  # noqa: S324
-                build_dir = str(pathlib.Path(cache, project))
-                return ["sphinx-build", "-M", "dirhtml", str(current), str(build_dir)]
+                return [
+                    "sphinx-build",
+                    "-M",
+                    "dirhtml",
+                    str(current),
+                    "${defaultBuildDir}",
+                ]
 
         return []

--- a/lib/esbonio/esbonio/server/server.py
+++ b/lib/esbonio/esbonio/server/server.py
@@ -39,7 +39,9 @@ class EsbonioWorkspace(Workspace):
         uri = str(Uri.parse(doc_uri).resolve())
         return super().get_text_document(uri)
 
-    def put_text_document(self, text_document: types.TextDocumentItem):
+    def put_text_document(
+        self, text_document: types.TextDocumentItem, notebook_uri: str | None = None
+    ):
         text_document.uri = str(Uri.parse(text_document.uri).resolve())
         return super().put_text_document(text_document)
 

--- a/lib/esbonio/esbonio/server/setup.py
+++ b/lib/esbonio/esbonio/server/setup.py
@@ -85,7 +85,7 @@ def _configure_lsp_methods(server: EsbonioLanguageServer):
     ):
         # Record the version number of the document
         doc = ls.workspace.get_text_document(params.text_document.uri)
-        doc.saved_version = doc.version or 0
+        doc.saved_version = doc.version or 0  # type: ignore[attr-defined]
 
         await call_features(ls, "document_save", params)
 

--- a/lib/esbonio/esbonio/sphinx_agent/config.py
+++ b/lib/esbonio/esbonio/sphinx_agent/config.py
@@ -160,7 +160,9 @@ class SphinxConfig:
                 continue
 
             replacement = self.resolve_config_variable(match.group(1), context)
-            setattr(self, name, VARIABLE.sub(replacement, value))
+            result = VARIABLE.sub(re.escape(replacement), value)
+
+            setattr(self, name, result)
 
         build_dir = pathlib.Path(self.build_dir).resolve()
         doctree_dir = pathlib.Path(self.doctree_dir).resolve()

--- a/lib/esbonio/esbonio/sphinx_agent/config.py
+++ b/lib/esbonio/esbonio/sphinx_agent/config.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import dataclasses
+import hashlib
 import inspect
 import pathlib
+import re
 import sys
 from typing import Any
 from typing import Literal
@@ -12,6 +14,8 @@ from unittest import mock
 
 from sphinx.application import Sphinx
 from sphinx.cmd.build import main as sphinx_build
+
+VARIABLE = re.compile(r"\$\{(\w+)\}")
 
 
 @dataclasses.dataclass
@@ -128,7 +132,7 @@ class SphinxConfig:
             warning_is_error=sphinx_args.get("warningiserror", False),
         )
 
-    def to_application_args(self) -> dict[str, Any]:
+    def to_application_args(self, context: dict[str, Any]) -> dict[str, Any]:
         """Convert this into the equivalent Sphinx application arguments."""
 
         # On OSes like Fedora Silverblue, `/home` is symlinked to `/var/home`.  This
@@ -139,6 +143,25 @@ class SphinxConfig:
         # Resolving these paths here, should ensure that the agent always
         # reports the true location of any given directory.
         conf_dir = pathlib.Path(self.conf_dir).resolve()
+        self.conf_dir = str(conf_dir)
+
+        # Resolve any config variables.
+        #
+        # This is a bit hacky, but let's go with it for now. The only config variable
+        # we currently support is 'defaultBuildDir' which is derived from the value
+        # of `conf_dir`. So we resolve the full path of `conf_dir` above, then resolve
+        # the configuration variables here, before finally calling resolve() on the
+        # remaining paths below.
+        for name, value in dataclasses.asdict(self).items():
+            if not isinstance(value, str):
+                continue
+
+            if (match := VARIABLE.match(value)) is None:
+                continue
+
+            replacement = self.resolve_config_variable(match.group(1), context)
+            setattr(self, name, VARIABLE.sub(replacement, value))
+
         build_dir = pathlib.Path(self.build_dir).resolve()
         doctree_dir = pathlib.Path(self.doctree_dir).resolve()
         src_dir = pathlib.Path(self.src_dir).resolve()
@@ -159,3 +182,18 @@ class SphinxConfig:
             "warning": sys.stderr,
             "warningiserror": self.warning_is_error,
         }
+
+    def resolve_config_variable(self, name: str, context: dict[str, str]):
+        """Resolve the value for the given configuration variable."""
+
+        if name.lower() == "defaultbuilddir":
+            if (cache_dir := context.get("cacheDir")) is None:
+                raise RuntimeError(
+                    f"Unable to resolve config variable {name!r}, "
+                    "missing context value: 'cacheDir'"
+                )
+
+            project = hashlib.md5(self.conf_dir.encode()).hexdigest()  # noqa: S324
+            return str(pathlib.Path(cache_dir, project))
+
+        raise ValueError(f"Unknown configuration variable {name!r}")

--- a/lib/esbonio/esbonio/sphinx_agent/handlers/__init__.py
+++ b/lib/esbonio/esbonio/sphinx_agent/handlers/__init__.py
@@ -106,12 +106,14 @@ class SphinxHandler:
 
     def create_sphinx_app(self, request: types.CreateApplicationRequest):
         """Create a new sphinx application instance."""
-        sphinx_config = SphinxConfig.fromcli(request.params.command)
+        params = request.params
+
+        sphinx_config = SphinxConfig.fromcli(params.command)
         if sphinx_config is None:
             raise ValueError("Invalid build command")
 
-        sphinx_config.config_overrides.update(request.params.config_overrides)
-        sphinx_args = sphinx_config.to_application_args()
+        sphinx_config.config_overrides.update(params.config_overrides)
+        sphinx_args = sphinx_config.to_application_args(params.context)
         self.app = Sphinx(**sphinx_args)
 
         # Connect event handlers.

--- a/lib/esbonio/esbonio/sphinx_agent/types/__init__.py
+++ b/lib/esbonio/esbonio/sphinx_agent/types/__init__.py
@@ -1,20 +1,16 @@
 """Type definitions for the sphinx agent.
 
-This is the *only* file shared between the agent itself and the parent language server.
-For this reason this file *cannot* import anything from Sphinx.
+This is the *only* module shared between the agent itself and the parent language
+server. For this reason this module *cannot* import anything from Sphinx.
 """
 
 from __future__ import annotations
 
 import dataclasses
-import os
-import pathlib
 import re
 from typing import Any
-from typing import Callable
 from typing import Optional
 from typing import Union
-from urllib import parse
 
 from .lsp import Diagnostic
 from .lsp import DiagnosticSeverity
@@ -25,10 +21,13 @@ from .roles import MYST_ROLE
 from .roles import RST_DEFAULT_ROLE
 from .roles import RST_ROLE
 from .roles import Role
+from .uri import IS_WIN
+from .uri import Uri
 
 __all__ = (
     "Diagnostic",
     "DiagnosticSeverity",
+    "IS_WIN",
     "Location",
     "MYST_ROLE",
     "Position",
@@ -36,6 +35,7 @@ __all__ = (
     "RST_ROLE",
     "Range",
     "Role",
+    "Uri",
 )
 
 MYST_DIRECTIVE: re.Pattern = re.compile(
@@ -127,322 +127,6 @@ A number of named capture groups are available
    The value passed to the option
 
 """
-
-
-IS_WIN = os.name == "nt"
-SCHEME = re.compile(r"^[a-zA-Z][a-zA-Z\d+.-]*$")
-RE_DRIVE_LETTER_PATH = re.compile(r"^(\/?)([a-zA-Z]:)")
-
-
-# TODO: Look into upstreaming this into pygls
-#       - if it works out
-#       - when pygls drops 3.7 (Uri uses the := operator)
-@dataclasses.dataclass(frozen=True)
-class Uri:
-    """Helper class for working with URIs."""
-
-    scheme: str
-
-    authority: str
-
-    path: str
-
-    query: str
-
-    fragment: str
-
-    def __post_init__(self):
-        """Basic validation."""
-        if self.scheme is None:
-            raise ValueError("URIs must have a scheme")
-
-        if not SCHEME.match(self.scheme):
-            raise ValueError("Invalid scheme")
-
-        if self.authority and self.path and (not self.path.startswith("/")):
-            raise ValueError("Paths with an authority must start with a slash '/'")
-
-        if self.path and self.path.startswith("//") and (not self.authority):
-            raise ValueError(
-                "Paths without an authority cannot start with two slashes '//'"
-            )
-
-    def __eq__(self, other):
-        if type(other) is not type(self):
-            return False
-
-        if self.scheme != other.scheme:
-            return False
-
-        if self.authority != other.authority:
-            return False
-
-        if self.query != other.query:
-            return False
-
-        if self.fragment != other.fragment:
-            return False
-
-        if IS_WIN and self.scheme == "file":
-            # Filepaths on windows are case in-sensitive
-            if self.path.lower() != other.path.lower():
-                return False
-
-        elif self.path != other.path:
-            return False
-
-        return True
-
-    def __hash__(self):
-        if IS_WIN and self.scheme == "file":
-            # Filepaths on windows are case in-sensitive
-            path = self.path.lower()
-        else:
-            path = self.path
-
-        return hash((self.scheme, self.authority, path, self.query, self.fragment))
-
-    def __fspath__(self):
-        """Return the file system representation of this uri.
-
-        This makes Uri instances compatible with any function that expects an
-        ``os.PathLike`` object!
-        """
-        # TODO: Should we raise an exception if scheme != "file"?
-        return self.as_fs_path(preserve_case=True)
-
-    def __str__(self):
-        return self.as_string()
-
-    def __truediv__(self, other):
-        return self.join(other)
-
-    @classmethod
-    def create(
-        cls,
-        *,
-        scheme: str = "",
-        authority: str = "",
-        path: str = "",
-        query: str = "",
-        fragment: str = "",
-    ) -> Uri:
-        """Create a uri with the given attributes."""
-
-        if scheme in {"http", "https", "file"}:
-            if not path.startswith("/"):
-                path = f"/{path}"
-
-        return cls(
-            scheme=scheme,
-            authority=authority,
-            path=path,
-            query=query,
-            fragment=fragment,
-        )
-
-    @classmethod
-    def parse(cls, uri: str) -> Uri:
-        """Parse the given uri from its string representation."""
-        scheme, authority, path, _, query, fragment = parse.urlparse(uri)
-        return cls.create(
-            scheme=parse.unquote(scheme),
-            authority=parse.unquote(authority),
-            path=parse.unquote(path),
-            query=parse.unquote(query),
-            fragment=parse.unquote(fragment),
-        )
-
-    def resolve(self) -> Uri:
-        """Return the fully resolved version of this Uri."""
-
-        # This operation only makes sense for file uris
-        if self.scheme != "file":
-            return Uri.parse(str(self))
-
-        return Uri.for_file(pathlib.Path(self).resolve())
-
-    @classmethod
-    def for_file(cls, filepath: Union[str, os.PathLike[str]]) -> Uri:
-        """Create a uri based on the given filepath."""
-
-        fpath = os.fspath(filepath)
-        if IS_WIN:
-            fpath = fpath.replace("\\", "/")
-
-        if fpath.startswith("//"):
-            authority, *path = fpath[2:].split("/")
-            fpath = "/".join(path)
-        else:
-            authority = ""
-
-        return cls.create(scheme="file", authority=authority, path=fpath)
-
-    @property
-    def fs_path(self) -> Optional[str]:
-        """Return the equivalent fs path."""
-        return self.as_fs_path()
-
-    def where(self, **kwargs) -> Uri:
-        """Return an transformed version of this uri where certain components of the uri
-        have been replace with the given arguments.
-
-        Passing a value of ``None`` will remove the given component entirely.
-        """
-        keys = {"scheme", "authority", "path", "query", "fragment"}
-        valid_keys = keys.copy() & kwargs.keys()
-
-        current = {k: getattr(self, k) for k in keys}
-        replacements = {k: kwargs[k] for k in valid_keys}
-
-        return Uri.create(**{**current, **replacements})
-
-    def join(self, path: str) -> Uri:
-        """Join this Uri's path component with the given path and return the resulting
-        uri.
-
-        Parameters
-        ----------
-        path
-           The path segment to join
-
-        Returns
-        -------
-        Uri
-           The resulting uri
-        """
-
-        if not self.path:
-            raise ValueError("This uri has no path")
-
-        if IS_WIN:
-            fs_path = self.fs_path
-            if fs_path is None:
-                raise ValueError("Unable to join paths, fs_path is None")
-
-            joined = os.path.normpath(os.path.join(fs_path, path))
-            new_path = self.for_file(joined).path
-        else:
-            new_path = os.path.normpath(os.path.join(self.path, path))
-
-        return self.where(path=new_path)
-
-    def as_fs_path(self, preserve_case: bool = False) -> Optional[str]:
-        """Return the file system path correspondin with this uri."""
-        if self.path:
-            path = _normalize_path(self.path, preserve_case)
-
-            if self.authority and len(path) > 1:
-                path = f"//{self.authority}{path}"
-
-            # Remove the leading `/` from windows paths
-            elif RE_DRIVE_LETTER_PATH.match(path):
-                path = path[1:]
-
-            if IS_WIN:
-                path = path.replace("/", "\\")
-
-            return path
-
-        return None
-
-    def as_string(self, encode=True) -> str:
-        """Return a string representation of this Uri.
-
-        Parameters
-        ----------
-        encode
-           If ``True`` (the default), encode any special characters.
-
-        Returns
-        -------
-        str
-           The string representation of the Uri
-        """
-
-        # See: https://github.com/python/mypy/issues/10740
-        encoder: Callable[[str], str] = parse.quote if encode else _replace_chars  # type: ignore[assignment]
-
-        if authority := self.authority:
-            usercred, *auth = authority.split("@")
-            if len(auth) > 0:
-                *user, cred = usercred.split(":")
-                if len(user) > 0:
-                    usercred = encoder(":".join(user)) + f":{encoder(cred)}"
-                else:
-                    usercred = encoder(usercred)
-                authority = "@".join(auth)
-            else:
-                usercred = ""
-
-            authority = authority.lower()
-            *auth, port = authority.split(":")
-            if len(auth) > 0:
-                authority = encoder(":".join(auth)) + f":{port}"
-            else:
-                authority = encoder(authority)
-
-            if usercred:
-                authority = f"{usercred}@{authority}"
-
-        scheme_separator = ""
-        if authority or self.scheme == "file":
-            scheme_separator = "//"
-
-        if path := self.path:
-            path = encoder(_normalize_path(path))
-
-        if query := self.query:
-            query = encoder(query)
-
-        if fragment := self.fragment:
-            fragment = encoder(fragment)
-
-        parts = [
-            f"{self.scheme}:",
-            scheme_separator,
-            authority if authority else "",
-            path if path else "",
-            f"?{query}" if query else "",
-            f"#{fragment}" if fragment else "",
-        ]
-        return "".join(parts)
-
-
-def _replace_chars(segment: str) -> str:
-    """Replace a certain subset of characters in a uri segment"""
-    return segment.replace("#", "%23").replace("?", "%3F")
-
-
-def _normalize_path(path: str, preserve_case: bool = False) -> str:
-    """Normalise the path segment of a Uri.
-
-    Parameters
-    ----------
-    path
-       The path to normalise.
-
-    preserve_case
-       If ``True``, preserve the case of the drive label on Windows.
-       If ``False``, the drive label will be lowercased.
-
-    Returns
-    -------
-    str
-       The normalised path.
-    """
-
-    # normalize to fwd-slashes on windows,
-    # on other systems bwd-slashes are valid
-    # filename character, eg /f\oo/ba\r.txt
-    if IS_WIN:
-        path = path.replace("\\", "/")
-
-    # Normalize drive paths to lower case
-    if (not preserve_case) and (match := RE_DRIVE_LETTER_PATH.match(path)):
-        path = match.group(1) + match.group(2).lower() + path[match.end() :]
-
-    return path
 
 
 # -- DB Types

--- a/lib/esbonio/esbonio/sphinx_agent/types/__init__.py
+++ b/lib/esbonio/esbonio/sphinx_agent/types/__init__.py
@@ -144,6 +144,10 @@ Symbol = tuple[  # Represents either a document symbol or workspace symbol depen
 ]
 
 
+# -- RPC Types
+#
+# These represent the structure of the messages sent between the Sphinx agent and the
+# parent language server.
 @dataclasses.dataclass
 class CreateApplicationParams:
     """Parameters of a ``sphinx/createApp`` request."""
@@ -153,6 +157,9 @@ class CreateApplicationParams:
 
     config_overrides: dict[str, Any]
     """Overrides to apply to the application's configuration."""
+
+    context: dict[str, str] = dataclasses.field(default_factory=dict)
+    """The context in which to resolve config variables."""
 
 
 @dataclasses.dataclass

--- a/lib/esbonio/esbonio/sphinx_agent/types/uri.py
+++ b/lib/esbonio/esbonio/sphinx_agent/types/uri.py
@@ -1,0 +1,325 @@
+from __future__ import annotations
+
+import dataclasses
+import os
+import pathlib
+import re
+from typing import Callable
+from typing import Optional
+from typing import Union
+from urllib import parse
+
+IS_WIN = os.name == "nt"
+SCHEME = re.compile(r"^[a-zA-Z][a-zA-Z\d+.-]*$")
+RE_DRIVE_LETTER_PATH = re.compile(r"^(\/?)([a-zA-Z]:)")
+
+
+# TODO: Look into upstreaming this into pygls
+#       - if it works out
+#       - when pygls drops 3.7 (Uri uses the := operator)
+@dataclasses.dataclass(frozen=True)
+class Uri:
+    """Helper class for working with URIs."""
+
+    scheme: str
+
+    authority: str
+
+    path: str
+
+    query: str
+
+    fragment: str
+
+    def __post_init__(self):
+        """Basic validation."""
+        if self.scheme is None:
+            raise ValueError("URIs must have a scheme")
+
+        if not SCHEME.match(self.scheme):
+            raise ValueError("Invalid scheme")
+
+        if self.authority and self.path and (not self.path.startswith("/")):
+            raise ValueError("Paths with an authority must start with a slash '/'")
+
+        if self.path and self.path.startswith("//") and (not self.authority):
+            raise ValueError(
+                "Paths without an authority cannot start with two slashes '//'"
+            )
+
+    def __eq__(self, other):
+        if type(other) is not type(self):
+            return False
+
+        if self.scheme != other.scheme:
+            return False
+
+        if self.authority != other.authority:
+            return False
+
+        if self.query != other.query:
+            return False
+
+        if self.fragment != other.fragment:
+            return False
+
+        if IS_WIN and self.scheme == "file":
+            # Filepaths on windows are case in-sensitive
+            if self.path.lower() != other.path.lower():
+                return False
+
+        elif self.path != other.path:
+            return False
+
+        return True
+
+    def __hash__(self):
+        if IS_WIN and self.scheme == "file":
+            # Filepaths on windows are case in-sensitive
+            path = self.path.lower()
+        else:
+            path = self.path
+
+        return hash((self.scheme, self.authority, path, self.query, self.fragment))
+
+    def __fspath__(self):
+        """Return the file system representation of this uri.
+
+        This makes Uri instances compatible with any function that expects an
+        ``os.PathLike`` object!
+        """
+        # TODO: Should we raise an exception if scheme != "file"?
+        return self.as_fs_path(preserve_case=True)
+
+    def __str__(self):
+        return self.as_string()
+
+    def __truediv__(self, other):
+        return self.join(other)
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        scheme: str = "",
+        authority: str = "",
+        path: str = "",
+        query: str = "",
+        fragment: str = "",
+    ) -> Uri:
+        """Create a uri with the given attributes."""
+
+        if scheme in {"http", "https", "file"}:
+            if not path.startswith("/"):
+                path = f"/{path}"
+
+        return cls(
+            scheme=scheme,
+            authority=authority,
+            path=path,
+            query=query,
+            fragment=fragment,
+        )
+
+    @classmethod
+    def parse(cls, uri: str) -> Uri:
+        """Parse the given uri from its string representation."""
+        scheme, authority, path, _, query, fragment = parse.urlparse(uri)
+        return cls.create(
+            scheme=parse.unquote(scheme),
+            authority=parse.unquote(authority),
+            path=parse.unquote(path),
+            query=parse.unquote(query),
+            fragment=parse.unquote(fragment),
+        )
+
+    def resolve(self) -> Uri:
+        """Return the fully resolved version of this Uri."""
+
+        # This operation only makes sense for file uris
+        if self.scheme != "file":
+            return Uri.parse(str(self))
+
+        return Uri.for_file(pathlib.Path(self).resolve())
+
+    @classmethod
+    def for_file(cls, filepath: Union[str, os.PathLike[str]]) -> Uri:
+        """Create a uri based on the given filepath."""
+
+        fpath = os.fspath(filepath)
+        if IS_WIN:
+            fpath = fpath.replace("\\", "/")
+
+        if fpath.startswith("//"):
+            authority, *path = fpath[2:].split("/")
+            fpath = "/".join(path)
+        else:
+            authority = ""
+
+        return cls.create(scheme="file", authority=authority, path=fpath)
+
+    @property
+    def fs_path(self) -> Optional[str]:
+        """Return the equivalent fs path."""
+        return self.as_fs_path()
+
+    def where(self, **kwargs) -> Uri:
+        """Return an transformed version of this uri where certain components of the uri
+        have been replace with the given arguments.
+
+        Passing a value of ``None`` will remove the given component entirely.
+        """
+        keys = {"scheme", "authority", "path", "query", "fragment"}
+        valid_keys = keys.copy() & kwargs.keys()
+
+        current = {k: getattr(self, k) for k in keys}
+        replacements = {k: kwargs[k] for k in valid_keys}
+
+        return Uri.create(**{**current, **replacements})
+
+    def join(self, path: str) -> Uri:
+        """Join this Uri's path component with the given path and return the resulting
+        uri.
+
+        Parameters
+        ----------
+        path
+           The path segment to join
+
+        Returns
+        -------
+        Uri
+           The resulting uri
+        """
+
+        if not self.path:
+            raise ValueError("This uri has no path")
+
+        if IS_WIN:
+            fs_path = self.fs_path
+            if fs_path is None:
+                raise ValueError("Unable to join paths, fs_path is None")
+
+            joined = os.path.normpath(os.path.join(fs_path, path))
+            new_path = self.for_file(joined).path
+        else:
+            new_path = os.path.normpath(os.path.join(self.path, path))
+
+        return self.where(path=new_path)
+
+    def as_fs_path(self, preserve_case: bool = False) -> Optional[str]:
+        """Return the file system path correspondin with this uri."""
+        if self.path:
+            path = _normalize_path(self.path, preserve_case)
+
+            if self.authority and len(path) > 1:
+                path = f"//{self.authority}{path}"
+
+            # Remove the leading `/` from windows paths
+            elif RE_DRIVE_LETTER_PATH.match(path):
+                path = path[1:]
+
+            if IS_WIN:
+                path = path.replace("/", "\\")
+
+            return path
+
+        return None
+
+    def as_string(self, encode=True) -> str:
+        """Return a string representation of this Uri.
+
+        Parameters
+        ----------
+        encode
+           If ``True`` (the default), encode any special characters.
+
+        Returns
+        -------
+        str
+           The string representation of the Uri
+        """
+
+        # See: https://github.com/python/mypy/issues/10740
+        encoder: Callable[[str], str] = parse.quote if encode else _replace_chars  # type: ignore[assignment]
+
+        if authority := self.authority:
+            usercred, *auth = authority.split("@")
+            if len(auth) > 0:
+                *user, cred = usercred.split(":")
+                if len(user) > 0:
+                    usercred = encoder(":".join(user)) + f":{encoder(cred)}"
+                else:
+                    usercred = encoder(usercred)
+                authority = "@".join(auth)
+            else:
+                usercred = ""
+
+            authority = authority.lower()
+            *auth, port = authority.split(":")
+            if len(auth) > 0:
+                authority = encoder(":".join(auth)) + f":{port}"
+            else:
+                authority = encoder(authority)
+
+            if usercred:
+                authority = f"{usercred}@{authority}"
+
+        scheme_separator = ""
+        if authority or self.scheme == "file":
+            scheme_separator = "//"
+
+        if path := self.path:
+            path = encoder(_normalize_path(path))
+
+        if query := self.query:
+            query = encoder(query)
+
+        if fragment := self.fragment:
+            fragment = encoder(fragment)
+
+        parts = [
+            f"{self.scheme}:",
+            scheme_separator,
+            authority if authority else "",
+            path if path else "",
+            f"?{query}" if query else "",
+            f"#{fragment}" if fragment else "",
+        ]
+        return "".join(parts)
+
+
+def _replace_chars(segment: str) -> str:
+    """Replace a certain subset of characters in a uri segment"""
+    return segment.replace("#", "%23").replace("?", "%3F")
+
+
+def _normalize_path(path: str, preserve_case: bool = False) -> str:
+    """Normalise the path segment of a Uri.
+
+    Parameters
+    ----------
+    path
+       The path to normalise.
+
+    preserve_case
+       If ``True``, preserve the case of the drive label on Windows.
+       If ``False``, the drive label will be lowercased.
+
+    Returns
+    -------
+    str
+       The normalised path.
+    """
+
+    # normalize to fwd-slashes on windows,
+    # on other systems bwd-slashes are valid
+    # filename character, eg /f\oo/ba\r.txt
+    if IS_WIN:
+        path = path.replace("\\", "/")
+
+    # Normalize drive paths to lower case
+    if (not preserve_case) and (match := RE_DRIVE_LETTER_PATH.match(path)):
+        path = match.group(1) + match.group(2).lower() + path[match.end() :]
+
+    return path


### PR DESCRIPTION
Unless esbonio finds a `sphinx-build` command to use from the user's config it will attempt to guess something reasonable. During this process it generates a default build directory to use, in a subfolder of `platformdirs.user_cache_dir()` so that it does not interfere with the user's files.

Up until now, the moment a user sets their own `sphinx-build` command this behavior is lost, which can lead to issues on some systems.

This PR introduces a `${defaultBuildDir}` placeholder value that the user can use to provide their own build flags, while maintaining the default choice of build directory provided by esbonio.

Closes #865