### PR TITLE
Some more fixes

### DIFF
--- a/lib/esbonio/changes/788.fix.md
+++ b/lib/esbonio/changes/788.fix.md
@@ -1,0 +1,1 @@
+The preview should no longer lose its scroll state when reloading a page that was opened at a specific anchor tag (e.g. `#heading-name`)

--- a/lib/esbonio/changes/904.fix.md
+++ b/lib/esbonio/changes/904.fix.md
@@ -1,0 +1,1 @@
+The configuration system should now produce a lot less log noise

--- a/lib/esbonio/esbonio/server/_configuration.py
+++ b/lib/esbonio/esbonio/server/_configuration.py
@@ -5,6 +5,7 @@ import json
 import pathlib
 import re
 import typing
+from functools import partial
 from typing import Generic
 from typing import TypeVar
 
@@ -230,46 +231,62 @@ class Configuration:
             self.logger.debug("Ignoring duplicate subscription: %s", subscription)
             return
 
-        self._subscriptions[subscription] = None
+        # We need to wait for the server to be ready before we update any subscriptions
+        if self.server.ready.done():
+            self._notify_subscription(subscription)
 
-        # Once the server is ready, update all the subscriptions
-        self.server.ready.add_done_callback(self._notify_subscriptions)
+        else:
+            callback = partial(self._notify_subscription, subscription)
+            self.server.ready.add_done_callback(callback)
 
-    def _notify_subscriptions(self, *args):
-        """Notify subscriptions about configuration changes, if necessary."""
+    def _notify_subscriptions(self):
+        """Notify all subscriptions about configuration changes, if necessary."""
 
