### PR TITLE
Add `esbonio.sphinx.buildTriggers` config option

### DIFF
--- a/code/changes/935.enhancement.md
+++ b/code/changes/935.enhancement.md
@@ -1,0 +1,1 @@
+Expose the `esbonio.sphinx.buildTriggers` configuration option

--- a/code/package.json
+++ b/code/package.json
@@ -164,6 +164,24 @@
                         "default": null,
                         "description": "The sphinx-build command to use."
                     },
+                    "esbonio.sphinx.buildTriggers": {
+                        "scope": "window",
+                        "type": "object",
+                        "default": null,
+                        "properties": {
+                            "onSave": {
+                                "type": "boolean",
+                                "default": true,
+                                "description": "Trigger a build each time a file is saved"
+                            },
+                            "onChange": {
+                                "type": ["boolean", "number"],
+                                "default": 2.0,
+                                "description": "Trigger a build each time a file is changed"
+                            }
+                        },
+                        "description": "Triggers that control when the language server rebuilds your project."
+                    },
                     "esbonio.sphinx.configOverrides": {
                         "scope": "resource",
                         "type": "object",

--- a/docs/lsp/reference/configuration.rst
+++ b/docs/lsp/reference/configuration.rst
@@ -230,7 +230,7 @@ Name                        Description
 Sphinx
 ^^^^^^
 
-The following options control the creation of the Sphinx application object managed by the server.
+The following options control the creation and management of background Sphinx process by the server.
 
 .. esbonio:config:: esbonio.sphinx.buildCommand
    :scope: project
@@ -291,7 +291,7 @@ The following options control the creation of the Sphinx application object mana
    .. code-block:: json
 
       {
-         "sphinx.configOverrides": {
+         "esbonio.sphinx.configOverrides": {
             "language": "cy"
          }
       }
@@ -301,9 +301,38 @@ The following options control the creation of the Sphinx application object mana
    .. code-block:: json
 
       {
-         "sphinx.configOverrides": {
+         "esbonio.sphinx.configOverrides": {
             "html_context.docstitle": "ProjectName"
          }
+      }
+
+.. esbonio:config:: esbonio.sphinx.buildTriggers
+   :scope: global
+   :type: object
+
+   This option controls when the language server rebuilds your documentation.
+   The server's default configuration is equivalent to setting
+
+   .. code-block:: json
+
+      {
+        "esbonio.sphinx.buildTriggers": {
+          "onSave": true,
+          "onChange": 2.0,
+        }
+      }
+
+   where ``esbonio`` will rebuild each time you save a file, or each time you modify a file after a delay of 2 seconds.
+
+   The following configuration will disable **all** builds
+
+   .. code-block:: json
+
+      {
+        "esbonio.sphinx.buildTriggers": {
+          "onSave": false,
+          "onChange": false,
+        }
       }
 
 .. _lsp-configuration-preview:

--- a/lib/esbonio/changes/935.enhancement.md
+++ b/lib/esbonio/changes/935.enhancement.md
@@ -1,0 +1,1 @@
+Add `esbonio.sphinx.buildTriggers` option that gives the user control over when esbonio will rebuild the documentation

--- a/lib/esbonio/esbonio/server/features/sphinx_manager/manager.py
+++ b/lib/esbonio/esbonio/server/features/sphinx_manager/manager.py
@@ -5,6 +5,7 @@ import traceback
 import typing
 import uuid
 from functools import partial
+from typing import Union
 
 import attrs
 import lsprotocol.types as lsp
@@ -73,6 +74,25 @@ class ClientDestroyedNotification:
     """The client's id"""
 
 
+@attrs.define
+class SphinxBuildTriggers:
+    """Valid configuration options for Sphinx build triggers."""
+
+    on_save: bool = attrs.field(default=True)
+    """Trigger a build when a file is saved."""
+
+    on_change: bool | float = attrs.field(default=2.0)
+    """Trigger a build each time a file has changed, with a configurable delay."""
+
+
+@attrs.define
+class ManagerConfig:
+    """Configuration options for the sphinx manager."""
+
+    build_triggers: SphinxBuildTriggers = attrs.field(factory=SphinxBuildTriggers)
+    """Options controlling when to trigger a Sphinx build."""
+
+
 class SphinxManager(server.LanguageFeature):
     """Responsible for managing Sphinx application instances."""
 
@@ -97,6 +117,9 @@ class SphinxManager(server.LanguageFeature):
         }
         """Holds currently active Sphinx clients."""
 
+        self.config: ManagerConfig = ManagerConfig()
+        """The SphinxManager's configuration."""
+
         self._events = server.EventSource(self.logger)
         """The SphinxManager can emit events."""
 
@@ -109,6 +132,20 @@ class SphinxManager(server.LanguageFeature):
     def add_listener(self, event: str, handler):
         self._events.add_listener(event, handler)
 
+    def initialized(self, params: lsp.InitializedParams):
+        """Called once the initial handshake between client and server has finished."""
+
+        self.server.converter.register_structure_hook(
+            Union[bool, float], lambda obj, _: obj
+        )
+        self.configuration.subscribe(
+            "esbonio.sphinx", ManagerConfig, self.update_configuration
+        )
+
+    def update_configuration(self, event: server.ConfigChangeEvent[ManagerConfig]):
+        """Called when the user's configuration is updated."""
+        self.config = event.value
+
     async def document_change(self, params: lsp.DidChangeTextDocumentParams):
         if (uri := Uri.parse(params.text_document.uri)) is None:
             return
@@ -117,12 +154,19 @@ class SphinxManager(server.LanguageFeature):
         if client is None:
             return
 
+        if (delay := self.config.build_triggers.on_change) is False:
+            return
+
         # Cancel any existing pending builds
         if (task := self._pending_builds.pop(client.id, None)) is not None:
             task.cancel()
 
         self._pending_builds[client.id] = asyncio.create_task(
-            self.trigger_build_after(uri, client.id, delay=2)
+            self.trigger_build_after(
+                uri,
+                client.id,
+                delay=max(float(delay), 1.0),  # Enforce a minimum 1s delay
+            )
         )
 
     async def document_open(self, params: lsp.DidOpenTextDocumentParams):
@@ -139,10 +183,14 @@ class SphinxManager(server.LanguageFeature):
         if client is None:
             return
 
+        if not self.config.build_triggers.on_save:
+            return
+
         # Cancel any existing pending builds
         if (task := self._pending_builds.pop(client.id, None)) is not None:
             task.cancel()
 
+        self.logger.debug("Build triggered on save")
         await self.trigger_build(uri)
 
     async def shutdown(self, params: None):
@@ -162,11 +210,11 @@ class SphinxManager(server.LanguageFeature):
         await asyncio.sleep(delay)
 
         self._pending_builds.pop(app_id)
+        self.logger.debug("Build triggered after %ss delay", delay)
         await self.trigger_build(uri)
 
     async def trigger_build(self, uri: Uri):
         """Trigger a build for the relevant Sphinx application for the given uri."""
-        self.logger.debug("Triggering build")
 
         client = await self.get_client(uri)
         if client is None:


### PR DESCRIPTION
This option controls when the language server rebuilds the project. The server's default configuration is equivalent to setting
```jsonc
      {
        "esbonio.sphinx.buildTriggers": {
          "onSave": true,
          "onChange": 2.0, // seconds
        }
      }
```
where it will rebuild each time a file is saved, or each time a file is changed - with a 2 second delay. Setting `onChange` to `false` will disable it entirely.

Closes #935