### PR TITLE
Directive argument completions

### DIFF
--- a/code/CHANGELOG.md
+++ b/code/CHANGELOG.md
@@ -19,6 +19,7 @@
 ### Enhancements
 
 - Expose the `esbonio.sphinx.configOverrides` option ([#785](https://github.com/swyddfa/esbonio/issues/785))
+- The Sphinx Process tree view now includes details including `esbonio.sphinx.pythonCommand`, `esbonio.sphinx.buildCommand`, the current builder and output files ([#881](https://github.com/swyddfa/esbonio/issues/881))
 
 ### Misc
 

--- a/code/changes/881.enchancement.md
+++ b/code/changes/881.enchancement.md
@@ -1,1 +1,0 @@
-The Sphinx Process tree view now includes details including `esbonio.sphinx.pythonCommand`, `esbonio.sphinx.buildCommand`, the current builder and output files

--- a/docs/extending/api-reference.rst
+++ b/docs/extending/api-reference.rst
@@ -1,0 +1,9 @@
+API Reference
+=============
+
+.. toctree::
+   :maxdepth: 2
+
+   common-api
+   server-api
+   sphinx-api

--- a/docs/extending/common-api.rst
+++ b/docs/extending/common-api.rst
@@ -1,0 +1,10 @@
+Common API
+==========
+
+This section contains the API reference for the provided by Esbonio that is available **both** within the server itself and the Sphinx subprocess.
+
+.. toctree::
+   :maxdepth: 1
+   :glob:
+
+   common-api/*

--- a/docs/extending/common-api/directives.rst
+++ b/docs/extending/common-api/directives.rst
@@ -1,0 +1,7 @@
+Directives
+==========
+
+.. currentmodule:: esbonio.sphinx_agent.types
+
+.. autoclass:: Directive
+   :members:

--- a/docs/extending/common-api/roles.rst
+++ b/docs/extending/common-api/roles.rst
@@ -1,0 +1,7 @@
+Roles
+=====
+
+.. currentmodule:: esbonio.sphinx_agent.types
+
+.. autoclass:: Role
+   :members:

--- a/docs/extending/common-api/uri.rst
+++ b/docs/extending/common-api/uri.rst
@@ -1,0 +1,8 @@
+URI
+===
+
+.. currentmodule:: esbonio.sphinx_agent.types
+
+
+.. autoclass:: Uri
+   :members:

--- a/docs/extending/server-api.rst
+++ b/docs/extending/server-api.rst
@@ -1,0 +1,10 @@
+Server API
+==========
+
+This section contains the API reference for the server-side extension API provided by Esbonio
+
+.. toctree::
+   :maxdepth: 1
+   :glob:
+
+   server-api/*

--- a/docs/extending/server-api/directives.rst
+++ b/docs/extending/server-api/directives.rst
@@ -1,0 +1,21 @@
+Directives
+==========
+
+.. currentmodule:: esbonio.server.features.directives
+
+.. autoclass:: DirectiveFeature
+   :members:
+
+Providers
+---------
+
+.. currentmodule:: esbonio.server.features.directives.providers
+
+.. autoclass:: DirectiveArgumentProvider
+   :members:
+
+.. autoclass:: ValuesProvider
+   :members:
+
+.. autoclass:: FilepathProvider
+   :members:

--- a/docs/extending/server-api/language-features.rst
+++ b/docs/extending/server-api/language-features.rst
@@ -1,0 +1,16 @@
+Language Features
+=================
+
+.. currentmodule:: esbonio.server
+
+.. autoclass:: LanguageFeature
+   :members:
+
+Completion
+----------
+
+.. autoclass:: CompletionTrigger
+   :members:
+
+.. autoclass:: CompletionContext
+   :members:

--- a/docs/extending/sphinx-api.rst
+++ b/docs/extending/sphinx-api.rst
@@ -1,0 +1,10 @@
+Sphinx API
+==========
+
+This section contains the API reference for the Sphinx-side extension API provided by Esbonio
+
+.. toctree::
+   :maxdepth: 1
+   :glob:
+
+   sphinx-api/*

--- a/docs/extending/sphinx-api/application.rst
+++ b/docs/extending/sphinx-api/application.rst
@@ -1,0 +1,10 @@
+Application
+===========
+
+.. currentmodule:: esbonio.sphinx_agent.app
+
+.. autoclass:: Esbonio
+   :members:
+
+.. autoclass:: Sphinx
+   :members: esbonio

--- a/docs/extending/sphinx-api/database.rst
+++ b/docs/extending/sphinx-api/database.rst
@@ -1,0 +1,7 @@
+Database
+========
+
+.. currentmodule:: esbonio.sphinx_agent.database
+
+.. autoclass:: Database
+   :members:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -56,6 +56,7 @@ The primary goal of Esbonio is to reduce the friction that comes from trying to 
    :hidden:
 
    Getting Started <extending/getting-started>
+   extending/api-reference
 
 .. toctree::
    :caption: Integrating

--- a/lib/esbonio/changes/941.feature.md
+++ b/lib/esbonio/changes/941.feature.md
@@ -1,0 +1,1 @@
+The language server once again offers completion suggestions for arguments to the following classes of directives `code-blocks`, `images` and `includes`

--- a/lib/esbonio/esbonio/server/features/directives/__init__.py
+++ b/lib/esbonio/esbonio/server/features/directives/__init__.py
@@ -3,24 +3,14 @@ from __future__ import annotations
 import inspect
 import typing
 
-import attrs
+from lsprotocol import types as lsp
 
 from esbonio import server
+from esbonio.sphinx_agent import types
 
 if typing.TYPE_CHECKING:
     from collections.abc import Coroutine
     from typing import Any
-
-
-@attrs.define
-class Directive:
-    """Represents a directive."""
-
-    name: str
-    """The name of the directive, as the user would type in an rst file."""
-
-    implementation: str | None
-    """The dotted name of the directive's implementation."""
 
 
 class DirectiveProvider:
@@ -28,7 +18,9 @@ class DirectiveProvider:
 
     def suggest_directives(
         self, context: server.CompletionContext
-    ) -> list[Directive] | None | Coroutine[Any, Any, list[Directive] | None]:
+    ) -> (
+        list[types.Directive] | None | Coroutine[Any, Any, list[types.Directive] | None]
+    ):
         """Given a completion context, suggest directives that may be used."""
         return None
 
@@ -57,7 +49,7 @@ class DirectiveFeature(server.LanguageFeature):
 
     async def suggest_directives(
         self, context: server.CompletionContext
-    ) -> list[Directive]:
+    ) -> list[types.Directive]:
         """Suggest directives that may be used, given a completion context.
 
         Parameters
@@ -65,11 +57,11 @@ class DirectiveFeature(server.LanguageFeature):
         context
            The completion context.
         """
-        items: list[Directive] = []
+        items: list[types.Directive] = []
 
         for provider in self._providers.values():
             try:
-                result: list[Directive] | None = None
+                result: list[types.Directive] | None = None
 
                 aresult = provider.suggest_directives(context)
                 if inspect.isawaitable(aresult):

--- a/lib/esbonio/esbonio/server/features/directives/__init__.py
+++ b/lib/esbonio/esbonio/server/features/directives/__init__.py
@@ -12,9 +12,26 @@ if typing.TYPE_CHECKING:
     from collections.abc import Coroutine
     from typing import Any
 
+    from esbonio.server import Uri
+
 
 class DirectiveProvider:
     """Base class for directive providers"""
+
+    def get_directive(
+        self, uri: Uri, name: str
+    ) -> types.Directive | None | Coroutine[Any, Any, types.Directive | None]:
+        """Return the definition of the given directive, if known
+
+        Parameters
+        ----------
+        uri
+           The uri of the document in which the directive name appears
+
+        name
+           The name of the directive, as the user would type in a document
+        """
+        return None
 
     def suggest_directives(
         self, context: server.CompletionContext
@@ -22,6 +39,20 @@ class DirectiveProvider:
         list[types.Directive] | None | Coroutine[Any, Any, list[types.Directive] | None]
     ):
         """Given a completion context, suggest directives that may be used."""
+        return None
+
+
+class DirectiveArgumentProvider:
+    """Base class for directive argument providers."""
+
+    def suggest_arguments(
+        self, context: server.CompletionContext, **kwargs
+    ) -> (
+        list[lsp.CompletionItem]
+        | None
+        | Coroutine[Any, Any, list[lsp.CompletionItem] | None]
+    ):
+        """Given a completion context, suggest directive arguments that may be used."""
         return None
 
 
@@ -35,9 +66,10 @@ class DirectiveFeature(server.LanguageFeature):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        self._providers: dict[int, DirectiveProvider] = {}
+        self._directive_providers: dict[int, DirectiveProvider] = {}
+        self._argument_providers: dict[str, DirectiveArgumentProvider] = {}
 
-    def add_provider(self, provider: DirectiveProvider):
+    def add_directive_provider(self, provider: DirectiveProvider):
         """Register a directive provider.
 
         Parameters
@@ -45,7 +77,25 @@ class DirectiveFeature(server.LanguageFeature):
         provider
            The directive provider
         """
-        self._providers[id(provider)] = provider
+        self._directive_providers[id(provider)] = provider
+
+    def add_directive_argument_provider(
+        self, name: str, provider: DirectiveArgumentProvider
+    ):
+        """Register a directive argument provider.
+
+        Parameters
+        ----------
+        provider
+           The directive argument provider
+        """
+        if (existing := self._argument_providers.get(name)) is not None:
+            raise ValueError(
+                f"DirectiveArgumentProvider {provider!r} conflicts with existing "
+                f"provider: {existing!r}"
+            )
+
+        self._argument_providers[name] = provider
 
     async def suggest_directives(
         self, context: server.CompletionContext
@@ -59,7 +109,7 @@ class DirectiveFeature(server.LanguageFeature):
         """
         items: list[types.Directive] = []
 
-        for provider in self._providers.values():
+        for provider in self._directive_providers.values():
             try:
                 result: list[types.Directive] | None = None
 
@@ -76,6 +126,87 @@ class DirectiveFeature(server.LanguageFeature):
                 )
 
         return items
+
+    async def get_directive(self, uri: Uri, name: str) -> types.Directive | None:
+        """Return the definition of the given directive name.
+
+        Parameters
+        ----------
+        uri
+           The uri of the document in which the directive name appears
+
+        name
+           The name of the directive, as the user would type into a document.
+
+        Returns
+        -------
+        types.Directive | None
+           The directive's definition, if known
+        """
+        for provider in self._directive_providers.values():
+            try:
+                result: types.Directive | None = None
+
+                aresult = provider.get_directive(uri, name)
+                if inspect.isawaitable(aresult):
+                    result = await aresult
+
+                if result is not None:
+                    return result
+            except Exception:
+                name = type(provider).__name__
+                self.logger.error("Error in '%s.get_directive'", name, exc_info=True)
+
+        return None
+
+    async def suggest_arguments(
+        self, context: server.CompletionContext, directive_name: str
+    ) -> list[lsp.CompletionItem]:
+        """Suggest directive arguments that may be used, given a completion context.
+
+        Parameters
+        ----------
+        context
+           The completion context
+
+        directive_name
+           The directive to suggest arguments for
+        """
+        if (directive := await self.get_directive(context.uri, directive_name)) is None:
+            self.logger.debug("Unknown directive '%s'", directive_name)
+            return []
+
+        arguments = []
+        self.logger.debug(
+            "Suggesting arguments for directive: '%s' (%s)",
+            directive.name,
+            directive.implementation,
+        )
+
+        for spec in directive.argument_providers:
+            if (provider := self._argument_providers.get(spec.name)) is None:
+                self.logger.error("Unknown argument provider: '%s'", spec.name)
+                continue
+
+            try:
+                result: list[lsp.CompletionItem] | None = None
+
+                aresult = provider.suggest_arguments(context, **spec.kwargs)
+                if inspect.isawaitable(aresult):
+                    result = await aresult
+                else:
+                    result = aresult
+
+                if result is not None:
+                    arguments.extend(result)
+
+            except Exception:
+                name = type(provider).__name__
+                self.logger.error(
+                    "Error in '%s.suggest_arguments'", name, exc_info=True
+                )
+
+        return arguments
 
 
 def esbonio_setup(server: server.EsbonioLanguageServer):

--- a/lib/esbonio/esbonio/server/features/directives/__init__.py
+++ b/lib/esbonio/esbonio/server/features/directives/__init__.py
@@ -8,6 +8,9 @@ from lsprotocol import types as lsp
 from esbonio import server
 from esbonio.sphinx_agent import types
 
+from . import providers
+from .providers import DirectiveArgumentProvider
+
 if typing.TYPE_CHECKING:
     from collections.abc import Coroutine
     from typing import Any
@@ -39,20 +42,6 @@ class DirectiveProvider:
         list[types.Directive] | None | Coroutine[Any, Any, list[types.Directive] | None]
     ):
         """Given a completion context, suggest directives that may be used."""
-        return None
-
-
-class DirectiveArgumentProvider:
-    """Base class for directive argument providers."""
-
-    def suggest_arguments(
-        self, context: server.CompletionContext, **kwargs
-    ) -> (
-        list[lsp.CompletionItem]
-        | None
-        | Coroutine[Any, Any, list[lsp.CompletionItem] | None]
-    ):
-        """Given a completion context, suggest directive arguments that may be used."""
         return None
 
 
@@ -211,4 +200,11 @@ class DirectiveFeature(server.LanguageFeature):
 
 def esbonio_setup(server: server.EsbonioLanguageServer):
     directives = DirectiveFeature(server)
+    directives.add_directive_argument_provider(
+        "values",
+        providers.ValuesProvider(
+            server.converter, server.logger.getChild("ValuesProvider")
+        ),
+    )
+
     server.add_feature(directives)

--- a/lib/esbonio/esbonio/server/features/directives/__init__.py
+++ b/lib/esbonio/esbonio/server/features/directives/__init__.py
@@ -201,10 +201,10 @@ class DirectiveFeature(server.LanguageFeature):
 def esbonio_setup(server: server.EsbonioLanguageServer):
     directives = DirectiveFeature(server)
     directives.add_directive_argument_provider(
-        "values",
-        providers.ValuesProvider(
-            server.converter, server.logger.getChild("ValuesProvider")
-        ),
+        "filepath", providers.FilepathProvider(server)
+    )
+    directives.add_directive_argument_provider(
+        "values", providers.ValuesProvider(server)
     )
 
     server.add_feature(directives)

--- a/lib/esbonio/esbonio/server/features/directives/completion.py
+++ b/lib/esbonio/esbonio/server/features/directives/completion.py
@@ -19,17 +19,34 @@ if typing.TYPE_CHECKING:
         [server.CompletionContext, Directive], Optional[types.CompletionItem]
     ]
 
+    DirectiveArgumentRenderer = Callable[
+        [server.CompletionContext, types.CompletionItem], Optional[types.CompletionItem]
+    ]
+
 
 WORD = re.compile("[a-zA-Z]+")
 _DIRECTIVE_RENDERERS: dict[tuple[str, str], DirectiveRenderer] = {}
 """CompletionItem rendering functions for directives."""
 
+_DIRECTIVE_ARGUMENT_RENDERERS: dict[tuple[str, str], DirectiveArgumentRenderer] = {}
+"""CompletionItem rendering functions for role targets."""
 
-def renderer(*, language: str, insert_behavior: str):
+
+def directive_renderer(*, language: str, insert_behavior: str):
     """Define a new rendering function."""
 
     def fn(f: DirectiveRenderer) -> DirectiveRenderer:
         _DIRECTIVE_RENDERERS[(language, insert_behavior)] = f
+        return f
+
+    return fn
+
+
+def directive_argument_renderer(*, language: str, insert_behavior: str):
+    """Define a new rendering function."""
+
+    def fn(f: DirectiveArgumentRenderer) -> DirectiveArgumentRenderer:
+        _DIRECTIVE_ARGUMENT_RENDERERS[(language, insert_behavior)] = f
         return f
 
     return fn
@@ -56,7 +73,28 @@ def get_directive_renderer(
     return _DIRECTIVE_RENDERERS.get((language, insert_behavior), None)
 
 
-@renderer(language="rst", insert_behavior="insert")
+def get_directive_argument_renderer(
+    language: str, insert_behavior: str
+) -> DirectiveArgumentRenderer | None:
+    """Return the directive argument renderer to use.
+
+    Parameters
+    ----------
+    language
+       The source language the completion item will be inserted into
+
+    insert_behavior
+       How the completion should behave when inserted.
+
+    Returns
+    -------
+    Optional[DirectiveArgumentRenderer]
+       The rendering function to use that matches the given criteria, if available.
+    """
+    return _DIRECTIVE_ARGUMENT_RENDERERS.get((language, insert_behavior), None)
+
+
+@directive_renderer(language="rst", insert_behavior="insert")
 def render_rst_directive_with_insert_text(
     context: server.CompletionContext,
     directive: Directive,
@@ -133,7 +171,31 @@ def render_rst_directive_with_insert_text(
     return item
 
 
-@renderer(language="rst", insert_behavior="replace")
+@directive_argument_renderer(language="rst", insert_behavior="replace")
+def render_directive_agument_with_text_edit(
+    context: server.CompletionContext, item: types.CompletionItem
+) -> types.CompletionItem | None:
+    """Render a ``CompletionItem`` using ``textEdit``.
+
+    This implements the ``replace`` insert behavior for role targets.
+
+    Parameters
+    ----------
+    context
+       The context in which the completion is being generated.
+
+    item
+       The ``CompletionItem`` representing the directive argument.
+
+    Returns
+    -------
+    Optional[types.CompletionItem]
+       The rendered completion item, or ``None`` if the item should be skipped
+    """
+    return item
+
+
+@directive_renderer(language="rst", insert_behavior="replace")
 def render_rst_directive_with_text_edit(
     context: server.CompletionContext,
     directive: Directive,
@@ -183,7 +245,7 @@ def render_rst_directive_with_text_edit(
     return item
 
 
-@renderer(language="markdown", insert_behavior="replace")
+@directive_renderer(language="markdown", insert_behavior="replace")
 def render_myst_directive_with_text_edit(
     context: server.CompletionContext,
     directive: Directive,
@@ -234,7 +296,7 @@ def render_myst_directive_with_text_edit(
     return item
 
 
-@renderer(language="markdown", insert_behavior="insert")
+@directive_renderer(language="markdown", insert_behavior="insert")
 def render_myst_directive_with_insert_text(
     context: server.CompletionContext,
     directive: Directive,

--- a/lib/esbonio/esbonio/server/features/directives/completion.py
+++ b/lib/esbonio/esbonio/server/features/directives/completion.py
@@ -172,12 +172,12 @@ def render_rst_directive_with_insert_text(
 
 
 @directive_argument_renderer(language="rst", insert_behavior="replace")
-def render_directive_agument_with_text_edit(
+def render_rst_argument_with_text_edit(
     context: server.CompletionContext, item: types.CompletionItem
 ) -> types.CompletionItem | None:
     """Render a ``CompletionItem`` using ``textEdit``.
 
-    This implements the ``replace`` insert behavior for role targets.
+    This implements the ``replace`` insert behavior for rst directive arguments.
 
     Parameters
     ----------
@@ -293,6 +293,30 @@ def render_myst_directive_with_text_edit(
         ),
     )
 
+    return item
+
+
+@directive_argument_renderer(language="markdown", insert_behavior="replace")
+def render_myst_argument_with_text_edit(
+    context: server.CompletionContext, item: types.CompletionItem
+) -> types.CompletionItem | None:
+    """Render a ``CompletionItem`` using ``textEdit``.
+
+    This implements the ``replace`` insert behavior for MyST directive arguments.
+
+    Parameters
+    ----------
+    context
+       The context in which the completion is being generated.
+
+    item
+       The ``CompletionItem`` representing the directive argument.
+
+    Returns
+    -------
+    Optional[types.CompletionItem]
+       The rendered completion item, or ``None`` if the item should be skipped
+    """
     return item
 
 

--- a/lib/esbonio/esbonio/server/features/directives/completion.py
+++ b/lib/esbonio/esbonio/server/features/directives/completion.py
@@ -13,7 +13,7 @@ if typing.TYPE_CHECKING:
     from typing import Callable
     from typing import Optional
 
-    from . import Directive
+    from esbonio.sphinx_agent.types import Directive
 
     DirectiveRenderer = Callable[
         [server.CompletionContext, Directive], Optional[types.CompletionItem]

--- a/lib/esbonio/esbonio/server/features/directives/providers.py
+++ b/lib/esbonio/esbonio/server/features/directives/providers.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+import pathlib
+import typing
+
+from lsprotocol import types as lsp
+
+from esbonio import server
+
+if typing.TYPE_CHECKING:
+    from collections.abc import Coroutine
+    from typing import Any
+
+
+class DirectiveArgumentProvider:
+    """Base class for directive argument providers."""
+
+    def __init__(self, esbonio: server.EsbonioLanguageServer):
+        self.converter = esbonio.converter
+        self.logger = esbonio.logger.getChild(self.__class__.__name__)
+
+    def suggest_arguments(
+        self, context: server.CompletionContext, **kwargs
+    ) -> (
+        list[lsp.CompletionItem]
+        | None
+        | Coroutine[Any, Any, list[lsp.CompletionItem] | None]
+    ):
+        """Given a completion context, suggest directive arguments that may be used."""
+        return None
+
+
+class ValuesProvider(DirectiveArgumentProvider):
+    """Simple completions provider that supports a static list of values."""
+
+    def suggest_arguments(  # type: ignore[override]
+        self, context: server.CompletionContext, *, values: list[str | dict[str, Any]]
+    ) -> list[lsp.CompletionItem]:
+        """Given a completion context, suggest directive arguments that may be used."""
+        result: list[lsp.CompletionItem] = []
+
+        for value in values:
+            if isinstance(value, str):
+                result.append(lsp.CompletionItem(label=value))
+                continue
+
+            try:
+                result.append(self.converter.structure(value, lsp.CompletionItem))
+            except Exception:
+                self.logger.exception("Unable to create CompletionItem")
+
+        return result
+
+
+class FilepathProvider(DirectiveArgumentProvider):
+    """Argument provider for filepaths."""
+
+    def suggest_arguments(  # type: ignore[override]
+        self,
+        context: server.CompletionContext,
+        *,
+        root: str = "/",
+        pattern: str | None = None,
+    ) -> list[lsp.CompletionItem]:
+        """Given a completion context, suggest files (or folders) that may be used.
+
+        Parameters
+        ----------
+        root
+           If the user provides an absolute path, generate suggestions relative to this directory.
+
+        pattern
+           If set, limit suggestions only to matching files.
+
+        Returns
+        -------
+        list[lsp.CompletionItem]
+           A list of completion items to suggest.
+        """
+        uri = server.Uri.parse(context.doc.uri)
+        cwd = pathlib.Path(uri).parent
+
+        if (partial := context.match.group("argument")) and partial.startswith("/"):
+            candidate_dir = pathlib.Path(root)
+
+            # Be sure to remove the leading '/', otherwise partial will wipe out the
+            # root when concatenated.
+            partial = partial[1:]
+        else:
+            candidate_dir = cwd
+
+        candidate_dir /= partial
+        if partial and not partial.endswith(("/", ".")):
+            candidate_dir = candidate_dir.parent
+
+        self.logger.debug("Suggesting files relative to %r", candidate_dir)
+        return [
+            self._path_to_completion_item(context, p) for p in candidate_dir.glob("*")
+        ]
+
+    def _path_to_completion_item(
+        self, context: server.CompletionContext, path: pathlib.Path
+    ) -> lsp.CompletionItem:
+        """Create the ``CompletionItem`` for the given path.
+
+        In the case where there are multiple filepath components, this function needs to
+        provide an appropriate ``TextEdit`` so that the most recent entry in the path can
+        be easily edited - without clobbering the existing path.
+
+        Also bear in mind that this function must play nice with both role target and
+        directive argument completions.
+        """
+
+        new_text = f"{path.name}"
+        kind = (
+            lsp.CompletionItemKind.Folder
+            if path.is_dir()
+            else lsp.CompletionItemKind.File
+        )
+
+        if (start := self._find_start_char(context)) == -1:
+            insert_text = new_text
+            filter_text = None
+            text_edit = None
+        else:
+            start += 1
+            _, end = context.match.span()
+            prefix = context.match.group(0)[start:]
+
+            insert_text = None
+            filter_text = f"{prefix}{new_text}"  # Needed so VSCode will actually show the results.
+
+            text_edit = lsp.TextEdit(
+                range=lsp.Range(
+                    start=lsp.Position(line=context.position.line, character=start),
+                    end=lsp.Position(line=context.position.line, character=end),
+                ),
+                new_text=new_text,
+            )
+
+        return lsp.CompletionItem(
+            label=new_text,
+            kind=kind,
+            insert_text=insert_text,
+            filter_text=filter_text,
+            text_edit=text_edit,
+        )
+
+    def _find_start_char(self, context: server.CompletionContext) -> int:
+        matched_text = context.match.group(0)
+        idx = matched_text.find("/")
+
+        while True:
+            next_idx = matched_text.find("/", idx + 1)
+            if next_idx == -1:
+                break
+
+            idx = next_idx
+
+        return idx

--- a/lib/esbonio/esbonio/server/features/myst/directives.py
+++ b/lib/esbonio/esbonio/server/features/myst/directives.py
@@ -21,7 +21,7 @@ class MystDirectives(server.LanguageFeature):
     completion_trigger = server.CompletionTrigger(
         patterns=[MYST_DIRECTIVE],
         languages={"markdown"},
-        characters={".", "`", "/"},
+        characters={".", "`", "/", "{"},
     )
 
     def initialized(self, params: types.InitializedParams):
@@ -49,24 +49,44 @@ class MystDirectives(server.LanguageFeature):
         if "directive" not in groups:
             return await self.complete_options(context)
 
-        # Don't offer completions for targets
-        if (groups["name"] or "").startswith("_"):
-            return None
-
         # Are we completing the directive's argument?
         directive_end = context.match.span()[0] + len(groups["directive"])
         complete_directive = groups["directive"].endswith("}")
 
+        directive_name = groups["name"]
         if complete_directive and directive_end < context.position.character:
-            return await self.complete_arguments(context)
+            return await self.complete_arguments(context, directive_name)
+
+        # Provide argument suggestions for `code-block` if the user is creating a regular code block.
+        if "{" not in groups["directive"]:
+            return await self.complete_arguments(context, "code-block")
 
         return await self.complete_directives(context)
 
     async def complete_options(self, context: server.CompletionContext):
         return None
 
-    async def complete_arguments(self, context: server.CompletionContext):
-        return None
+    async def complete_arguments(
+        self,
+        context: server.CompletionContext,
+        directive_name: str,
+    ) -> list[types.CompletionItem] | None:
+        """Return completion suggestions for the current directive's argument."""
+
+        render_func = completion.get_directive_argument_renderer(
+            context.language, self._insert_behavior
+        )
+        if render_func is None:
+            return None
+
+        items = []
+        suggestions = await self.directives.suggest_arguments(context, directive_name)
+
+        for argument in suggestions:
+            if (item := render_func(context, argument)) is not None:
+                items.append(item)
+
+        return items if len(items) > 0 else None
 
     async def complete_directives(
         self, context: server.CompletionContext

--- a/lib/esbonio/esbonio/server/features/myst/directives.py
+++ b/lib/esbonio/esbonio/server/features/myst/directives.py
@@ -3,10 +3,10 @@ from __future__ import annotations
 from lsprotocol import types
 
 from esbonio import server
-from esbonio.server.features.directives import Directive
 from esbonio.server.features.directives import DirectiveFeature
 from esbonio.server.features.directives import completion
 from esbonio.sphinx_agent.types import MYST_DIRECTIVE
+from esbonio.sphinx_agent.types import Directive
 
 
 class MystDirectives(server.LanguageFeature):

--- a/lib/esbonio/esbonio/server/features/project_manager/project.py
+++ b/lib/esbonio/esbonio/server/features/project_manager/project.py
@@ -72,6 +72,20 @@ class Project:
         (value,) = row
         return json.loads(value)
 
+    async def get_directive(self, name: str) -> types.Directive | None:
+        """Get the directive with the given name."""
+        db = await self.get_db()
+
+        query = "SELECT * FROM directives WHERE name = ?"
+        cursor = await db.execute(query, (name,))
+        result = await cursor.fetchone()
+
+        return (
+            types.Directive.from_db(self.load_as, *result)
+            if result is not None
+            else None
+        )
+
     async def get_directives(self) -> list[tuple[str, str | None]]:
         """Get the directives known to Sphinx."""
         db = await self.get_db()
@@ -81,7 +95,7 @@ class Project:
         return await cursor.fetchall()  # type: ignore[return-value]
 
     async def get_role(self, name: str) -> types.Role | None:
-        """Get the roles known to Sphinx."""
+        """Get the role with the given name."""
         db = await self.get_db()
 
         query = "SELECT * FROM roles WHERE name = ?"

--- a/lib/esbonio/esbonio/server/features/rst/directives.py
+++ b/lib/esbonio/esbonio/server/features/rst/directives.py
@@ -64,8 +64,26 @@ class RstDirectives(server.LanguageFeature):
     async def complete_options(self, context: server.CompletionContext):
         return None
 
-    async def complete_arguments(self, context: server.CompletionContext):
-        return None
+    async def complete_arguments(
+        self, context: server.CompletionContext
+    ) -> list[types.CompletionItem] | None:
+        """Return completion suggestions for the current directive's argument"""
+
+        render_func = completion.get_directive_argument_renderer(
+            context.language, self._insert_behavior
+        )
+        if render_func is None:
+            return None
+
+        items = []
+        directive_name = context.match.group("name")
+        suggestions = await self.directives.suggest_arguments(context, directive_name)
+
+        for argument in suggestions:
+            if (item := render_func(context, argument)) is not None:
+                items.append(item)
+
+        return items if len(items) > 0 else None
 
     async def complete_directives(
         self, context: server.CompletionContext

--- a/lib/esbonio/esbonio/server/features/sphinx_support/directives.py
+++ b/lib/esbonio/esbonio/server/features/sphinx_support/directives.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import typing
+
 from lsprotocol import types as lsp
 
 from esbonio import server
@@ -7,12 +9,48 @@ from esbonio.server.features import directives
 from esbonio.server.features.project_manager import ProjectManager
 from esbonio.sphinx_agent import types
 
+if typing.TYPE_CHECKING:
+    from esbonio.server import Uri
+    from esbonio.server.features.project_manager import Project
+
 
 class SphinxDirectives(directives.DirectiveProvider):
     """Support for directives in a sphinx project."""
 
     def __init__(self, manager: ProjectManager):
         self.manager = manager
+
+    async def get_default_domain(self, project: Project, uri: Uri) -> str:
+        """Get the name of the default domain for the given document"""
+
+        # Does the document have a default domain set?
+        results = await project.find_symbols(
+            uri=str(uri.resolve()),
+            kind=lsp.SymbolKind.Class.value,
+            detail="default-domain",
+        )
+        if len(results) > 0:
+            default_domain = results[0][1]
+        else:
+            default_domain = None
+
+        primary_domain = await project.get_config_value("primary_domain")
+        return default_domain or primary_domain or "py"
+
+    async def get_directive(self, uri: Uri, name: str) -> types.Directive | None:
+        """Return the directive with the given name."""
+
+        if (project := self.manager.get_project(uri)) is None:
+            return None
+
+        if (directive := await project.get_directive(name)) is not None:
+            return directive
+
+        if (directive := await project.get_directive(f"std:{name}")) is not None:
+            return directive
+
+        default_domain = await self.get_default_domain(project, uri)
+        return await project.get_directive(f"{default_domain}:{name}")
 
     async def suggest_directives(
         self, context: server.CompletionContext
@@ -62,4 +100,4 @@ def esbonio_setup(
     directive_feature: directives.DirectiveFeature,
 ):
     provider = SphinxDirectives(project_manager)
-    directive_feature.add_provider(provider)
+    directive_feature.add_directive_provider(provider)

--- a/lib/esbonio/esbonio/server/features/sphinx_support/directives.py
+++ b/lib/esbonio/esbonio/server/features/sphinx_support/directives.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
-from lsprotocol import types
+from lsprotocol import types as lsp
 
 from esbonio import server
 from esbonio.server.features import directives
 from esbonio.server.features.project_manager import ProjectManager
+from esbonio.sphinx_agent import types
 
 
 class SphinxDirectives(directives.DirectiveProvider):
@@ -15,7 +16,7 @@ class SphinxDirectives(directives.DirectiveProvider):
 
     async def suggest_directives(
         self, context: server.CompletionContext
-    ) -> list[directives.Directive] | None:
+    ) -> list[types.Directive] | None:
         """Given a completion context, suggest directives that may be used."""
 
         if (project := self.manager.get_project(context.uri)) is None:
@@ -24,7 +25,7 @@ class SphinxDirectives(directives.DirectiveProvider):
         # Does the document have a default domain set?
         results = await project.find_symbols(
             uri=str(context.uri.resolve()),
-            kind=types.SymbolKind.Class.value,
+            kind=lsp.SymbolKind.Class.value,
             detail="default-domain",
         )
         if len(results) > 0:
@@ -35,25 +36,23 @@ class SphinxDirectives(directives.DirectiveProvider):
         primary_domain = await project.get_config_value("primary_domain")
         active_domain = default_domain or primary_domain or "py"
 
-        result: list[directives.Directive] = []
+        result: list[types.Directive] = []
         for name, implementation in await project.get_directives():
             # std: directives can be used unqualified
             if name.startswith("std:"):
                 short_name = name.replace("std:", "")
                 result.append(
-                    directives.Directive(name=short_name, implementation=implementation)
+                    types.Directive(name=short_name, implementation=implementation)
                 )
 
             # Also suggest unqualified versions of directives from the currently active domain.
             elif name.startswith(f"{active_domain}:"):
                 short_name = name.replace(f"{active_domain}:", "")
                 result.append(
-                    directives.Directive(name=short_name, implementation=implementation)
+                    types.Directive(name=short_name, implementation=implementation)
                 )
 
-            result.append(
-                directives.Directive(name=name, implementation=implementation)
-            )
+            result.append(types.Directive(name=name, implementation=implementation))
 
         return result
 

--- a/lib/esbonio/esbonio/sphinx_agent/app.py
+++ b/lib/esbonio/esbonio/sphinx_agent/app.py
@@ -23,7 +23,11 @@ if typing.TYPE_CHECKING:
     from docutils.nodes import Element
     from docutils.parsers.rst import Directive
 
+    DirectiveDefinition = tuple[
+        str, type[Directive], list[types.Directive.ArgumentProvider]
+    ]
     RoleDefinition = tuple[str, Any, list[types.Role.TargetProvider]]
+
 
 sphinx_logger = logging.getLogger(SPHINX_LOG_NAMESPACE)
 logger = sphinx_logger.getChild("esbonio")
@@ -55,6 +59,9 @@ class Esbonio:
         self._roles: list[RoleDefinition] = []
         """Roles captured during Sphinx startup."""
 
+        self._directives: list[DirectiveDefinition] = []
+        """Directives captured during Sphinx startup."""
+
         self._config_ast: ast.Module | Literal[False] | None = None
         """The parsed AST of the user's conf.py file.
         If ``False``, we already tried parsing the module and were unable to."""
@@ -82,6 +89,48 @@ class Esbonio:
             self._config_ast = False
 
             return None
+
+    def add_directive(
+        self,
+        name: str,
+        directive: type[Directive],
+        argument_providers: list[types.Directive.ArgumentProvider] | None = None,
+    ):
+        """Register a directive with esbonio.
+
+        Parameters
+        ----------
+        name
+           The name of the directive, as the user would type in a document
+
+        directive
+           The directive's implementation
+
+        argument_providers
+           A list of argument providers for the role
+        """
+        self._directives.append((name, directive, argument_providers or []))
+
+    @staticmethod
+    def create_directive_argument_provider(
+        name: str, **kwargs
+    ) -> types.Directive.ArgumentProvider:
+        """Create a new directive argument provider
+
+        Parameters
+        ----------
+        name
+           The name of the provider
+
+        kwargs
+           Additional arguments to pass to the provider instance
+
+        Returns
+        -------
+        types.Directive.ArgumentProvider
+           The target provider
+        """
+        return types.Directive.ArgumentProvider(name, kwargs)
 
     def add_role(
         self,
@@ -154,6 +203,7 @@ class Sphinx(_Sphinx):
 
     def add_directive(self, name: str, cls: type[Directive], override: bool = False):
         super().add_directive(name, cls, override or self._esbonio_retry_count > 0)
+        self.esbonio.add_directive(name, cls)
 
     def add_node(self, node: type[Element], override: bool = False, **kwargs):
         super().add_node(node, override or self._esbonio_retry_count > 0, **kwargs)

--- a/lib/esbonio/esbonio/sphinx_agent/handlers/directives.py
+++ b/lib/esbonio/esbonio/sphinx_agent/handlers/directives.py
@@ -101,7 +101,7 @@ def index_directives(app: Sphinx):
 
         directives[name] = types.Directive(name, get_impl_name(directive))
 
-    _add_providers(directives)
+    _add_providers(app, directives)
 
     app.esbonio.db.ensure_table(DIRECTIVES_TABLE)
     app.esbonio.db.clear_table(DIRECTIVES_TABLE)
@@ -114,14 +114,21 @@ def setup(app: Sphinx):
     app.connect("builder-inited", index_directives, priority=999)
 
 
-def _add_providers(directives: dict[str, types.Directive]):
+def _add_providers(app: Sphinx, directives: dict[str, types.Directive]):
     """Add provider definitions to built in directive types we know about."""
 
     lexers_provider = _get_lexers_provider()
+    filepath_provider = types.Directive.ArgumentProvider(
+        "filepath", {"root": app.srcdir}
+    )
 
     for name in ["code-block", "sourcecode", "highlight"]:
         if (directive := directives.get(name)) is not None:
             directive.argument_providers = [lexers_provider]
+
+    for name in ["image", "figure", "include", "literalinclude"]:
+        if (directive := directives.get(name)) is not None:
+            directive.argument_providers = [filepath_provider]
 
 
 def _get_lexers_provider() -> types.Directive.ArgumentProvider:

--- a/lib/esbonio/esbonio/sphinx_agent/handlers/directives.py
+++ b/lib/esbonio/esbonio/sphinx_agent/handlers/directives.py
@@ -18,6 +18,7 @@ DIRECTIVES_TABLE = Database.Table(
         Database.Column(name="name", dtype="TEXT"),
         Database.Column(name="implementation", dtype="TEXT"),
         Database.Column(name="location", dtype="JSON"),
+        Database.Column(name="argument_providers", dtype="JSON"),
     ],
 )
 
@@ -66,7 +67,13 @@ def index_directives(app: Sphinx):
     first time.
     """
 
-    directives: list[types.Directive] = []
+    directives: dict[str, types.Directive] = {}
+
+    # Process the roles registered through Sphinx
+    for name, impl, providers in app.esbonio._directives:
+        directives[name] = types.Directive(
+            name, get_impl_name(impl), argument_providers=providers
+        )
 
     ignored_directives = {"restructuredtext-test-directive"}
     found_directives = {
@@ -75,7 +82,7 @@ def index_directives(app: Sphinx):
     }
 
     for name, directive in found_directives.items():
-        if name in ignored_directives:
+        if name in ignored_directives or name in directives:
             continue
 
         # core docutils directives are a (module, Class) reference.
@@ -88,25 +95,17 @@ def index_directives(app: Sphinx):
                 directive = getattr(module, cls)
             except Exception:
                 # TODO: Log the error somewhere...
-                directives.append((name, None, None))
+                directives[name] = types.Directive(name, None, None)
                 continue
 
-        directives.append((name, get_impl_name(directive), None))
-
-    for prefix, domain in app.env.domains.items():
-        for name, directive in domain.directives.items():
-            directives.append(
-                (
-                    f"{prefix}:{name}",
-                    get_impl_name(directive),
-                    None,
-                )
-            )
+        directives[name] = types.Directive(name, get_impl_name(directive))
 
     app.esbonio.db.ensure_table(DIRECTIVES_TABLE)
     app.esbonio.db.clear_table(DIRECTIVES_TABLE)
-    app.esbonio.db.insert_values(DIRECTIVES_TABLE, directives)
+    app.esbonio.db.insert_values(
+        DIRECTIVES_TABLE, [d.to_db(as_json) for d in directives.values()]
+    )
 
 
 def setup(app: Sphinx):
-    app.connect("builder-inited", index_directives)
+    app.connect("builder-inited", index_directives, priority=999)

--- a/lib/esbonio/esbonio/sphinx_agent/handlers/directives.py
+++ b/lib/esbonio/esbonio/sphinx_agent/handlers/directives.py
@@ -6,6 +6,7 @@ from typing import Optional
 
 from docutils.parsers.rst import Directive
 from docutils.parsers.rst import directives as docutils_directives
+from pygments.lexers import get_all_lexers
 
 from .. import types
 from ..app import Database
@@ -100,6 +101,8 @@ def index_directives(app: Sphinx):
 
         directives[name] = types.Directive(name, get_impl_name(directive))
 
+    _add_providers(directives)
+
     app.esbonio.db.ensure_table(DIRECTIVES_TABLE)
     app.esbonio.db.clear_table(DIRECTIVES_TABLE)
     app.esbonio.db.insert_values(
@@ -109,3 +112,36 @@ def index_directives(app: Sphinx):
 
 def setup(app: Sphinx):
     app.connect("builder-inited", index_directives, priority=999)
+
+
+def _add_providers(directives: dict[str, types.Directive]):
+    """Add provider definitions to built in directive types we know about."""
+
+    lexers_provider = _get_lexers_provider()
+
+    for name in ["code-block", "sourcecode", "highlight"]:
+        if (directive := directives.get(name)) is not None:
+            directive.argument_providers = [lexers_provider]
+
+
+def _get_lexers_provider() -> types.Directive.ArgumentProvider:
+    """Get the argument provider instance that returns the names of pygments lexers."""
+
+    langs = []
+    for name, labels, files, mimes in get_all_lexers():
+        filenames = ", ".join(f"`{f}`" for f in files)
+        mimetypes = ", ".join(f"`{m}`" for m in mimes)
+
+        for label in labels:
+            langs.append(
+                {
+                    "label": label,
+                    "kind": 21,  # Constant
+                    "documentation": {
+                        "kind": "markdown",
+                        "value": f"### {name}\nFilenames: {filenames}\n\nMIME Types: {mimetypes}",
+                    },
+                }
+            )
+
+    return types.Directive.ArgumentProvider("values", {"values": langs})

--- a/lib/esbonio/esbonio/sphinx_agent/handlers/domains.py
+++ b/lib/esbonio/esbonio/sphinx_agent/handlers/domains.py
@@ -57,7 +57,8 @@ class DomainObjects:
         project_names = [p[0] for p in projects]
 
         for domain in app.env.domains.values():
-            index_domain(app, domain, project_names)
+            index_domain_directives(app, domain)
+            index_domain_roles(app, domain, project_names)
 
     def commit(self, app, exc):
         """Commit changes to the database.
@@ -131,7 +132,22 @@ class DomainObjects:
         self._info[key] = (description, location)
 
 
-def index_domain(app: Sphinx, domain: Domain, projects: list[str] | None):
+def index_domain_directives(app: Sphinx, domain: Domain):
+    """Index the directives in the given domain.
+
+    Parameters
+    ----------
+    app
+       The application instance
+
+    domain
+       The domain to index
+    """
+    for name, directive in domain.directives.items():
+        app.esbonio.add_directive(f"{domain.name}:{name}", directive, [])
+
+
+def index_domain_roles(app: Sphinx, domain: Domain, projects: list[str] | None):
     """Index the roles in the given domain.
 
     Parameters

--- a/lib/esbonio/esbonio/sphinx_agent/types/__init__.py
+++ b/lib/esbonio/esbonio/sphinx_agent/types/__init__.py
@@ -7,11 +7,14 @@ server. For this reason this module *cannot* import anything from Sphinx.
 from __future__ import annotations
 
 import dataclasses
-import re
 from typing import Any
 from typing import Optional
 from typing import Union
 
+from .directives import MYST_DIRECTIVE
+from .directives import RST_DIRECTIVE
+from .directives import RST_DIRECTIVE_OPTION
+from .directives import Directive
 from .lsp import Diagnostic
 from .lsp import DiagnosticSeverity
 from .lsp import Location
@@ -27,112 +30,25 @@ from .uri import Uri
 __all__ = (
     "Diagnostic",
     "DiagnosticSeverity",
+    "Directive",
     "IS_WIN",
     "Location",
+    "MYST_DIRECTIVE",
     "MYST_ROLE",
     "Position",
     "RST_DEFAULT_ROLE",
+    "RST_DIRECTIVE",
+    "RST_DIRECTIVE_OPTION",
     "RST_ROLE",
     "Range",
     "Role",
     "Uri",
 )
 
-MYST_DIRECTIVE: re.Pattern = re.compile(
-    r"""
-    (\s*)                             # directives can be indented
-    (?P<directive>
-      ```(`*)?                        # directives start with at least 3 ` chars
-      (?!\w)                          # -- regular code blocks are not directives
-      [{]?                            # followed by an opening brace
-      (?P<name>[^}]+)?                # directives have a name
-      [}]?                            # directives are closed with a closing brace
-    )
-    (\s+(?P<argument>.*?)\s*$)?       # directives may take an argument
-    """,
-    re.VERBOSE,
-)
-"""A regular expression to detect and parse partial and complete MyST directives.
-
-This does **not** include any options or content that may be included with the
-initial declaration.
-"""
-
-
-RST_DIRECTIVE: re.Pattern = re.compile(
-    r"""
-    (\s*)                             # directives can be indented
-    (?P<directive>
-      \.\.                            # directives start with a comment
-      [ ]?                            # followed by a space
-      (?P<substitution>\|             # this could be a substitution definition
-        (?P<substitution_text>[^|]+)?
-      \|?)?
-      [ ]?
-      (?P<name>([\w-]|:(?!:))+)?      # directives have a name
-      (::)?                           # directives end with '::'
-    )
-    ([\s]+(?P<argument>.*?)\s*$)?     # directives may take an argument
-    """,
-    re.VERBOSE,
-)
-"""A regular expression to detect and parse partial and complete directives.
-
-This does **not** include any options or content that may be included underneath
-the initial declaration. A number of named capture groups are available.
-
-``name``
-   The name of the directive, not including the domain prefix.
-
-``directive``
-   Everything that makes up a directive, from the initial ``..`` up to and including the
-   ``::`` characters.
-
-``argument``
-   All argument text.
-
-``substitution``
-   If the directive is part of a substitution definition, this group will contain
-"""
-
-
-RST_DIRECTIVE_OPTION: re.Pattern = re.compile(
-    r"""
-    (?P<indent>\s+)       # directive options must be indented
-    (?P<option>
-      :                   # options start with a ':'
-      (?P<name>[\w-]+)?   # options have a name
-      :?                  # options end with a ':'
-    )
-    (\s*
-      (?P<value>.*)       # options can have a value
-    )?
-    """,
-    re.VERBOSE,
-)
-"""A regular expression used to detect and parse partial and complete directive options.
-
-A number of named capture groups are available
-
-``name``
-   The name of the option
-
-``option``
-   The name of the option including the surrounding ``:`` characters.
-
-``indent``
-   The whitespace characters making preceeding the initial ``:`` character
-
-``value``
-   The value passed to the option
-
-"""
-
 
 # -- DB Types
 #
 # These represent the structure of data as stored in the SQLite database
-Directive = tuple[str, Optional[str], Optional[str]]
 Symbol = tuple[  # Represents either a document symbol or workspace symbol depending on context.
     int,  # id
     str,  # name

--- a/lib/esbonio/esbonio/sphinx_agent/types/directives.py
+++ b/lib/esbonio/esbonio/sphinx_agent/types/directives.py
@@ -4,6 +4,7 @@ import re
 import typing
 from dataclasses import dataclass
 from dataclasses import field
+from typing import Any
 
 from .lsp import Location
 
@@ -110,6 +111,16 @@ A number of named capture groups are available
 class Directive:
     """Represents a directive."""
 
+    @dataclass
+    class ArgumentProvider:
+        """An argument provider instance."""
+
+        name: str
+        """The name of the provider."""
+
+        kwargs: dict[str, Any] = field(default_factory=dict)
+        """Arguments to pass to the argument provider"""
+
     name: str
     """The name of the directive, as the user would type in an rst file."""
 
@@ -119,6 +130,21 @@ class Directive:
     location: Location | None = field(default=None)
     """The location of the directive's implementation, if known"""
 
+    argument_providers: list[ArgumentProvider] = field(default_factory=list)
+    """The list of argument providers that can be used with this directive."""
+
+    def to_db(
+        self, dumps: Callable[[Any], str]
+    ) -> tuple[str, str | None, str | None, str | None]:
+        """Convert this directive to its database representation"""
+
+        providers = None
+        if len(self.argument_providers) > 0:
+            providers = dumps(self.argument_providers)
+
+        location = dumps(self.location) if self.location is not None else None
+        return (self.name, self.implementation, location, providers)
+
     @classmethod
     def from_db(
         cls,
@@ -126,11 +152,20 @@ class Directive:
         name: str,
         implementation: str | None,
         location: str | None,
+        providers: str | None,
     ) -> Directive:
         """Create a directive from its database representation"""
+
         loc = load_as(location, Location) if location is not None else None
+        argument_providers = (
+            load_as(providers, list[Directive.ArgumentProvider])
+            if providers is not None
+            else []
+        )
+
         return cls(
             name=name,
             implementation=implementation,
             location=loc,
+            argument_providers=argument_providers,
         )

--- a/lib/esbonio/esbonio/sphinx_agent/types/directives.py
+++ b/lib/esbonio/esbonio/sphinx_agent/types/directives.py
@@ -21,7 +21,6 @@ MYST_DIRECTIVE: re.Pattern = re.compile(
     (\s*)                             # directives can be indented
     (?P<directive>
       ```(`*)?                        # directives start with at least 3 ` chars
-      (?!\w)                          # -- regular code blocks are not directives
       [{]?                            # followed by an opening brace
       (?P<name>[^}]+)?                # directives have a name
       [}]?                            # directives are closed with a closing brace

--- a/lib/esbonio/esbonio/sphinx_agent/types/directives.py
+++ b/lib/esbonio/esbonio/sphinx_agent/types/directives.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import re
+import typing
+from dataclasses import dataclass
+from dataclasses import field
+
+from .lsp import Location
+
+if typing.TYPE_CHECKING:
+    from typing import Callable
+    from typing import TypeVar
+
+    T = TypeVar("T")
+    JsonLoader = Callable[[str, type[T]], T]
+
+
+MYST_DIRECTIVE: re.Pattern = re.compile(
+    r"""
+    (\s*)                             # directives can be indented
+    (?P<directive>
+      ```(`*)?                        # directives start with at least 3 ` chars
+      (?!\w)                          # -- regular code blocks are not directives
+      [{]?                            # followed by an opening brace
+      (?P<name>[^}]+)?                # directives have a name
+      [}]?                            # directives are closed with a closing brace
+    )
+    (\s+(?P<argument>.*?)\s*$)?       # directives may take an argument
+    """,
+    re.VERBOSE,
+)
+"""A regular expression to detect and parse partial and complete MyST directives.
+
+This does **not** include any options or content that may be included with the
+initial declaration.
+"""
+
+
+RST_DIRECTIVE: re.Pattern = re.compile(
+    r"""
+    (\s*)                             # directives can be indented
+    (?P<directive>
+      \.\.                            # directives start with a comment
+      [ ]?                            # followed by a space
+      (?P<substitution>\|             # this could be a substitution definition
+        (?P<substitution_text>[^|]+)?
+      \|?)?
+      [ ]?
+      (?P<name>([\w-]|:(?!:))+)?      # directives have a name
+      (::)?                           # directives end with '::'
+    )
+    ([\s]+(?P<argument>.*?)\s*$)?     # directives may take an argument
+    """,
+    re.VERBOSE,
+)
+"""A regular expression to detect and parse partial and complete directives.
+
+This does **not** include any options or content that may be included underneath
+the initial declaration. A number of named capture groups are available.
+
+``name``
+   The name of the directive, not including the domain prefix.
+
+``directive``
+   Everything that makes up a directive, from the initial ``..`` up to and including the
+   ``::`` characters.
+
+``argument``
+   All argument text.
+
+``substitution``
+   If the directive is part of a substitution definition, this group will contain
+"""
+
+
+RST_DIRECTIVE_OPTION: re.Pattern = re.compile(
+    r"""
+    (?P<indent>\s+)       # directive options must be indented
+    (?P<option>
+      :                   # options start with a ':'
+      (?P<name>[\w-]+)?   # options have a name
+      :?                  # options end with a ':'
+    )
+    (\s*
+      (?P<value>.*)       # options can have a value
+    )?
+    """,
+    re.VERBOSE,
+)
+"""A regular expression used to detect and parse partial and complete directive options.
+
+A number of named capture groups are available
+
+``name``
+   The name of the option
+
+``option``
+   The name of the option including the surrounding ``:`` characters.
+
+``indent``
+   The whitespace characters making preceeding the initial ``:`` character
+
+``value``
+   The value passed to the option
+
+"""
+
+
+@dataclass
+class Directive:
+    """Represents a directive."""
+
+    name: str
+    """The name of the directive, as the user would type in an rst file."""
+
+    implementation: str | None
+    """The dotted name of the directive's implementation."""
+
+    location: Location | None = field(default=None)
+    """The location of the directive's implementation, if known"""
+
+    @classmethod
+    def from_db(
+        cls,
+        load_as: JsonLoader,
+        name: str,
+        implementation: str | None,
+        location: str | None,
+    ) -> Directive:
+        """Create a directive from its database representation"""
+        loc = load_as(location, Location) if location is not None else None
+        return cls(
+            name=name,
+            implementation=implementation,
+            location=loc,
+        )

--- a/lib/esbonio/esbonio/sphinx_agent/types/roles.py
+++ b/lib/esbonio/esbonio/sphinx_agent/types/roles.py
@@ -177,7 +177,7 @@ class Role:
         location: str | None,
         providers: str | None,
     ) -> Role:
-        """Convert this role to its database representation."""
+        """Create a role from its database representation."""
 
         loc = load_as(location, Location) if location is not None else None
         target_providers = (

--- a/lib/esbonio/tests/e2e/conftest.py
+++ b/lib/esbonio/tests/e2e/conftest.py
@@ -26,11 +26,19 @@ async def client(lsp_client: LanguageClient, uri_for, tmp_path_factory):
     await lsp_client.initialize_session(
         types.InitializeParams(
             capabilities=types.ClientCapabilities(
-                # Signal pull diagnostic support
                 text_document=types.TextDocumentClientCapabilities(
+                    completion=types.CompletionClientCapabilities(
+                        completion_item=types.ClientCompletionItemOptions(
+                            documentation_format=[
+                                types.MarkupKind.Markdown,
+                                types.MarkupKind.PlainText,
+                            ]
+                        ),
+                    ),
+                    # Signal pull diagnostic support
                     diagnostic=types.DiagnosticClientCapabilities(
                         dynamic_registration=False
-                    )
+                    ),
                 ),
                 # Signal workDoneProgress/create support.
                 window=types.WindowClientCapabilities(

--- a/lib/esbonio/tests/e2e/test_e2e_directives.py
+++ b/lib/esbonio/tests/e2e/test_e2e_directives.py
@@ -23,7 +23,6 @@ EXPECTED = {
 
 RST_EXPECTED = EXPECTED.copy()
 MYST_EXPECTED = {"eval-rst", *EXPECTED}
-LEXERS = {"python", "python-console", "nix"}
 
 UNEXPECTED = {
     "macro",
@@ -33,10 +32,19 @@ UNEXPECTED = {
 RST_UNEXPECTED = {"eval-rst", *UNEXPECTED}
 MYST_UNEXPECTED = UNEXPECTED.copy()
 
+# Code blocks
+LEXERS = {"python", "python-console", "nix"}
+
+# Filepaths
+ROOT_FILES = {"conf.py", "index.rst", "myst", "rst"}
+RST_FILES = {"directives.rst", "roles.rst", "domains"}
+MYST_FILES = {"directives.md", "roles.md"}
+
 
 @pytest.mark.parametrize(
     "text, expected, unexpected",
     [
+        # Test cases covering directive name completion
         (".", None, None),
         ("..", RST_EXPECTED, RST_UNEXPECTED),
         (".. ", RST_EXPECTED, RST_UNEXPECTED),
@@ -54,6 +62,21 @@ MYST_UNEXPECTED = UNEXPECTED.copy()
         ("   .. codex-block:: ", None, None),
         ("   .. _some_label:", None, None),
         ("   .. c:", RST_EXPECTED, RST_UNEXPECTED),
+        # Test cases covering directive argument completion for...
+        #
+        # -- pygments lexers
+        (".. code-block:: ", LEXERS, None),
+        (".. highlight:: ", LEXERS, None),
+        (".. sourcecode:: ", LEXERS, None),
+        # -- filepaths
+        (".. image:: /", ROOT_FILES, None),
+        (".. image:: ../", ROOT_FILES, None),
+        (".. image:: ", RST_FILES, None),
+        (".. image:: .", RST_FILES, None),
+        (".. image:: ./", RST_FILES, None),
+        (".. figure:: ./", RST_FILES, None),
+        (".. include:: ./", RST_FILES, None),
+        (".. literalinclude:: ./", RST_FILES, None),
     ],
 )
 @pytest.mark.asyncio(loop_scope="session")
@@ -132,9 +155,10 @@ async def test_rst_directive_completions(
 @pytest.mark.parametrize(
     "text, expected, unexpected",
     [
+        # Test cases covering directive name completions
         ("`", None, None),
         ("``", None, None),
-        # Unless the user types a '{', we should suggest languauge names
+        # -- Unless the user types a '{', we should suggest languauge names
         ("```", LEXERS, MYST_EXPECTED | MYST_UNEXPECTED),
         ("```{", MYST_EXPECTED, MYST_UNEXPECTED),
         ("```{d", MYST_EXPECTED, MYST_UNEXPECTED),
@@ -143,7 +167,7 @@ async def test_rst_directive_completions(
         ("```{c:", MYST_EXPECTED, MYST_UNEXPECTED),
         ("   `", None, None),
         ("   ``", None, None),
-        # Unless the user types a '{', we should suggest languauge names
+        # -- Unless the user types a '{', we should suggest languauge names
         ("   ```", LEXERS, MYST_EXPECTED | MYST_UNEXPECTED),
         ("   ```{", MYST_EXPECTED, MYST_UNEXPECTED),
         ("   ```{d", MYST_EXPECTED, MYST_UNEXPECTED),
@@ -151,6 +175,21 @@ async def test_rst_directive_completions(
         ("   ```{code-b", MYST_EXPECTED, MYST_UNEXPECTED),
         ("   ```{codex-block}", None, None),
         ("   ```{c:", MYST_EXPECTED, MYST_UNEXPECTED),
+        # Test cases covering directive argument completions for...
+        #
+        # -- pygments lexers
+        ("```{code-block} ", LEXERS, None),
+        ("```{highlight} ", LEXERS, None),
+        ("```{sourcecode} ", LEXERS, None),
+        # -- filepaths
+        ("```{image} /", ROOT_FILES, None),
+        ("```{image} ../", ROOT_FILES, None),
+        ("```{image} ", MYST_FILES, None),
+        ("```{image} .", MYST_FILES, None),
+        ("```{image} ./", MYST_FILES, None),
+        ("```{figure} ./", MYST_FILES, None),
+        ("```{include} ./", MYST_FILES, None),
+        ("```{literalinclude} ./", MYST_FILES, None),
     ],
 )
 @pytest.mark.asyncio(loop_scope="session")

--- a/lib/esbonio/tests/e2e/test_e2e_directives.py
+++ b/lib/esbonio/tests/e2e/test_e2e_directives.py
@@ -23,6 +23,7 @@ EXPECTED = {
 
 RST_EXPECTED = EXPECTED.copy()
 MYST_EXPECTED = {"eval-rst", *EXPECTED}
+LEXERS = {"python", "python-console", "nix"}
 
 UNEXPECTED = {
     "macro",
@@ -133,7 +134,8 @@ async def test_rst_directive_completions(
     [
         ("`", None, None),
         ("``", None, None),
-        ("```", MYST_EXPECTED, MYST_UNEXPECTED),
+        # Unless the user types a '{', we should suggest languauge names
+        ("```", LEXERS, MYST_EXPECTED | MYST_UNEXPECTED),
         ("```{", MYST_EXPECTED, MYST_UNEXPECTED),
         ("```{d", MYST_EXPECTED, MYST_UNEXPECTED),
         ("```{code-b", MYST_EXPECTED, MYST_UNEXPECTED),
@@ -141,7 +143,8 @@ async def test_rst_directive_completions(
         ("```{c:", MYST_EXPECTED, MYST_UNEXPECTED),
         ("   `", None, None),
         ("   ``", None, None),
-        ("   ```", MYST_EXPECTED, MYST_UNEXPECTED),
+        # Unless the user types a '{', we should suggest languauge names
+        ("   ```", LEXERS, MYST_EXPECTED | MYST_UNEXPECTED),
         ("   ```{", MYST_EXPECTED, MYST_UNEXPECTED),
         ("   ```{d", MYST_EXPECTED, MYST_UNEXPECTED),
         ("   ```{doctest}", None, None),

--- a/lib/esbonio/tests/server/features/test_directive_completion.py
+++ b/lib/esbonio/tests/server/features/test_directive_completion.py
@@ -8,11 +8,11 @@ from pygls.workspace import TextDocument
 from pytest_lsp import client_capabilities
 
 from esbonio import server
-from esbonio.server.features.directives import Directive
 from esbonio.server.features.directives import completion
 from esbonio.server.testing import range_from_str
 from esbonio.sphinx_agent.types import MYST_DIRECTIVE
 from esbonio.sphinx_agent.types import RST_DIRECTIVE
+from esbonio.sphinx_agent.types import Directive
 
 if typing.TYPE_CHECKING:
     from typing import Literal

--- a/lib/esbonio/tests/server/test_patterns.py
+++ b/lib/esbonio/tests/server/test_patterns.py
@@ -16,8 +16,7 @@ from esbonio.sphinx_agent.types import RST_ROLE
         ("```", {"directive": "```"}),
         ("````", {"directive": "````"}),
         ("```{d", {"directive": "```{d", "name": "d"}),
-        # Regular code blocks should not be recognised
-        ("```python", None),
+        ("```python", {"directive": "```python", "name": "python"}),
         ("```{image}", {"name": "image", "directive": "```{image}"}),
         (
             "```{image}  filename.png",

--- a/lib/esbonio/tests/workspaces/demo/myst/directives.md
+++ b/lib/esbonio/tests/workspaces/demo/myst/directives.md
@@ -9,3 +9,33 @@ The most obvious feature is the completion suggestions, try inserting a `{note}`
 % Add your note here...
 
 Notice how VSCode automatically presented you with a list of all the directives you can use in this Sphinx project?
+
+### Arguments
+
+While directive names Just Work{sup}`TM`, Esbonio is only able to offer suggestions for specific argument types.
+By default Esbonio can provide suggestions for
+
+**Filepaths**
+
+Completing filepath arguments is supported for the following directives
+
+- [`figure`](https://docutils.sourceforge.io/docs/ref/rst/directives.html#figure)
+- [`image`](https://docutils.sourceforge.io/docs/ref/rst/directives.html#image)
+- [`include`](https://docutils.sourceforge.io/docs/ref/rst/directives.html#image)
+- {external+sphinx:rst:dir}`literalinclude`
+
+% Try using the `literalinclude` directive to insert the contents of this project's conf.py here...
+
+
+**Pygments Lexers**
+
+Sphinx uses the [pygments](https://pygments.org/) library for its syntax highlighting, Esbonio will offer the names of available lexers as suggestions for the following directives.
+
+- {external+sphinx:rst:dir}`code`
+- {external+sphinx:rst:dir}`code-block`
+- {external+sphinx:rst:dir}`highlight`
+- {external+sphinx:rst:dir}`sourcecode`
+
+Of course MyST allows you to use standard Markdown code blocks as well, Esbonio will also offer suggestions in this context.
+
+% Try inserting a code block on the next line...

--- a/lib/esbonio/tests/workspaces/demo/rst/directives.rst
+++ b/lib/esbonio/tests/workspaces/demo/rst/directives.rst
@@ -11,3 +11,31 @@ The most obvious feature is the completion suggestions, try inserting a ``.. not
 .. Add your note here...
 
 Notice how VSCode automatically presented you with a list of all the directives you can use in this Sphinx project?
+
+Arguments
+^^^^^^^^^
+
+While directive names Just Work\ :sup:`TM`, Esbonio is only able to offer suggestions for specific argument types.
+By default Esbonio can provide suggestions for
+
+**Filepaths**
+
+Completing filepath arguments is supported for the following directives
+
+- `figure <https://docutils.sourceforge.io/docs/ref/rst/directives.html#figure>`__
+- `image <https://docutils.sourceforge.io/docs/ref/rst/directives.html#image>`__
+- `include <https://docutils.sourceforge.io/docs/ref/rst/directives.html#image>`__
+- :external+sphinx:rst:dir:`literalinclude`
+
+.. Try using the `literalinclude` directive to insert the contents of this project's conf.py here...
+
+**Pygments Lexers**
+
+Sphinx uses the `pygments <https://pygments.org/>`__ library for its syntax highlighting, Esbonio will offer the names of available lexers as suggestions for the following directives.
+
+- :external+sphinx:rst:dir:`code`
+- :external+sphinx:rst:dir:`code-block`
+- :external+sphinx:rst:dir:`highlight`
+- :external+sphinx:rst:dir:`sourcecode`
+
+.. Try inserting a code block on the next line...


### PR DESCRIPTION
This re-implements support for providing completion suggestions for a directive's arguments.
Including:

**Code blocks**

![image](https://github.com/user-attachments/assets/778a1968-0b60-4551-bf74-ba5680affa76)

![image](https://github.com/user-attachments/assets/71d1e825-b57d-4ae4-a413-768532d5f8cc)


**Filepaths**

![image](https://github.com/user-attachments/assets/9a556258-63a6-4b56-9745-0fd21e8c68c6)

![image](https://github.com/user-attachments/assets/19883b7a-c827-4bc4-a69d-dc1a789dc2d9)


TODO
- [x] MyST support
- [x] Filenames
- [x] Tests!
