### PR TITLE
Implement a `${venv:<path>}` config variable

### DIFF
--- a/docs/lsp/getting-started.rst
+++ b/docs/lsp/getting-started.rst
@@ -147,7 +147,7 @@ With the environment created, we now need to tell Esbonio to use it
 
         [tool.esbonio.sphinx]
         buildCommand = ["sphinx-build", "-M", "dirhtml", ".", "./_build"]
-      + pythonCommand = ["env/bin/python"]
+      + pythonCommand = ["${venv:env}"]
 
 #. Save the file, Esbonio will detect the configuration change and automatically restart its background Sphinx process within the newly created environment
 
@@ -157,7 +157,7 @@ With the environment created, we now need to tell Esbonio to use it
 Next Steps
 ----------
 
-That's all you need to get started, you should now be able to start using Esbonio in your own projects!
+That's all you need to get started, you should now be able to make use of Esbonio in your own projects!
 
 If you like, you can continue exploring the demo project to discover some of the other features Esbonio provides by clicking either
 

--- a/docs/lsp/howto/use-esbonio-with.rst
+++ b/docs/lsp/howto/use-esbonio-with.rst
@@ -29,8 +29,32 @@ Then you should set :esbonio:conf:`esbonio.sphinx.pythonCommand` to
    [tool.esbonio.sphinx]
    pythonCommand = ["hatch", "-e", "docs", "run", "python"]
 
-... Poetry
-----------
+Pipenv
+------
+
+If your project uses `Pipenv <https://pipenv.pypa.io/en/latest/index.html>`__ for its dependency management
+
+.. code-block:: ini
+
+   [[source]]
+   url = "https://pypi.org/simple"
+   verify_ssl = true
+   name = "pypi"
+
+   [packages]
+   furo = "*"
+   sphinx = "*"
+   sphinx-design = "*"
+
+Then :esbonio:conf:`esbonio.sphinx.pythonCommand` should be set to
+
+.. code-block:: toml
+
+   [tool.esbonio.sphinx]
+   pythonCommand = ["pipenv", "run", "python"]
+
+Poetry
+------
 
 Given a set of dependencies managed through `Poetry <https://python-poetry.org/>`__
 

--- a/docs/lsp/howto/use-esbonio-with.rst
+++ b/docs/lsp/howto/use-esbonio-with.rst
@@ -6,8 +6,8 @@ How To Use Esbonio With...
 There are (almost!) as many ways to manage a Python environment as there are packages on PyPi!
 This guide outlines how to configure ``esbonio`` to use the right environment for your project.
 
-... Hatch
----------
+Hatch
+-----
 
 If for example, you used `hatch <https://hatch.pypa.io/latest/>`__ to define an environment in which you build your documentation
 
@@ -85,8 +85,8 @@ Then you should set :esbonio:conf:`esbonio.sphinx.pythonCommand` to
    [tool.esbonio.sphinx]
    pythonCommand = ["poetry", "run", "python"]
 
-... venv / virtualenv
----------------------
+venv / virtualenv
+-----------------
 
 .. tip::
 
@@ -112,7 +112,7 @@ Assuming you already have an envrionment that you use to build your documentatio
    sphinxcontrib-serializinghtml 1.1.5
    urllib3                       2.1.0
 
-Then you set :esbonio:conf:`esbonio.sphinx.pythonCommand` to the full path to the ``python`` executable contained in the environment (which will be slightly different depending on your operating system)
+Then set :esbonio:conf:`esbonio.sphinx.pythonCommand` to the full path to the ``python`` executable contained in the environment (which will be slightly different depending on your operating system)
 
 .. tab-set::
 
@@ -128,4 +128,24 @@ Then you set :esbonio:conf:`esbonio.sphinx.pythonCommand` to the full path to th
       .. code-block:: toml
 
          [tool.esbonio.sphinx]
-         pythonCommand = ["C:\\Users\\user\\Projects\\myproject\\Scripts\\python.exe"]
+         pythonCommand = ["C:\\Users\\user\\Projects\\myproject\\venv\\Scripts\\python.exe"]
+
+Alternatively, you can use the ``${venv:<path>}`` configuration variable, this allows you to provide just the path to the ``venv`` folder and ``esbonio`` will expand it to the correct path to the Python executable for your platform.
+``<path>`` can either be an absolute path, or relative to the folder containing your ``pyproject.toml`` file.
+
+For example, say your project had the following structure
+
+.. code-block:: console
+
+   $ tree myproject
+   myproject
+   ├── docs
+   │   └── pyproject.toml
+   └── venv
+
+Then your ``pyproject.toml`` might look something like the following.
+
+.. code-block:: toml
+
+   [tool.esbonio.sphinx]
+   pythonCommand = ["${venv:../venv}"]

