### PR TITLE
preview.ts: Remove iframe border

### DIFF
--- a/code/src/node/preview.ts
+++ b/code/src/node/preview.ts
@@ -312,6 +312,7 @@ export class PreviewManager {
     iframe {
       height: 100%;
       width: 100%;
+      border: none;
     }
 
     #status {


### PR DESCRIPTION
This should remove the iframe border, which is very noticeable when previewing a dark mode page in dark mode vscode.