### PR TITLE
code: Use `vscode.env.asExternalUri` to generate preview uris

### DIFF
--- a/code/changes/896.fix.md
+++ b/code/changes/896.fix.md
@@ -1,0 +1,1 @@
+The preview window should now work when using Codespaces

--- a/code/src/node/preview.ts
+++ b/code/src/node/preview.ts
@@ -141,7 +141,21 @@ export class PreviewManager {
       return
     }
 
-    this.panel.webview.postMessage({ 'show': params.uri })
+    let panel = this.panel
+    let uri = vscode.Uri.parse(params.uri)
+
+    // Needed so that previews work in Codespaces
+    // see: https://github.com/swyddfa/esbonio/issues/896
+    vscode.env.asExternalUri(uri).then(
+      extUri => {
+        this.logger.debug(`${uri.toString(true)} -> asExternalUri -> ${extUri.toString(true)}`)
+        panel.webview.postMessage({ 'show': extUri.toString(true) })
+      },
+      err => {
+        this.logger.error(`Unable to convert uri to an external uri: ${err}`)
+      }
+    )
+
   }
 
   private showInternalDocument(params: ShowDocumentParams) {

--- a/code/src/node/preview.ts
+++ b/code/src/node/preview.ts
@@ -221,7 +221,6 @@ export class PreviewManager {
 
     let scriptNonce = getNonce()
     let cssNonce = getNonce()
-    this.logger.debug(`Generating HTML for origin: ${origin}`)
 
     return `
 <!DOCTYPE html>
@@ -231,7 +230,11 @@ export class PreviewManager {
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="Content-Security-Policy"
-        content="default-src 'none'; style-src 'nonce-${cssNonce}'; script-src 'nonce-${scriptNonce}'; frame-src ${origin}/" />
+        content="default-src 'none';
+                 style-src 'nonce-${cssNonce}';
+                 style-src-attr 'unsafe-inline';
+                 script-src 'nonce-${scriptNonce}';
+                 frame-src ${origin}/" />
 
   <style nonce="${cssNonce}">
     * { box-sizing: border-box;}

--- a/code/src/node/preview.ts
+++ b/code/src/node/preview.ts
@@ -148,10 +148,13 @@ export class PreviewManager {
     // see: https://github.com/swyddfa/esbonio/issues/896
     vscode.env.asExternalUri(uri).then(
       extUri => {
-        this.logger.debug(`${uri.toString(true)} -> asExternalUri -> ${extUri.toString(true)}`)
+        // Annoyingly, asExternalUri doesn't preserve attributes like `path` or `query`
+        let previewUri = uri.with({ scheme: extUri.scheme, authority: extUri.authority })
+        let origin = `${previewUri.scheme}://${previewUri.authority}`
+        this.logger.debug(`asExternalUri('${uri.toString(true)}') -> '${previewUri.toString(true)}'`)
 
-        panel.webview.html = this.getWebViewHTML(`${extUri.scheme}://${extUri.authority}`)
-        panel.webview.postMessage({ 'show': extUri.toString(true) })
+        panel.webview.html = this.getWebViewHTML(origin)
+        panel.webview.postMessage({ 'show': previewUri.toString(true) })
       },
       err => {
         this.logger.error(`Unable to convert uri to an external uri: ${err}`)

--- a/code/src/node/preview.ts
+++ b/code/src/node/preview.ts
@@ -336,8 +336,6 @@ export class PreviewManager {
     const noContent = document.getElementById("no-content")
     const status = document.getElementById("status")
 
-    console.debug(window.location)
-
     // Restore previous page?
     const previousState = vscode.getState()
     if (previousState && previousState.url) {
@@ -349,7 +347,7 @@ export class PreviewManager {
       let message = event.data
 
       // Control messages coming from the webview hosting this page
-      if (event.origin.startsWith("vscode-webview://")) {
+      if (event.origin === window.location.origin) {
 
         if (message.show === "<nothing>") {
           status.style.display = "none"

--- a/lib/esbonio/esbonio/server/features/preview_manager/__init__.py
+++ b/lib/esbonio/esbonio/server/features/preview_manager/__init__.py
@@ -188,14 +188,15 @@ class PreviewManager(server.LanguageFeature):
         server = await self.preview
         webview = await self.webview
 
-        query_params: dict[str, Any] = dict(ws=webview.port)
+        host = "localhost"
+        query_params: dict[str, Any] = dict(ws=f"ws://{host}:{webview.port}")
 
         if self.config.show_line_markers:
             query_params["show-markers"] = True
 
         uri = Uri.create(
             scheme="http",
-            authority=f"localhost:{server.port}",
+            authority=f"{host}:{server.port}",
             path=self.build_path,
             query=urlencode(query_params),
         )

--- a/lib/esbonio/esbonio/sphinx_agent/static/webview.js
+++ b/lib/esbonio/esbonio/sphinx_agent/static/webview.js
@@ -216,16 +216,12 @@ function renderLineMarkers() {
     document.body.append(markerStyle)
 }
 
-const host = window.location.hostname;
-const queryString = window.location.search;
-const queryParams = new URLSearchParams(queryString);
-const ws = parseInt(queryParams.get("ws"));
+const queryParams = new URLSearchParams(window.location.search);
 const showMarkers = queryParams.has("show-markers")
+const wsUrl = queryParams.get("ws");
 
-const wsServer = `ws://${host}:${ws}`
-console.debug(`Connecting to '${wsServer}'...`)
-
-const socket = new WebSocket(wsServer);
+console.debug(`Connecting to '${wsUrl}'...`)
+const socket = new WebSocket(wsUrl);
 let connected = false
 
 function sendMessage(data) {
@@ -242,7 +238,7 @@ const handlers = {
         console.debug("Reloading page...")
         window.location.reload()
     },
-    "view/scroll": (params) => {scrollViewTo(params.uri, params.line)}
+    "view/scroll": (params) => { scrollViewTo(params.uri, params.line) }
 }
 
 function handle(message) {
@@ -291,7 +287,7 @@ function main() {
         renderLineMarkers()
     }
 
-    rewriteInternalLinks(ws)
+    rewriteInternalLinks(wsUrl)
 
     // Are we in an <iframe>?
     if (window.parent !== window.top) {


### PR DESCRIPTION
This looks it fixes #896

- The language server now passes the entire WebSocket connection string via the `ws` query parameter e.g. `?ws=ws://localhost:1234`
- The VSCode extension calls `vscode.env.asExternalUri` on both the `http://` and `ws://` URIs which triggers the relevant ports to be forwarded when run in CodeSpaces
- Includes fixes for assumptions that are broken when run in the context of CodeSpaces