--- a/lib/esbonio/changes/914.enhancement.md
+++ b/lib/esbonio/changes/914.enhancement.md
@@ -1,0 +1,1 @@
+Add support for `${venv:<path>}` config variable to `esbonio.sphinx.pythonCommand`

--- a/lib/esbonio/esbonio/server/features/sphinx_manager/config.py
+++ b/lib/esbonio/esbonio/server/features/sphinx_manager/config.py
@@ -3,14 +3,18 @@ from __future__ import annotations
 import importlib.util
 import logging
 import pathlib
+import re
 import sys
 from typing import Any
 from typing import Optional
 
 import attrs
+from pygls import IS_WIN
 from pygls.workspace import Workspace
 
 from esbonio.server import Uri
+
+VARIABLE = re.compile(r"\$\{([^}]+)\}")
 
 
 def get_module_path(module: str) -> Optional[pathlib.Path]:
@@ -97,12 +101,12 @@ class SphinxConfig:
            The fully resolved config object to use.
            If ``None``, a valid configuration could not be created.
         """
-        python_command, python_path = self._resolve_python(logger)
-        if len(python_path) == 0 or len(python_command) == 0:
+
+        if (cwd := self._resolve_cwd(uri, workspace, logger)) is None:
             return None
 
-        cwd = self._resolve_cwd(uri, workspace, logger)
-        if cwd is None:
+        python_command, python_path = self._resolve_python(logger, cwd)
+        if len(python_path) == 0 or len(python_command) == 0:
             return None
 
         build_command = self._resolve_build_command(uri, logger)
@@ -167,7 +171,7 @@ class SphinxConfig:
         return None
 
     def _resolve_python(
-        self, logger: logging.Logger
+        self, logger: logging.Logger, cwd: str
     ) -> tuple[list[str], list[pathlib.Path]]:
         """Return the python configuration to use when launching the sphinx agent.
 
@@ -220,6 +224,9 @@ class SphinxConfig:
             python_path.append(fallback_env)
             python_command.extend([sys.executable, "-S"])
 
+        else:
+            python_command = [_resolve_variable(c, cwd) for c in python_command]
+
         return python_command, python_path
 
     def _resolve_build_command(self, uri: Uri, logger: logging.Logger) -> list[str]:
@@ -270,3 +277,41 @@ class SphinxConfig:
                 ]
 
         return []
+
+
+def _resolve_variable(arg: str, cwd: str) -> str:
+    """Resolve the configuration variables in the given argument, if any.
+
+    Parameters
+    ----------
+    arg
+       The string containing the vatiables to resolve
+
+    cwd
+       The current working directory of the configuration.
+    """
+
+    if (match := VARIABLE.match(arg)) is None:
+        return arg
+
+    varname = match.group(1)
+
+    if varname.startswith("venv:"):
+        env = varname.replace("venv:", "")
+        return _resolve_variable_venv(env, cwd)
+
+    raise ValueError(f"Undefined variable: {varname!r}")
+
+
+def _resolve_variable_venv(env: str, cwd: str) -> str:
+    """Resolve the ``${venv:<path>}`` config variable"""
+    if IS_WIN:
+        envpath = pathlib.Path(env, "Scripts", "python.exe")
+    else:
+        envpath = pathlib.Path(env, "bin", "python")
+
+    if envpath.is_absolute():
+        return str(envpath)
+    else:
+        envpath = cwd / envpath
+        return str(envpath.resolve())

--- a/lib/esbonio/tests/server/features/test_sphinx_config.py
+++ b/lib/esbonio/tests/server/features/test_sphinx_config.py
@@ -6,6 +6,7 @@ from typing import Optional
 
 import pytest
 from lsprotocol.types import WorkspaceFolder
+from pygls import IS_WIN
 from pygls.workspace import Workspace
 
 from esbonio.server import Uri
@@ -15,10 +16,15 @@ logger = logging.getLogger(__name__)
 
 
 # Default values
-CWD = os.path.join(".", "path", "to", "workspace")[1:]
 PYTHON_CMD = ["/bin/python"]
 BUILD_CMD = ["sphinx-build", "-M", "html", "src", "dest"]
 PYPATH = [pathlib.Path("/path/to/site-packages/esbonio")]
+
+if IS_WIN:
+    CWD = r"c:\path\to\workspace"
+else:
+    CWD = "/path/to/workspace"
+
 
 # The value of FALLBACK_ENV must actually exist somewhere on the filesystem
 # But for the tests here, the actual location doesn't really matter