-        for subscription, previous_value in self._subscriptions.items():
-            value = self._get_config(
-                subscription.section,
-                subscription.spec,
-                subscription.context,
+        for subscription in self._subscriptions:
+            self._notify_subscription(subscription)
+
+    def _notify_subscription(self, subscription: Subscription, *args):
+        """Check a single subscription's value and notify it, if it has changed.
+
+        Parameters
+        ----------
+        subscription
+           The subscription to check
+        """
+
+        previous_value = self._subscriptions.get(subscription)
+        value = self._get_config(
+            subscription.section,
+            subscription.spec,
+            subscription.context,
+        )
+
+        # No need to notify if nothing has changed
+        self.logger.debug("Previous: %s", previous_value)
+        self.logger.debug("Current: %s", value)
+        self._subscriptions[subscription] = value
+
+        if previous_value == value:
+            return
+
+        change_event = ConfigChangeEvent(
+            scope=subscription.context.scope,
+            value=value,
+            previous=previous_value,
+        )
+        self.logger.info("%s", change_event)
+
+        try:
+            ret = subscription.callback(change_event)
+            if inspect.iscoroutine(ret):
+                self.server.run_task(ret)
+
+        except Exception:
+            self.logger.error(
+                "Error in configuration callback: %s",
+                subscription.callback,
+                exc_info=True,
             )
-
-            # No need to notify if nothing has changed
-            self.logger.debug("Previous: %s", previous_value)
-            self.logger.debug("Current: %s", value)
-            if previous_value == value:
-                continue
-
-            self._subscriptions[subscription] = value
-            change_event = ConfigChangeEvent(
-                scope=subscription.context.scope,
-                value=value,
-                previous=previous_value,
-            )
-            self.logger.info("%s", change_event)
-
-            try:
-                ret = subscription.callback(change_event)
-                if inspect.iscoroutine(ret):
-                    self.server.run_task(ret)
-
-            except Exception:
-                self.logger.error(
-                    "Error in configuration callback: %s",
-                    subscription.callback,
-                    exc_info=True,
-                )
 
     def get(self, section: str, spec: type[T], scope: Uri | None = None) -> T:
         """Get the requested configuration section.

--- a/lib/esbonio/esbonio/server/_configuration.py
+++ b/lib/esbonio/esbonio/server/_configuration.py
@@ -46,9 +46,6 @@ class Subscription(Generic[T]):
     spec: type[T]
     """The subscription's class definition."""
 
-    callback: ConfigurationCallback
-    """The subscription's callback."""
-
     context: ConfigurationContext
     """The context for this subscription."""
 
@@ -163,7 +160,9 @@ class Configuration:
         self._file_config: dict[str, dict[str, Any]] = {}
         """The cached configuration coming from configuration files."""
 
-        self._subscriptions: dict[Subscription, Any] = {}
+        self._subscriptions: dict[
+            Subscription, tuple[Any, list[ConfigurationCallback]]
+        ] = {}
         """Subscriptions and their last known value"""
 
     @property
@@ -225,19 +224,33 @@ class Configuration:
         context = ConfigurationContext(
             file_scope=file_scope, workspace_scope=workspace_scope
         )
-        subscription = Subscription(section, spec, callback, context)
+        subscription = Subscription(section, spec, context)
 
-        if subscription in self._subscriptions:
-            self.logger.debug("Ignoring duplicate subscription: %s", subscription)
-            return
+        if new_subscription := subscription not in self._subscriptions:
+            self.logger.debug("Creating new subscription: %s", subscription)
+            self._subscriptions[subscription] = (None, [])
 
-        # We need to wait for the server to be ready before we update any subscriptions
+        value, callbacks = self._subscriptions[subscription]
+        callbacks.append(callback)
+
         if self.server.ready.done():
-            self._notify_subscription(subscription)
+            # If a value exists, notify the new callback immediately
+            if value is not None:
+                change_event = ConfigChangeEvent(
+                    scope=subscription.context.scope,
+                    value=value,
+                    previous=None,
+                )
+                self._invoke_callback(callback, change_event)
 
-        else:
-            callback = partial(self._notify_subscription, subscription)
-            self.server.ready.add_done_callback(callback)
+            else:
+                # Otherwise compute a value and notify all of them
+                self._notify_subscription(subscription)
+
+        elif new_subscription:
+            self.server.ready.add_done_callback(
+                partial(self._notify_subscription, subscription)
+            )
 
     def _notify_subscriptions(self):
         """Notify all subscriptions about configuration changes, if necessary."""
@@ -254,7 +267,7 @@ class Configuration:
            The subscription to check
         """
 
-        previous_value = self._subscriptions.get(subscription)
+        previous_value, callbacks = self._subscriptions[subscription]
         value = self._get_config(
             subscription.section,
             subscription.spec,
@@ -264,7 +277,7 @@ class Configuration:
         # No need to notify if nothing has changed
         self.logger.debug("Previous: %s", previous_value)
         self.logger.debug("Current: %s", value)
-        self._subscriptions[subscription] = value
+        self._subscriptions[subscription] = value, callbacks
 
         if previous_value == value:
             return
@@ -276,16 +289,30 @@ class Configuration:
         )
         self.logger.info("%s", change_event)
 
+        for callback in callbacks:
+            self._invoke_callback(callback, change_event)
+
+    def _invoke_callback(
+        self, callback: ConfigurationCallback, change_event: ConfigChangeEvent
+    ):
+        """Invoke the given callback
+
+        Parameters
+        ----------
+        callback
+           The callback function to invoke
+
+        change_event
+           The change event to send
+        """
         try:
-            ret = subscription.callback(change_event)
+            ret = callback(change_event)
             if inspect.iscoroutine(ret):
                 self.server.run_task(ret)
 
         except Exception:
             self.logger.error(
-                "Error in configuration callback: %s",
-                subscription.callback,
-                exc_info=True,
+                "Error in configuration callback: %s", callback, exc_info=True
             )
 
     def get(self, section: str, spec: type[T], scope: Uri | None = None) -> T:

--- a/lib/esbonio/esbonio/sphinx_agent/static/webview.js
+++ b/lib/esbonio/esbonio/sphinx_agent/static/webview.js
@@ -239,6 +239,14 @@ function sendMessage(data) {
 const handlers = {
     "view/reload": function (params) {
         console.debug("Reloading page...")
+
+        if (window.location.hash) {
+            // Clear the url hash before reloading, this will prevent us from losing our scroll state on reload.
+            // see https://github.com/swyddfa/esbonio/issues/788
+            //
+            // Can't be the empty string though, as that will cause the browser to jump to the top of the page!
+            window.location.hash = '_'
+        }
         window.location.reload()
     },
     "view/scroll": (params) => { scrollViewTo(params.uri, params.line) }


### PR DESCRIPTION
- The webview will now remove the `#hash` url component if present before reloading the page. This should help preserve scroll state across reloads. 
  Closes #788 
- The configuration system has been cleaned up to reduce duplicated work which helps to reduce the amount of logging spam it generated. 
  Closes #904