### PR TITLE
Fix `_StrPath` handling

### DIFF
--- a/lib/esbonio/changes/970.fix.md
+++ b/lib/esbonio/changes/970.fix.md
@@ -1,0 +1,1 @@
+Fix `${defaultBuildDir}` expansion for recent Sphinx versions

--- a/lib/esbonio/esbonio/sphinx_agent/config.py
+++ b/lib/esbonio/esbonio/sphinx_agent/config.py
@@ -158,9 +158,8 @@ class SphinxConfig:
         # the configuration variables here, before finally calling resolve() on the
         # remaining paths below.
         for name, value in dataclasses.asdict(self).items():
-            if not isinstance(value, str):
-                continue
-
+            # value can sometimes be Sphinx's `_StrPath` helper
+            value = str(value)
             if (match := VARIABLE.match(value)) is None:
                 continue
 

--- a/lib/esbonio/tests/conftest.py
+++ b/lib/esbonio/tests/conftest.py
@@ -19,6 +19,21 @@ def pytest_addoption(parser):
     )
 
 
+@pytest.hookimpl(tryfirst=True)
+def pytest_report_header(config: pytest.Config):
+    """Report additional information in pytest's output header"""
+    lines = []
+
+    try:
+        from sphinx import __version__
+
+        lines.append(f"sphinx: v{__version__}")
+    except ImportError:
+        lines.append("sphinx: none")
+
+    return lines
+
+
 @pytest.fixture(scope="session")
 def uri_for():
     """Helper function for returning the uri for a given file in the ``tests/``


### PR DESCRIPTION
Recent Sphinx versions started using the `_StrPath` helper/adapter in values produced by the cli which broke `${defaultBuildDir}` expansion