@@ -76,7 +82,7 @@ def mk_uri(path: str) -> str:
                 cwd=CWD,
             ),
         ),
-        (  # If only a ``root_uri`` is given use that.
+        pytest.param(  # If only a ``root_uri`` is given use that.
             "file:///path/to/workspace/file.rst",
             Workspace(mk_uri(CWD)),
             SphinxConfig(
@@ -90,6 +96,23 @@ def mk_uri(path: str) -> str:
                 python_path=PYPATH,
                 cwd=CWD,
             ),
+            marks=pytest.mark.skipif(IS_WIN, reason="windows"),
+        ),
+        pytest.param(  # If only a ``root_uri`` is given use that.
+            "file:///c:/path/to/workspace/file.rst",
+            Workspace(mk_uri(CWD)),
+            SphinxConfig(
+                python_command=PYTHON_CMD,
+                build_command=BUILD_CMD,
+                python_path=PYPATH,
+            ),
+            SphinxConfig(
+                python_command=PYTHON_CMD,
+                build_command=BUILD_CMD,
+                python_path=PYPATH,
+                cwd=CWD,
+            ),
+            marks=pytest.mark.skipif(not IS_WIN, reason="windows only"),
         ),
         (  # Assuming that the requested uri resides within it.
             "file:///path/to/other/workspace/file.rst",
@@ -101,7 +124,7 @@ def mk_uri(path: str) -> str:
             ),
             None,
         ),
