### PR TITLE
Improvements to diagnostics

### DIFF
--- a/lib/esbonio/changes/998.fix.md
+++ b/lib/esbonio/changes/998.fix.md
@@ -1,0 +1,1 @@
+Improve diagnostic experience in editors like neovim which do not support `workspace/diagnostic/refresh` requests

--- a/lib/esbonio/esbonio/server/features/sphinx_manager/manager.py
+++ b/lib/esbonio/esbonio/server/features/sphinx_manager/manager.py
@@ -360,6 +360,7 @@ class SphinxManager(server.LanguageFeature):
         if old_state == ClientState.Starting and new_state == ClientState.Running:
             if (sphinx_info := client.sphinx_info) is not None:
                 self.project_manager.register_project(scope, client.db)
+                self._events.trigger("app-created", client)
                 self.server.protocol.notify(
                     "sphinx/appCreated",
                     AppCreatedNotification(id=client.id, application=sphinx_info),

--- a/lib/esbonio/esbonio/server/features/sphinx_support/diagnostics.py
+++ b/lib/esbonio/esbonio/server/features/sphinx_support/diagnostics.py
@@ -12,7 +12,7 @@ async def refresh_diagnostics(
     server: EsbonioLanguageServer,
     projects: ProjectManager,
     client: SphinxClient,
-    result,
+    *args,
 ):
     """Refresh sphinx diagnostics."""
     if (project := projects.get_project(client.src_uri)) is None:
@@ -36,6 +36,9 @@ def esbonio_setup(
     sphinx_manager: SphinxManager,
     project_manager: ProjectManager,
 ):
+    sphinx_manager.add_listener(
+        "app-created", partial(refresh_diagnostics, server, project_manager)
+    )
     sphinx_manager.add_listener(
         "build", partial(refresh_diagnostics, server, project_manager)
     )

--- a/lib/esbonio/esbonio/server/server.py
+++ b/lib/esbonio/esbonio/server/server.py
@@ -292,14 +292,23 @@ class EsbonioLanguageServer(LanguageServer):
         return ""
 
     def sync_diagnostics(self) -> None:
-        """Update the client with the currently stored diagnostics.
+        """Update the client with the currently stored diagnostics using
+        a ``textDocument/publishDiagnostics`` notification.
 
-        When the client supports the pull diagnostics model, this is a no-op.
+        When using the pull diagnostics model, this triggers a
+        ``workspace/diagnostic/refresh`` request instead.
         """
-        pull_support = get_capability(
-            self.client_capabilities, "text_document.diagnostic", None
+        diagnostic_provider = self.server_capabilities.diagnostic_provider
+        workspace_diagnostic = get_capability(
+            self.client_capabilities,
+            "workspace.diagnostics",
+            types.DiagnosticWorkspaceClientCapabilities(),
         )
-        if pull_support is not None:
+
+        if diagnostic_provider is not None:
+            if workspace_diagnostic.refresh_support:
+                # Signal to the client that is should ask again for more diagnostics
+                self.workspace_diagnostic_refresh(None)
             return
 
         uris = {uri for _, uri in self._diagnostics.keys()}

--- a/lib/esbonio/esbonio/server/setup.py
+++ b/lib/esbonio/esbonio/server/setup.py
@@ -7,6 +7,7 @@ import typing
 from collections.abc import Iterable
 
 from lsprotocol import types
+from pygls.capabilities import get_capability
 
 from . import Uri
 from .feature import DocumentLinkContext
@@ -35,17 +36,31 @@ def create_language_server(
     for module in modules:
         _load_module(server, module)
 
-    _configure_lsp_methods(server)
-    _configure_completion(server)
+    _register_lsp_methods(server)
+    _register_completion(server)
 
     return server
 
 
-def _configure_lsp_methods(server: EsbonioLanguageServer):
+def _register_lsp_methods(server: EsbonioLanguageServer):
     """Configure method handlers for the portions of the LSP spec we support."""
 
     @server.feature(types.INITIALIZE)
     async def on_initialize(ls: EsbonioLanguageServer, params: types.InitializeParams):
+        text_diagnostic = get_capability(
+            params.capabilities, "text_document.diagnostic", None
+        )
+        workspace_diagnostic = get_capability(
+            params.capabilities,
+            "workspace.diagnostics",
+            types.DiagnosticWorkspaceClientCapabilities(),
+        )
+
+        # While we can use the pull-based diagnostic model, we need the client to support
+        # `workspace/diagnositc/refresh` requests in order for the experience to be good.
+        if text_diagnostic is not None and workspace_diagnostic.refresh_support:
+            _register_pull_diagnostics(ls)
+
         ls.initialize(params)
         await call_features(ls, "initialize", params)
 
@@ -89,30 +104,45 @@ def _configure_lsp_methods(server: EsbonioLanguageServer):
 
         await call_features(ls, "document_save", params)
 
-    @server.feature(
-        types.TEXT_DOCUMENT_DIAGNOSTIC,
-        types.DiagnosticOptions(
-            identifier="esbonio",
-            inter_file_dependencies=True,
-            workspace_diagnostics=True,
-        ),
-    )
-    async def on_document_diagnostic(
-        ls: EsbonioLanguageServer, params: types.DocumentDiagnosticParams
-    ):
-        """Handle a ``textDocument/diagnostic`` request."""
-        doc_uri = Uri.parse(params.text_document.uri).resolve()
-        items = []
+    @server.feature(types.TEXT_DOCUMENT_DEFINITION)
+    async def on_definition(ls: EsbonioLanguageServer, params: types.DefinitionParams):
+        uri = params.text_document.uri
+        pos = params.position
+        doc = ls.workspace.get_text_document(uri)
+        language = ls.get_language_at(doc, pos)
 
-        for (_, uri), diags in ls._diagnostics.items():
-            if uri.resolve() == doc_uri:
-                items.extend(diags)
+        definitions = []
 
-        # TODO: Detect no changes and send 'unchanged' responses
-        return types.RelatedFullDocumentDiagnosticReport(
-            items=items,
-            kind=types.DocumentDiagnosticReportKind.Full,
-        )
+        for cls, feature in ls:
+            if not feature.definition_trigger:
+                continue
+
+            context = feature.definition_trigger(
+                uri=Uri.parse(uri),
+                params=params,
+                document=doc,
+                language=language,
+                client_capabilities=ls.client_capabilities,
+            )
+
+            if context is None:
+                continue
+
+            ls.logger.debug("%s", context)
+            name = f"{cls.__name__}"
+
+            try:
+                result = feature.definition(context)
+                if inspect.isawaitable(result):
+                    result = await result
+            except Exception:
+                ls.logger.exception("Error in '%s.definition' handler", name)
+                continue
+
+            if result is not None:
+                definitions.extend(result)
+
+        return definitions if len(definitions) > 0 else None
 
     @server.feature(types.TEXT_DOCUMENT_DOCUMENT_LINK)
     async def on_document_link(
@@ -142,29 +172,6 @@ def _configure_lsp_methods(server: EsbonioLanguageServer):
                 continue
 
         return links or None
-
-    @server.feature(types.WORKSPACE_DIAGNOSTIC)
-    async def on_workspace_diagnostic(
-        ls: EsbonioLanguageServer, params: types.WorkspaceDiagnosticParams
-    ):
-        """Handle a ``workspace/diagnostic`` request."""
-        diagnostics: dict[Uri, list[types.Diagnostic]] = {}
-
-        for (_, uri), diags in ls._diagnostics.items():
-            diagnostics.setdefault(uri, []).extend(diags)
-
-        # TODO: Detect no changes and send 'unchanged' responses
-        reports = []
-        for uri, items in diagnostics.items():
-            reports.append(
-                types.WorkspaceFullDocumentDiagnosticReport(
-                    uri=str(uri),
-                    items=items,
-                    kind=types.DocumentDiagnosticReportKind.Full,
-                )
-            )
-
-        return types.WorkspaceDiagnosticReport(items=reports)
 
     @server.feature(types.TEXT_DOCUMENT_DOCUMENT_SYMBOL)
     async def on_document_symbol(
@@ -200,7 +207,7 @@ def _configure_lsp_methods(server: EsbonioLanguageServer):
         await ls.configuration.update_file_configuration(paths)
 
 
-def _configure_completion(server: EsbonioLanguageServer):
+def _register_completion(server: EsbonioLanguageServer):
     """Configuration completion handlers."""
 
     trigger_characters: set[str] = set()
@@ -275,45 +282,57 @@ def _configure_completion(server: EsbonioLanguageServer):
         # return feature.completion_resolve(item)
         return item
 
-    @server.feature(types.TEXT_DOCUMENT_DEFINITION)
-    async def on_definition(ls: EsbonioLanguageServer, params: types.DefinitionParams):
-        uri = params.text_document.uri
-        pos = params.position
-        doc = ls.workspace.get_text_document(uri)
-        language = ls.get_language_at(doc, pos)
 
-        definitions = []
+def _register_pull_diagnostics(server: EsbonioLanguageServer):
+    """Configure method handlers for diagnostics."""
 
-        for cls, feature in ls:
-            if not feature.definition_trigger:
-                continue
+    @server.feature(
+        types.TEXT_DOCUMENT_DIAGNOSTIC,
+        types.DiagnosticOptions(
+            identifier="esbonio",
+            inter_file_dependencies=True,
+            workspace_diagnostics=True,
+        ),
+    )
+    async def on_document_diagnostic(
+        ls: EsbonioLanguageServer, params: types.DocumentDiagnosticParams
+    ):
+        """Handle a ``textDocument/diagnostic`` request."""
+        doc_uri = Uri.parse(params.text_document.uri).resolve()
+        items = []
 
-            context = feature.definition_trigger(
-                uri=Uri.parse(uri),
-                params=params,
-                document=doc,
-                language=language,
-                client_capabilities=ls.client_capabilities,
+        for (_, uri), diags in ls._diagnostics.items():
+            if uri.resolve() == doc_uri:
+                items.extend(diags)
+
+        # TODO: Detect no changes and send 'unchanged' responses
+        return types.RelatedFullDocumentDiagnosticReport(
+            items=items,
+            kind=types.DocumentDiagnosticReportKind.Full,
+        )
+
+    @server.feature(types.WORKSPACE_DIAGNOSTIC)
+    async def on_workspace_diagnostic(
+        ls: EsbonioLanguageServer, params: types.WorkspaceDiagnosticParams
+    ):
+        """Handle a ``workspace/diagnostic`` request."""
+        diagnostics: dict[Uri, list[types.Diagnostic]] = {}
+
+        for (_, uri), diags in ls._diagnostics.items():
+            diagnostics.setdefault(uri, []).extend(diags)
+
+        # TODO: Detect no changes and send 'unchanged' responses
+        reports = []
+        for uri, items in diagnostics.items():
+            reports.append(
+                types.WorkspaceFullDocumentDiagnosticReport(
+                    uri=str(uri),
+                    items=items,
+                    kind=types.DocumentDiagnosticReportKind.Full,
+                )
             )
 
-            if context is None:
-                continue
-
-            ls.logger.debug("%s", context)
-            name = f"{cls.__name__}"
-
-            try:
-                result = feature.definition(context)
-                if inspect.isawaitable(result):
-                    result = await result
-            except Exception:
-                ls.logger.exception("Error in '%s.definition' handler", name)
-                continue
-
-            if result is not None:
-                definitions.extend(result)
-
-        return definitions if len(definitions) > 0 else None
+        return types.WorkspaceDiagnosticReport(items=reports)
 
 
 async def call_features(ls: EsbonioLanguageServer, method: str, *args, **kwargs):

--- a/lib/esbonio/esbonio/sphinx_agent/handlers/diagnostics.py
+++ b/lib/esbonio/esbonio/sphinx_agent/handlers/diagnostics.py
@@ -16,7 +16,6 @@ DIAGNOSTICS_TABLE = Database.Table(
 
 def init_db(app: Sphinx, config: Config):
     app.esbonio.db.ensure_table(DIAGNOSTICS_TABLE)
-    sync_diagnostics(app)
 
 
 def clear_diagnostics(app: Sphinx, docname: str, source):

--- a/lib/esbonio/tests/e2e/conftest.py
+++ b/lib/esbonio/tests/e2e/conftest.py
@@ -23,6 +23,10 @@ async def client(lsp_client: LanguageClient, uri_for, tmp_path_factory):
     workspace_uri = uri_for("workspaces", "demo")
     test_uri = workspace_uri / "index.rst"
 
+    @lsp_client.feature(types.WORKSPACE_DIAGNOSTIC_REFRESH)
+    def _(lc: LanguageClient, params):
+        print(f"{types.WORKSPACE_DIAGNOSTIC_REFRESH} requsted", sys.stderr)
+
     await lsp_client.initialize_session(
         types.InitializeParams(
             capabilities=types.ClientCapabilities(
@@ -42,6 +46,11 @@ async def client(lsp_client: LanguageClient, uri_for, tmp_path_factory):
                     # Signal pull diagnostic support
                     diagnostic=types.DiagnosticClientCapabilities(
                         dynamic_registration=False
+                    ),
+                ),
+                workspace=types.WorkspaceClientCapabilities(
+                    diagnostics=types.DiagnosticWorkspaceClientCapabilities(
+                        refresh_support=True,
                     ),
                 ),
                 # Signal workDoneProgress/create support.


### PR DESCRIPTION
- Call `workspace/diagnostic/refresh` when sphinx builds complete to ensure timely updates to diagnostics
- Fallback to push based diagnostics when the client does not support `workspace/diagnostic/refresh`

Closes #998 