### PR TITLE
Postpone diagnostic collection until everything was emitted

### DIFF
--- a/lib/esbonio/changes/925.fix.md
+++ b/lib/esbonio/changes/925.fix.md
@@ -1,0 +1,1 @@
+The sphinx agent should now be able to collect diagnostics from extensions that make use of the `build-finished` event e.g. sphinx-needs by @AlexanderLanin

--- a/lib/esbonio/esbonio/sphinx_agent/handlers/diagnostics.py
+++ b/lib/esbonio/esbonio/sphinx_agent/handlers/diagnostics.py
@@ -45,4 +45,8 @@ def setup(app: Sphinx):
     # TODO: Support for Sphinx v7+
     # app.connect("include-read")
 
-    app.connect("build-finished", sync_diagnostics)
+    # sync_diagnostics needs to run after all diagnostics have been emitted.
+    # This ensures proper synchronization of data, as some extensions, like
+    # sphinx-needs, emit diagnostics during the "build-finished" event.
+    # Setting priority to 900 ensures this handler runs after typical operations.
+    app.connect("build-finished", sync_diagnostics, priority=900)


### PR DESCRIPTION
Collecting diagnostics at build-finished is too early, as other extension may emit at build-finished. Setting priority to 501 might be enough (default is 500). But 900 should be safer.

Tested locally with a sphinx-needs installation.

Closes #925