### PR TITLE
sphinx-agent: Simplify `dump_config` code

### DIFF
--- a/lib/esbonio/changes/969.fix.md
+++ b/lib/esbonio/changes/969.fix.md
@@ -1,0 +1,1 @@
+The sphinx agent no longer crashes when saving a configuration value that is a list containing exactly three items

--- a/lib/esbonio/esbonio/sphinx_agent/handlers/files.py
+++ b/lib/esbonio/esbonio/sphinx_agent/handlers/files.py
@@ -9,8 +9,6 @@ from ..types import Uri
 from ..util import as_json
 
 if typing.TYPE_CHECKING:
-    from typing import Any
-
     from sphinx.config import Config
 
 
@@ -27,12 +25,13 @@ CONFIG_TABLE = Database.Table(
     "config",
     [
         Database.Column(name="name", dtype="TEXT"),
-        Database.Column(name="scope", dtype="TEXT"),
         Database.Column(name="value", dtype="TEXT"),
     ],
 )
 
 IGNORED_CONFIG_NAMES = {
+    # Declared private by Sphinx in `68af0ac2b`
+    "_options",
     # Deprecated/removed in v3.5 and the backwards compatibility code causes issues when
     # dumping the config
     "html_add_permalinks",
@@ -44,42 +43,22 @@ def init_db(app: Sphinx, config: Config):
     app.esbonio.db.ensure_table(CONFIG_TABLE)
 
 
-def value_to_db(name: str, item: Any) -> tuple[str, str, Any]:
-    """Convert a single value to its DB representation"""
-
-    try:
-        (value, scope, _) = item
-        return (name, scope, as_json(value))
-    except Exception:
-        return (name, "", as_json(item))
-
-
 def dump_config(app: Sphinx, *args):
     """Dump the user's config into the db so that the parent language server can inspect
     it."""
     app.esbonio.db.clear_table(CONFIG_TABLE)
 
-    values: list[tuple[str, str, str]] = []
+    values: list[tuple[str, str]] = []
     config = app.config.__getstate__()
-
-    # For some reason, most config values are nested under 'values'
-    config_values = config.pop("values", {})
-
-    for name, item in config_values.items():
-        if name in IGNORED_CONFIG_NAMES:
-            continue
-
-        try:
-            values.append(value_to_db(name, item))
-        except Exception as exc:
-            logger.debug(f"Unable to dump config value: {name!r}: {exc}")
 
     for name, item in config.items():
         if name in IGNORED_CONFIG_NAMES:
             continue
 
         try:
-            values.append(value_to_db(name, item))
+            values.append(
+                (name, as_json(item)),
+            )
         except Exception as exc:
             logger.debug(f"Unable to dump config value: {name!r}: {exc}")
 


### PR DESCRIPTION
When saving the config to the db, esbonio tried to process the `values` key that appears to have contained additional information about a configuration value - such as the scope that needs to be recalculated when its value changes.

Trying to handle this introduced a strange bug where configuration values that were set to a list of *exactly* 3 values would be corrupted by the sphinx agent and would crash the process.

However, this `values` key was declared private and renamed to `_options` in [68af0ac2b](https://github.com/sphinx-doc/sphinx/commit/68af0ac2bee975621d089c5ac0e5ce44d0c75a7d). This commit fixes the issue by ignoring this `_options` key and removing the `scope` column (which is now always empty anyway) from the database

Closes #969