### PR TITLE
Add option to control synchronized scrolling behavior

### DIFF
--- a/code/changes/979.enhancement.md
+++ b/code/changes/979.enhancement.md
@@ -1,1 +1,3 @@
-Expose `esbonio.preview.synchronizeScroll` setting
+Expose `esbonio.preview.synchronizeScroll` setting.
+
+Add interactive `esbonio.preview.setScrollingBehavior` command to easily switch between valid options.

--- a/code/changes/979.enhancement.md
+++ b/code/changes/979.enhancement.md
@@ -1,0 +1,1 @@
+Expose `esbonio.preview.synchronizeScroll` setting

--- a/code/package.json
+++ b/code/package.json
@@ -78,6 +78,12 @@
                 "category": "Esbonio"
             },
             {
+                "command": "esbonio.preview.setScrollingBehavior",
+                "title": "Set Synchronized Scrolling Behavior",
+                "icon": "$(settings)",
+                "category": "Esbonio"
+            },
+            {
                 "command": "esbonio.server.restart",
                 "title": "Restart Language Server",
                 "category": "Esbonio",
@@ -468,6 +474,11 @@
                     "alt": "esbonio.preview.open",
                     "group": "navigation",
                     "when": "resourceLangId == restructuredtext || resourceLangId == markdown"
+                },
+                {
+                    "command": "esbonio.preview.setScrollingBehavior",
+                    "group": "navigation",
+                    "when": "activeWebviewPanelId == 'esbonioPreview'"
                 }
             ],
             "view/title": [

--- a/code/package.json
+++ b/code/package.json
@@ -237,6 +237,24 @@
                         "type": "integer",
                         "default": null,
                         "description": "The port number to bind the WebSocket server to.\nIf 0, a random port number will be chosen"
+                    },
+                    "esbonio.preview.synchronizeScroll": {
+                        "scope": "window",
+                        "type": "string",
+                        "default": "bothWays",
+                        "enum": [
+                            "bothWays",
+                            "editorWithPreview",
+                            "previewWithEditor",
+                            "disabled"
+                        ],
+                        "enumDescriptions": [
+                            "Synchronized scrolling will work both ways",
+                            "Scrolling the editor will automatically scroll the preview pane",
+                            "Scrolling the preview pane will automatically scroll the editor",
+                            "Synchronized scrolling is disabled"
+                        ],
+                        "description": "Control how synchronized scrolling behaves"
                     }
                 }
             },