-        (  # Otherwise, prefer workspace_folders.
+        pytest.param(  # Otherwise, prefer workspace_folders.
             "file:///path/to/workspace/file.rst",
             Workspace(
                 "file:///path/to",
@@ -118,6 +141,26 @@ def mk_uri(path: str) -> str:
                 python_path=PYPATH,
                 cwd=CWD,
             ),
+            marks=pytest.mark.skipif(IS_WIN, reason="windows"),
+        ),
+        pytest.param(  # Otherwise, prefer workspace_folders.
+            "file:///c:/path/to/workspace/file.rst",
+            Workspace(
+                "file:///c:/path/to",
+                workspace_folders=[WorkspaceFolder(mk_uri(CWD), "workspace")],
+            ),
+            SphinxConfig(
+                python_command=PYTHON_CMD,
+                build_command=BUILD_CMD,
+                python_path=PYPATH,
+            ),
+            SphinxConfig(
+                python_command=PYTHON_CMD,
+                build_command=BUILD_CMD,
+                python_path=PYPATH,
+                cwd=CWD,
+            ),
+            marks=pytest.mark.skipif(not IS_WIN, reason="windows only"),
         ),
         (  # Handle multi-root scenarios.
             "file:///path/to/workspace-b/file.rst",
@@ -203,6 +246,158 @@ def mk_uri(path: str) -> str:
                 cwd=CWD,
                 python_path=PYPATH,
             ),
+        ),
+        pytest.param(
+            # When not on Windows `${venv:/path/to/env}` should expand to
+            # `/path/to/env/bin/python`
+            "file:///path/to/workspace/file.rst",
+            Workspace(None),
+            SphinxConfig(
+                python_command=["${venv:/path/to/env}"],
+                build_command=BUILD_CMD,
+                cwd=CWD,
+                python_path=PYPATH,
+            ),
+            SphinxConfig(
+                python_command=["/path/to/env/bin/python"],
+                build_command=BUILD_CMD,
+                cwd=CWD,
+                python_path=PYPATH,
+            ),
+            marks=pytest.mark.skipif(IS_WIN, reason="windows"),
+        ),
+        pytest.param(
+            # When on Windows `${venv:c:/path/to/env}` should expand to
+            # `c:/path/to/env/Scripts/python.exe`
+            "file:///path/to/workspace/file.rst",
+            Workspace(None),
+            SphinxConfig(
+                python_command=["${venv:c:/path/to/env}"],
+                build_command=BUILD_CMD,
+                cwd=CWD,
+                python_path=PYPATH,
+            ),
+            SphinxConfig(
+                python_command=["c:\\path\\to\\env\\Scripts\\python.exe"],
+                build_command=BUILD_CMD,
+                cwd=CWD,
+                python_path=PYPATH,
+            ),
+            marks=pytest.mark.skipif(not IS_WIN, reason="windows only"),
+        ),
+        pytest.param(
+            # When on Windows `${venv:c:\\path\\to\\env}` should expand to
+            # `c:/path/to/env/Scripts/python.exe`
+            "file:///path/to/workspace/file.rst",
+            Workspace(None),
+            SphinxConfig(
+                python_command=["${venv:c:\\path\\to\\env}"],
+                build_command=BUILD_CMD,
+                cwd=CWD,
+                python_path=PYPATH,
+            ),
+            SphinxConfig(
+                python_command=["c:\\path\\to\\env\\Scripts\\python.exe"],
+                build_command=BUILD_CMD,
+                cwd=CWD,
+                python_path=PYPATH,
+            ),
+            marks=pytest.mark.skipif(not IS_WIN, reason="windows only"),
+        ),
+        pytest.param(
+            # When not on Windows `${venv:env}` should expand to
+            # `${cwd}/env/bin/python`
+            "file:///path/to/workspace/file.rst",
+            Workspace(None),
+            SphinxConfig(
+                python_command=["${venv:env}"],
+                build_command=BUILD_CMD,
+                cwd=CWD,
+                python_path=PYPATH,
+            ),
+            SphinxConfig(
+                python_command=["/path/to/workspace/env/bin/python"],
+                build_command=BUILD_CMD,
+                cwd=CWD,
+                python_path=PYPATH,
+            ),
+            marks=pytest.mark.skipif(IS_WIN, reason="windows"),
+        ),
+        pytest.param(
+            # When on Windows `${venv:env}` should expand to
+            # `c:/path/to/workspace/env/Scripts/python.exe`
+            "file:///path/to/workspace/file.rst",
+            Workspace(None),
+            SphinxConfig(
+                python_command=["${venv:env}"],
+                build_command=BUILD_CMD,
+                cwd=CWD,
+                python_path=PYPATH,
+            ),
+            SphinxConfig(
+                python_command=["C:\\path\\to\\workspace\\env\\Scripts\\python.exe"],
+                build_command=BUILD_CMD,
+                cwd=CWD,
+                python_path=PYPATH,
+            ),
+            marks=pytest.mark.skipif(not IS_WIN, reason="windows only"),
+        ),
+        pytest.param(
+            # When not on Windows `${venv:../env}` should expand to
+            # `${cwd}/../env/bin/python`
+            "file:///path/to/workspace/file.rst",
+            Workspace(None),
+            SphinxConfig(
+                python_command=["${venv:../env}"],
+                build_command=BUILD_CMD,
+                cwd=CWD,
+                python_path=PYPATH,
+            ),
+            SphinxConfig(
+                python_command=["/path/to/env/bin/python"],
+                build_command=BUILD_CMD,
+                cwd=CWD,
+                python_path=PYPATH,
+            ),
+            marks=pytest.mark.skipif(IS_WIN, reason="windows"),
+        ),
+        pytest.param(
+            # When on Windows `${venv:../env}` should expand to
+            # `c:/path/to/workspace/Scripts/python.exe`
+            "file:///path/to/workspace/file.rst",
+            Workspace(None),
+            SphinxConfig(
+                python_command=["${venv:../env}"],
+                build_command=BUILD_CMD,
+                cwd=CWD,
+                python_path=PYPATH,
+            ),
+            SphinxConfig(
+                python_command=["C:\\path\\to\\env\\Scripts\\python.exe"],
+                build_command=BUILD_CMD,
+                cwd=CWD,
+                python_path=PYPATH,
+            ),
+            marks=pytest.mark.skipif(not IS_WIN, reason="windows only"),
+        ),
+        pytest.param(
+            # When on Windows `${venv:..\\env}` should expand to
+            # `c:/path/to/workspace/Scripts/python.exe`
+            "file:///path/to/workspace/file.rst",
+            Workspace(None),
+            SphinxConfig(
+                python_command=["${venv:..\\env}"],
+                build_command=BUILD_CMD,
+                cwd=CWD,
+                python_path=PYPATH,
+            ),
+            SphinxConfig(
+                python_command=["C:\\path\\to\\env\\Scripts\\python.exe"],
+                build_command=BUILD_CMD,
+                cwd=CWD,
+                python_path=PYPATH,
+            ),
+            marks=pytest.mark.skipif(not IS_WIN, reason="windows only"),
         ),
     ],
 )


### PR DESCRIPTION
This adds support for a `${venv:<path>}` configuration variable to the value of `esbonio.sphinx.pythonCommand`. It will expand into `<path>/bin/python` or `<path>/Scripts/python.exe` depending on the current OS. Both relative and absolute paths are supported.

When a relative path is given, it will be treated as relative to the `cwd` of the configuration scope, which by default will be the location of the `pyproject.toml` file.

Closes #914