### PR TITLE
Instruct webview client not to cache content

### DIFF
--- a/lib/esbonio/changes/665.docs.md
+++ b/lib/esbonio/changes/665.docs.md
@@ -1,0 +1,1 @@
+Add first draft of the `1.0` getting started guide

--- a/lib/esbonio/changes/665.docs.md
+++ b/lib/esbonio/changes/665.docs.md
@@ -1,1 +1,0 @@
-Add first draft of the `1.0` getting started guide

--- a/lib/esbonio/changes/951.fix.md
+++ b/lib/esbonio/changes/951.fix.md
@@ -1,0 +1,1 @@
+Rather than trying to generate unique urls across projects (which broke many links), the preview server now sets the `Cache-Control` header in an attempt to ensure the preview always updates correctly.

--- a/lib/esbonio/changes/987.fix.md
+++ b/lib/esbonio/changes/987.fix.md
@@ -1,0 +1,1 @@
+Rather than trying to generate unique urls across projects (which broke many links), the preview server now sets the `Cache-Control` header in an attempt to ensure the preview always updates correctly.

--- a/lib/esbonio/esbonio/server/features/preview_manager/__init__.py
+++ b/lib/esbonio/esbonio/server/features/preview_manager/__init__.py
@@ -30,18 +30,16 @@ class PreviewManager(server.LanguageFeature):
         super().__init__(server)
         self.sphinx = sphinx
         self.sphinx.add_listener("build", self.on_build)
+        """The sphinx manager."""
+
+        self.built_clients: set[str] = set()
+        """Keeps track of which clients run a build at least once."""
 
         self.build_path: Optional[str] = None
-        """Used to construct the preview url, this holds the path to the build file
-        containing the content from the current src file. (Relative to the build
-        directory for the project.)"""
+        """The filepath we are currently displaying."""
 
-        self.active_client: Optional[str] = None
-        """Used to construct the preview url, holds the client id for the project we
-        are currently previewing."""
-
-        self.build_mapping: dict[str, Uri] = {}
-        """Used by the server itself, maps client ids to build directories."""
+        self.build_uri: Optional[Uri] = None
+        """The uri of the build dir we are currently serving from."""
 
         self.config = PreviewConfig()
         """The current configuration."""
@@ -110,7 +108,7 @@ class PreviewManager(server.LanguageFeature):
         # (Re)create the http server
         if self.preview is None:
             self.preview = make_http_server(self.server, config)
-            self.preview.build_mapping = self.build_mapping
+            self.preview.build_uri = self.build_uri
 
         elif (
             config.bind != self.preview.config.bind
@@ -118,7 +116,7 @@ class PreviewManager(server.LanguageFeature):
         ):
             self.preview.stop()
             self.preview = make_http_server(self.server, config)
-            self.preview.build_mapping = self.build_mapping
+            self.preview.build_uri = self.build_uri
 
         self.config = config
         self.webview.config = config
@@ -126,16 +124,13 @@ class PreviewManager(server.LanguageFeature):
 
     async def on_build(self, client: SphinxClient, result):
         """Called whenever a sphinx build completes."""
-        self.build_mapping[client.id] = client.build_uri
-
-        if self.preview is not None:
-            self.preview.build_mapping = self.build_mapping
+        self.built_clients.add(client.id)
 
         if self.webview is None or self.preview is None:
             return
 
         # Only refresh the view if the project we are previewing was built.
-        if client.id != self.active_client:
+        if client.build_uri != self.preview.build_uri:
             return
 
         self.logger.debug("Refreshing preview")
@@ -165,7 +160,7 @@ class PreviewManager(server.LanguageFeature):
 
         if (build_path := await project.get_build_path(src_uri)) is None:
             # The client might not have built the project yet.
-            if client.id not in self.build_mapping and retry is True:
+            if client.id not in self.built_clients and retry is True:
                 # Only retry this once.
                 await self.sphinx.trigger_build(src_uri)
                 return await self.preview_file(params, retry=False)
@@ -175,13 +170,9 @@ class PreviewManager(server.LanguageFeature):
                     src_uri,
                 )
                 return None
-        self.build_path = build_path
-        self.active_client = client.id
 
-        # If the language server has restarted, but there are cached build results
-        # we might not have added the client to the build mapping yet, so let's do
-        # it here also.
-        self.build_mapping[self.active_client] = client.build_uri
+        self.build_path = build_path
+        self.build_uri = self.preview.build_uri = client.build_uri
 
         if (uri := await self.show_preview_uri()) is None:
             return None
@@ -192,10 +183,7 @@ class PreviewManager(server.LanguageFeature):
         """Show the preview uri in the client using a ``window/showDocument`` request.
         Also return the final uri."""
 
