### PR TITLE
Add support for missing extensions

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,27 +1,6 @@
 {
     "version": "0.2.0",
-    "inputs": [
-        {
-            "id": "workspace",
-            "type": "pickString",
-            "description": "Pick the workspace root for this session",
-            "default": "code/",
-            "options": [
-                {
-                    "label": "code",
-                    "value": "code"
-                },
-                {
-                    "label": "docs",
-                    "value": "docs"
-                },
-                {
-                    "label": "demo",
-                    "value": "lib/esbonio/tests/workspaces/demo"
-                },
-            ]
-        }
-    ],
+    "inputs": [],
     "configurations": [
         {
             "name": "VSCode Extension",
@@ -39,38 +18,8 @@
             "preLaunchTask": "${defaultBuildTask}",
         },
         {
-            "name": "VSCode Web Extension",
-            "type": "extensionHost",
-            "debugWebWorkerHost": true,
-            "request": "launch",
-            "args": [
-                "--extensionDevelopmentPath=${workspaceRoot}/code",
-                "--extensionDevelopmentKind=web",
-                "--folder-uri=${workspaceRoot}/${input:workspace}"
-            ],
-            "outFiles": [
-                "${workspaceRoot}/code/dist/browser/**/*.js"
-            ],
-            "preLaunchTask": "${defaultBuildTask}",
-        },
-        {
-            "name": "Docs",
-            "type": "python",
-            "request": "launch",
-            "module": "sphinx.cmd.build",
-            "args": [
-                "-M",
-                "html",
-                ".",
-                "_build",
-                "-Ea"
-            ],
-            "python": "${command:python.interpreterPath}",
-            "cwd": "${workspaceFolder}/docs"
-        },
-        {
             "name": "pytest: esbonio",
-            "type": "python",
+            "type": "debugpy",
             "request": "launch",
             "module": "pytest",
             "justMyCode": false,
@@ -84,7 +33,7 @@
         },
         {
             "name": "Python: Attach",
-            "type": "python",
+            "type": "debugpy",
             "request": "attach",
             "connect": {
                 "host": "localhost",
@@ -92,11 +41,12 @@
             },
             "pathMappings": [
                 {
-                    "localRoot": "${workspaceFolder}/lib/esbonio",
+                    "localRoot": "${workspaceFolder}",
                     "remoteRoot": "."
                 }
             ],
-            "justMyCode": false
+            "justMyCode": false,
+            "subProcess": true,
         },
     ],
 }

--- a/lib/esbonio/changes/912.fix.md
+++ b/lib/esbonio/changes/912.fix.md
@@ -1,0 +1,1 @@
+Esbonio should once again be able to parse `sphinx-build` command line arguments for versions of Sphinx `>=8.1`

--- a/lib/esbonio/changes/913.enhancement.md
+++ b/lib/esbonio/changes/913.enhancement.md
@@ -1,0 +1,1 @@
+The language server should now also work with an incomplete Python environment. If one or more Sphinx extensions are missing, esbonio will still be able to run a build and report the missing extensions as a diagnostic

--- a/lib/esbonio/esbonio/sphinx_agent/config.py
+++ b/lib/esbonio/esbonio/sphinx_agent/config.py
@@ -112,6 +112,11 @@ class SphinxConfig:
         values = m_Sphinx.call_args[0]
         sphinx_args = {k: v for k, v in zip(keys, values)}
 
+        # Sphinx 8.1 changed the way arguments are passed to the `Sphinx` class.
+        # See: https://github.com/swyddfa/esbonio/issues/912
+        if len(values) == 0:
+            sphinx_args = m_Sphinx.call_args.kwargs
+
         if sphinx_args is None:
             return None
 

--- a/lib/esbonio/esbonio/sphinx_agent/handlers/diagnostics.py
+++ b/lib/esbonio/esbonio/sphinx_agent/handlers/diagnostics.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from sphinx.config import Config
 
 from ..app import Database
@@ -18,6 +16,7 @@ DIAGNOSTICS_TABLE = Database.Table(
 
 def init_db(app: Sphinx, config: Config):
     app.esbonio.db.ensure_table(DIAGNOSTICS_TABLE)
+    sync_diagnostics(app)
 
 
 def clear_diagnostics(app: Sphinx, docname: str, source):
@@ -26,7 +25,7 @@ def clear_diagnostics(app: Sphinx, docname: str, source):
     app.esbonio.log.diagnostics.pop(uri, None)
 
 
-def sync_diagnostics(app: Sphinx, exc: Optional[Exception]):
+def sync_diagnostics(app: Sphinx, *args):
     app.esbonio.db.clear_table(DIAGNOSTICS_TABLE)
 
     results = []

--- a/lib/esbonio/tests/sphinx-agent/test_sa_unit.py
+++ b/lib/esbonio/tests/sphinx-agent/test_sa_unit.py
@@ -9,6 +9,7 @@ import typing
 from unittest import mock
 
 import pytest
+from sphinx import version_info as sphinx_version
 
 from esbonio.sphinx_agent.config import SphinxConfig
 from esbonio.sphinx_agent.log import DiagnosticFilter
@@ -20,6 +21,11 @@ if typing.TYPE_CHECKING:
 
 
 logger = logging.getLogger(__name__)
+
+
+sphinx_lt_81 = sphinx_version[0] < 8 or (
+    sphinx_version[0] == 8 and sphinx_version[1] < 1
+)
 
 
 def application_args(**kwargs) -> dict[str, Any]:
@@ -231,7 +237,9 @@ def application_args(**kwargs) -> dict[str, Any]:
                 doctreedir=os.path.join("out", "doctrees"),
                 buildername="html",
                 warningiserror=True,
-                keep_going=True,
+                # --keep-going ignored since v8.1
+                # https://github.com/sphinx-doc/sphinx/pull/12743/files#diff-4aea2ac365ab5325b530ac42efc67feac98db110e7f943ea13b5cf88f4260e59
+                keep_going=sphinx_lt_81,
             ),
         ),
         (
@@ -421,7 +429,9 @@ def application_args(**kwargs) -> dict[str, Any]:
                 doctreedir=os.path.join("out", ".doctrees"),
                 buildername="html",
                 warningiserror=True,
-                keep_going=True,
+                # --keep-going ignored since v8.1
+                # https://github.com/sphinx-doc/sphinx/pull/12743/files#diff-4aea2ac365ab5325b530ac42efc67feac98db110e7f943ea13b5cf88f4260e59
+                keep_going=sphinx_lt_81,
             ),
         ),
     ],


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/6d69799f-a8a3-48d0-b782-f8f7739dfaa8)

In an attempt to help with first-time setup issues, this PR enables `esbonio` to continue to work when configured to use an incomplete environment (though for obvious reasons `sphinx` itself still has to be present). It will suppress errors generated from missing extensions allowing users to continue to work - albeit with reduced knowledge of their project.

When possible, the server will report any missing extension modules as a diagnostic

This PR also fixes #912