### PR TITLE
Improve error handling in the VSCode extension

### DIFF
--- a/code/changes/988.enhancement.md
+++ b/code/changes/988.enhancement.md
@@ -1,0 +1,2 @@
+If there is not already a server running and the user changes their Python env, the extension will automatically try to start the server.
+This should make recovering from a missing Python interpreter easier

--- a/code/changes/988.fix.md
+++ b/code/changes/988.fix.md
@@ -1,0 +1,2 @@
+The extension no longer silently does nothing if it cannot locate a compatible Python interpreter.
+Instead it uses an error notification to inform the user and given them the option of selecting an interpreter via the Python extension.

--- a/code/src/common/constants.ts
+++ b/code/src/common/constants.ts
@@ -15,6 +15,8 @@ export namespace Commands {
   export const SET_SCROLL_BEHAVIOUR = "esbonio.preview.setScrollingBehavior"
 
   export const RESTART_SERVER = "esbonio.server.restart"
+
+  export const PYTHON_SELECT_INTERPRETER = "python.setInterpreter"
 }
 
 /**

--- a/code/src/node/client.ts
+++ b/code/src/node/client.ts
@@ -233,6 +233,14 @@ export class EsbonioClient {
 
     let pythonCommand = await this.python.getCmd()
     if (!pythonCommand) {
+      let message = `Unable to start the Esbonio server as a compatible Python interpreter could not be found.
+        Please select an interpreter using the Python extension, or set the esbonio.server.pythonPath setting.`
+
+      let result = await vscode.window.showErrorMessage(message, 'Select Interpreter')
+      if (result === 'Select Interpreter') {
+        await vscode.commands.executeCommand(Commands.PYTHON_SELECT_INTERPRETER)
+      }
+
       return
     }
 

--- a/code/src/node/client.ts
+++ b/code/src/node/client.ts
@@ -153,7 +153,11 @@ export class EsbonioClient {
 
     // React to environment changes in the Python extension
     python.addHandler(Events.PYTHON_ENV_CHANGE, (_event: ActiveEnvironmentPathChangeEvent) => {
-      this.server?.sendNotification("workspace/didChangeConfiguration", { settings: null })
+
+      let states = [State.Running, State.Starting]
+      if (!this.server || !states.includes(this.server.state)) {
+        this.start()
+      }
     })
   }
 

--- a/code/src/node/python.ts
+++ b/code/src/node/python.ts
@@ -71,13 +71,13 @@ export class PythonManager {
 
     let activeEnv = await this.python.environments.resolveEnvironment(activeEnvPath)
     if (!activeEnv) {
-      this.logger.debug("Unable to resolve environment")
+      this.logger.error(`Python extension: Unable to resolve environment '${activeEnvPath.path}'`)
       return
     }
 
     let pythonUri = activeEnv.executable.uri
     if (!pythonUri) {
-      this.logger.debug("URI of Python executable is undefined...")
+      this.logger.error("Python extension: URI of Python executable is undefined...")
       return
     }
 


### PR DESCRIPTION
- The extension no longer silently does nothing if it cannot locate a compatible Python interpreter. Instead it uses an error notification to inform the user and given them the option of selecting an interpreter via the Python extension.

  ![image](https://github.com/user-attachments/assets/587dd0ff-c3de-47bd-925e-47401e973514)


- If there is not already a server running and the user changes their Python env, the extension will automatically try to start the server. This should make recovering from a missing Python interpreter easier