### PR TITLE
Refine build and progress token handling

### DIFF
--- a/lib/esbonio/changes/802.fix.md
+++ b/lib/esbonio/changes/802.fix.md
@@ -1,0 +1,1 @@
+The server should now ensure that all `window/workDoneProgress` tokens are cleaned up

--- a/lib/esbonio/esbonio/server/features/sphinx_manager/client.py
+++ b/lib/esbonio/esbonio/server/features/sphinx_manager/client.py
@@ -50,6 +50,7 @@ class SphinxClient(Protocol):
     @property
     def db(self) -> pathlib.Path:
         """Connection to the associated database."""
+        ...
 
     @property
     def builder(self) -> str:

--- a/lib/esbonio/esbonio/server/features/sphinx_manager/client_subprocess.py
+++ b/lib/esbonio/esbonio/server/features/sphinx_manager/client_subprocess.py
@@ -267,13 +267,17 @@ class SubprocessSphinxClient(JsonRPCClient):
             content_overrides=content_overrides or {},
         )
 
-        self._building = True
+        self._set_state(ClientState.Building)
         try:
             result = await self.protocol.send_request_async("sphinx/build", params)
-        finally:
-            self._building = False
+            self._set_state(ClientState.Running)
 
-        return result
+            return result
+        except Exception as exc:
+            self.exception = exc
+            self._set_state(ClientState.Errored)
+
+            raise
 
 
 async def forward_stderr(server: asyncio.subprocess.Process):

--- a/lib/esbonio/esbonio/server/features/sphinx_manager/manager.py
+++ b/lib/esbonio/esbonio/server/features/sphinx_manager/manager.py
@@ -389,6 +389,11 @@ class SphinxManager(server.LanguageFeature):
     async def start_progress(self, client: SphinxClient):
         """Start reporting work done progress for the given client."""
 
+        # Make sure any existing progress tokens are cleaned up
+        if (existing := self._progress_tokens.get(client.id)) is not None:
+            self.logger.warning("Overwriting existing progress token: %r!", existing)
+            self.stop_progress(client)
+
         token = str(uuid.uuid4())
         self.logger.debug("Starting progress: '%s'", token)
 
@@ -408,6 +413,7 @@ class SphinxManager(server.LanguageFeature):
         if (token := self._progress_tokens.pop(client.id, None)) is None:
             return
 
+        self.logger.debug("Ending progress: %r", token)
         self.server.work_done_progress.end(
             token, lsp.WorkDoneProgressEnd(message="Finished")
         )

--- a/lib/esbonio/esbonio/server/features/sphinx_manager/manager.py
+++ b/lib/esbonio/esbonio/server/features/sphinx_manager/manager.py
@@ -220,8 +220,8 @@ class SphinxManager(server.LanguageFeature):
         if client is None:
             return
 
-        if client.state != ClientState.Running:
-            self.logger.debug("Skipping build, state is: %s", client.state)
+        if client.state not in {ClientState.Running}:
+            self.logger.debug("Skipping build, client is %s", client.state)
             return
 
         if (project := self.project_manager.get_project(uri)) is None:
@@ -240,20 +240,17 @@ class SphinxManager(server.LanguageFeature):
             if saved_version < doc_version:
                 content_overrides[str(src_uri)] = doc.source
 
-        await self.start_progress(client)
-
         try:
             result = await client.build(content_overrides=content_overrides)
+
+            # Notify listeners.
+            self._events.trigger("build", client, result)
+
         except Exception as exc:
             self.server.window_show_message(
                 lsp.ShowMessageParams(message=f"{exc}", type=lsp.MessageType.Error)
             )
             return
-        finally:
-            self.stop_progress(client)
-
-        # Notify listeners.
-        self._events.trigger("build", client, result)
 
     async def restart_client(self, client_id: str):
         """Restart the client with the given id"""
@@ -367,6 +364,12 @@ class SphinxManager(server.LanguageFeature):
                     "sphinx/appCreated",
                     AppCreatedNotification(id=client.id, application=sphinx_info),
                 )
+
+        if old_state == ClientState.Building:
+            self.stop_progress(client)
+
+        if new_state == ClientState.Building:
+            self.server.run_task(self.start_progress(client))
 
         if new_state == ClientState.Errored:
             error = ""


### PR DESCRIPTION
Before creating a new progress token, the server now checks to see if there is one already and ends it. (Closes #802)

However, as of this PR, the check to see if Sphinx was already building before triggering another one - now actually works which should prevent the situation that originally caused #802 in the first place.