-        if self.webview is None or self.preview is None:
-            return None
-
-        if self.build_path is None or self.active_client is None:
+        if self.webview is None or self.preview is None or self.build_path is None:
             return None
 
         server = await self.preview
@@ -210,7 +198,7 @@ class PreviewManager(server.LanguageFeature):
         uri = Uri.create(
             scheme="http",
             authority=f"{host}:{server.port}",
-            path=f"{self.active_client}/{self.build_path}",
+            path=self.build_path,
             query=urlencode(query_params),
         )
         self.logger.info("Preview available at: %s", uri.as_string(encode=False))

--- a/lib/esbonio/esbonio/server/features/preview_manager/preview.py
+++ b/lib/esbonio/esbonio/server/features/preview_manager/preview.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import pathlib
 import typing
 from http.server import HTTPServer
 from http.server import SimpleHTTPRequestHandler
@@ -17,28 +16,13 @@ if typing.TYPE_CHECKING:
 
 
 class RequestHandler(SimpleHTTPRequestHandler):
-    def __init__(
-        self, *args, logger: logging.Logger, build_mapping: dict[str, Uri], **kwargs
-    ) -> None:
+    def __init__(self, *args, logger: logging.Logger, directory: str, **kwargs) -> None:
         self.logger = logger
-        self.build_mapping = build_mapping
-        super().__init__(*args, **kwargs)
+        super().__init__(*args, directory=directory, **kwargs)
 
     def translate_path(self, path: str) -> str:
-        url = Uri.parse(f"http://{path}")
-        urlpath = pathlib.Path(url.path[1:] if url.path.startswith("/") else url.path)
-
-        if (build_uri := self.build_mapping.get(urlpath.parts[0])) is not None:
-            if (build_dir := build_uri.fs_path) is None:
-                return "/this/is/not/a/real/path"
-
-            self.directory = build_dir
-            fpath = str(pathlib.Path(*urlpath.parts[1:]))
-            result = super().translate_path(fpath)
-        else:
-            result = "/this/is/not/a/real/path"
-
-        # self.logger.debug("Translate: %r -> %r", path, result)
+        result = super().translate_path(path)
+        # self.logger.debug("Translate: '%s' -> '%s'", path, result)
         return result
 
     def log_message(self, format: str, *args: Any) -> None:
@@ -53,14 +37,20 @@ class RequestHandlerFactory:
     produce a request handler based on the current situation.
     """
 
-    def __init__(self, logger: logging.Logger):
+    def __init__(self, logger: logging.Logger, build_uri: Uri | None = None):
         self.logger = logger
-        self.build_mapping: dict[str, Uri] = {}
+        self.build_uri = build_uri
 
     def __call__(self, *args, **kwargs):
-        return RequestHandler(
-            *args, logger=self.logger, build_mapping=self.build_mapping, **kwargs
-        )
+        if self.build_uri is None:
+            raise ValueError("No build directory set")
+
+        if (build_dir := self.build_uri.fs_path) is None:
+            raise ValueError(
+                "Unable to determine build dir from uri: '%s'", self.build_uri
+            )
+
+        return RequestHandler(*args, logger=self.logger, directory=build_dir, **kwargs)
 
 
 class PreviewServer:
@@ -103,13 +93,12 @@ class PreviewServer:
         return self._server.server_port
 
     @property
-    def build_mapping(self) -> dict[str, Uri]:
-        """A mapping from client id to build directory."""
-        return self._handler_factory.build_mapping
+    def build_uri(self):
+        return self._handler_factory.build_uri
 
-    @build_mapping.setter
-    def build_mapping(self, value: dict[str, Uri]):
-        self._handler_factory.build_mapping = value
+    @build_uri.setter
+    def build_uri(self, value):
+        self._handler_factory.build_uri = value
 
     async def start(self):
         """Start the server."""

--- a/lib/esbonio/esbonio/server/features/preview_manager/preview.py
+++ b/lib/esbonio/esbonio/server/features/preview_manager/preview.py
@@ -25,6 +25,14 @@ class RequestHandler(SimpleHTTPRequestHandler):
         # self.logger.debug("Translate: '%s' -> '%s'", path, result)
         return result
 
+    def end_headers(self):
+        # Instruct the client not to cache the response.
+        #
+        # See: https://github.com/swyddfa/esbonio/issues/951
+        #      https://github.com/swyddfa/esbonio/issues/987
+        self.send_header("Cache-Control", "no-store")
+        return super().end_headers()
+
     def log_message(self, format: str, *args: Any) -> None:
         self.logger.debug(format, *args)
 


### PR DESCRIPTION
The attempted fix for #951 in #976 (prefixing urls with the Sphinx client id) turned out to be a bad idea (see #987).

This PR reverts that change and tries an alternative approach - setting the `Cache-Control` header to instruct the client not to cache any content and to instead fetch it fresh every time. 