--- a/code/package.json
+++ b/code/package.json
@@ -223,19 +223,19 @@
                     "esbonio.preview.bind": {
                         "scope": "window",
                         "type": "string",
-                        "default": null,
+                        "default": "localhost",
                         "description": "The network interface to bind the preview server to."
                     },
                     "esbonio.preview.httpPort": {
                         "scope": "window",
                         "type": "integer",
-                        "default": null,
+                        "default": 0,
                         "description": "The port number to bind the HTTP server to.\nIf 0, a random port number will be chosen"
                     },
                     "esbonio.preview.wsPort": {
                         "scope": "window",
                         "type": "integer",
-                        "default": null,
+                        "default": 0,
                         "description": "The port number to bind the WebSocket server to.\nIf 0, a random port number will be chosen"
                     },
                     "esbonio.preview.synchronizeScroll": {

--- a/code/src/common/constants.ts
+++ b/code/src/common/constants.ts
@@ -12,6 +12,7 @@ export namespace Commands {
   export const OPEN_PREVIEW = "esbonio.preview.open"
   export const OPEN_PREVIEW_TO_SIDE = "esbonio.preview.openSide"
   export const PREVIEW_FILE = "esbonio.server.previewFile"
+  export const SET_SCROLL_BEHAVIOUR = "esbonio.preview.setScrollingBehavior"
 
   export const RESTART_SERVER = "esbonio.server.restart"
 }

--- a/code/src/node/preview.ts
+++ b/code/src/node/preview.ts
@@ -26,9 +26,12 @@ export class PreviewManager {
 
   constructor(
     private logger: OutputChannelLogger,
-    private context: vscode.ExtensionContext,
+    context: vscode.ExtensionContext,
     private client: EsbonioClient
   ) {
+    context.subscriptions.push(
+      vscode.commands.registerCommand(Commands.SET_SCROLL_BEHAVIOUR, this.setScrollBehaviour, this)
+    )
     context.subscriptions.push(
       vscode.commands.registerTextEditorCommand(Commands.OPEN_PREVIEW, this.openPreview, this)
     )
@@ -68,6 +71,32 @@ export class PreviewManager {
         this.currentUri = uri
       }
     )
+  }
+
+
+  async setScrollBehaviour() {
+    let selection = await vscode.window.showQuickPick(
+      [
+        { label: "$(arrow-swap) Synchronize Scrolling Both Ways", value: "bothWays"},
+        { label: "$(arrow-right) Synchronize Editor Scrolling with Preview", value: "editorWithPreview"},
+        { label: "$(arrow-left) Synchronize Preview Scrolling with Editor", value: "previewWithEditor"},
+        { label: "$(x) Disable Synchronized Scrolling", value: "disabled"},
+      ],
+      {title: "Set Synchronized Scrolling Behavior"},
+    )
+    if (!selection) {
+      return
+    }
+
+    this.logger.debug(`Setting sync scroll behavior: '${selection.value}'`)
+    let config = vscode.workspace.getConfiguration("esbonio.preview")
+
+    try {
+      await config.update("synchronizeScroll", selection.value, vscode.ConfigurationTarget.Workspace)
+    } catch (err) {
+      this.logger.error(`Unable to update config: ${err}`)
+      return
+    }
   }
 
   async openPreview(editor: vscode.TextEditor) {

--- a/docs/lsp/reference/configuration.rst
+++ b/docs/lsp/reference/configuration.rst
@@ -343,21 +343,33 @@ Preview
 The following options control the behavior of the preview
 
 .. esbonio:config:: esbonio.preview.bind
-   :scope: project
+   :scope: global
    :type: string
 
    The network interface to bind the preview server to.
 
 .. esbonio:config:: esbonio.preview.httpPort
-   :scope: project
+   :scope: global
    :type: integer
 
    The port number to bind the HTTP server to.
    If ``0`` (the default), a random port number will be chosen
 
 .. esbonio:config:: esbonio.preview.wsPort
-   :scope: project
+   :scope: global
    :type: integer
 
    The port number to bind the WebSocket server to.
    If ``0`` (the default), a random port number will be chosen
+
+.. esbonio:config:: esbonio.preview.synchronizeScroll
+   :scope: global
+   :type: string
+
+   Controls how synchronized scrolling behaves.
+   The valid options are
+
+   - ``bothWays`` (default): Scrolling in either the editor or preview window will update the other window
+   - ``editorWithPreview``: Scrolling the editor window will update the preview window, but not vice-versa
+   - ``previewWithEditor``: Scrolling the preview window will update the editor window, but not vice-versa
+   - ``disabled``: Disable any form of synchronized scrolling

--- a/lib/esbonio/changes/979.enhancement.md
+++ b/lib/esbonio/changes/979.enhancement.md
@@ -1,0 +1,1 @@
+Introduce `esbonio.preview.synchronizeScroll` setting

--- a/lib/esbonio/esbonio/server/features/preview_manager/__init__.py
+++ b/lib/esbonio/esbonio/server/features/preview_manager/__init__.py
@@ -121,6 +121,7 @@ class PreviewManager(server.LanguageFeature):
             self.preview.build_mapping = self.build_mapping
 
         self.config = config
+        self.webview.config = config
         self.server.run_task(self.show_preview_uri())
 
     async def on_build(self, client: SphinxClient, result):

--- a/lib/esbonio/esbonio/server/features/preview_manager/config.py
+++ b/lib/esbonio/esbonio/server/features/preview_manager/config.py
@@ -1,6 +1,12 @@
 from __future__ import annotations
 
+from typing import Literal
+
 import attrs
+
+SyncScrollOptions = Literal[
+    "bothWays", "editorWithPreview", "previewWithEditor", "disabled"
+]
 
 
 @attrs.define
@@ -17,6 +23,9 @@ class PreviewConfig:
     ws_port: int = attrs.field(default=0)
     """The port to host the WebSocket server on. If ``0`` a random port number will be
     chosen"""
+
+    synchronize_scroll: SyncScrollOptions = attrs.field(default="bothWays")
+    """Control how synchronised scrolling works"""
 
     show_line_markers: bool = attrs.field(default=False)
     """If set, render the source line markers in the preview"""

--- a/lib/esbonio/esbonio/server/features/preview_manager/webview.py
+++ b/lib/esbonio/esbonio/server/features/preview_manager/webview.py
@@ -84,6 +84,9 @@ class WebviewServer(JsonRPCServer):
         if not self.connected or self._view_in_control:
             return
 
+        if self.config.synchronize_scroll not in {"bothWays", "editorWithPreview"}:
+            return
+
         # If the editor is already in control, reset the cooldown
         if self._editor_in_control:
             self._editor_in_control.cancel()
@@ -156,6 +159,9 @@ def make_ws_server(
     def on_scroll(ls: WebviewServer, params):
         """Called by the webview to scroll the editor."""
         if not server.connected or server._editor_in_control:
+            return
+
+        if ls.config.synchronize_scroll not in {"bothWays", "previewWithEditor"}:
             return
 
         # If the view is already in control, reset the cooldown.


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/a2d6ea5d-5eba-4073-84ab-9f4ce0e77abe)

This adds a new option to the language server - `esbonio.preview.synchronizeScroll` - which allows the user to control how synchronized scrolling works

- ``bothWays`` (default): Scrolling in either the editor or preview window will update the other window
- ``editorWithPreview``: Scrolling the editor window will update the preview window, but not vice-versa
- ``previewWithEditor``: Scrolling the preview window will update the editor window, but not vice-versa
- ``disabled``: Disable any form of synchronized scrolling

The VSCode extension has also been updated to provide a command making it easy to switch between the different options

Closes #979 