### PR TITLE
lsp: Don't follow symlinks when expanding `${venv:<env>}`

### DIFF
--- a/lib/esbonio/changes/945.fix.md
+++ b/lib/esbonio/changes/945.fix.md
@@ -1,0 +1,1 @@
+When expanding the `${venv}` config variable, the server should no longer accidentally follow symlinks back to the base Python installation

--- a/lib/esbonio/esbonio/server/features/sphinx_manager/config.py
+++ b/lib/esbonio/esbonio/server/features/sphinx_manager/config.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import importlib.util
 import logging
+import os
 import pathlib
 import re
 import sys
@@ -314,4 +315,7 @@ def _resolve_variable_venv(env: str, cwd: str) -> str:
         return str(envpath)
     else:
         envpath = cwd / envpath
-        return str(envpath.resolve())
+        # Can't call envpath.resolve() here as that will also follow symlinks which we
+        # don't want to do
+        # https://github.com/swyddfa/esbonio/issues/945
+        return os.path.normpath(envpath)

--- a/lib/esbonio/esbonio/sphinx_agent/util.py
+++ b/lib/esbonio/esbonio/sphinx_agent/util.py
@@ -12,8 +12,10 @@ logger = logging.getLogger("esbonio.sphinx_agent")
 
 
 def _serialize_message(obj):
-    if dataclasses.is_dataclass(obj):
-        return dataclasses.asdict(obj)  # type: ignore[call-overload]
+    # As far as I know there's not a public function to detect just instances of a
+    # dataclass...
+    if dataclasses.is_dataclass(obj) and not isinstance(obj, type):
+        return dataclasses.asdict(obj)
 
     if isinstance(obj, (_TranslationProxy, pathlib.Path)):
         return str(obj)

--- a/lib/esbonio/tests/server/features/test_sphinx_config.py
+++ b/lib/esbonio/tests/server/features/test_sphinx_config.py
@@ -335,7 +335,7 @@ def mk_uri(path: str) -> str:
                 python_path=PYPATH,
             ),
             SphinxConfig(
-                python_command=["C:\\path\\to\\workspace\\env\\Scripts\\python.exe"],
+                python_command=["c:\\path\\to\\workspace\\env\\Scripts\\python.exe"],
                 build_command=BUILD_CMD,
                 cwd=CWD,
                 python_path=PYPATH,
@@ -373,7 +373,7 @@ def mk_uri(path: str) -> str:
                 python_path=PYPATH,
             ),
             SphinxConfig(
-                python_command=["C:\\path\\to\\env\\Scripts\\python.exe"],
+                python_command=["c:\\path\\to\\env\\Scripts\\python.exe"],
                 build_command=BUILD_CMD,
                 cwd=CWD,
                 python_path=PYPATH,
@@ -392,7 +392,7 @@ def mk_uri(path: str) -> str:
                 python_path=PYPATH,
             ),
             SphinxConfig(
-                python_command=["C:\\path\\to\\env\\Scripts\\python.exe"],
+                python_command=["c:\\path\\to\\env\\Scripts\\python.exe"],
                 build_command=BUILD_CMD,
                 cwd=CWD,
                 python_path=PYPATH,


### PR DESCRIPTION
Closes #945