### PR TITLE
Initial re-implementation of hover requests

### DIFF
--- a/lib/esbonio/changes/1008.feature.md
+++ b/lib/esbonio/changes/1008.feature.md
@@ -1,0 +1,1 @@
+Re-implement support for hover requests, where the hover reveals the documentation behind cross-references like ```:class:`HoverContext` ```

--- a/lib/esbonio/esbonio/server/__init__.py
+++ b/lib/esbonio/esbonio/server/__init__.py
@@ -13,6 +13,8 @@ from .feature import CompletionTrigger
 from .feature import DefinitionContext
 from .feature import DefinitionTrigger
 from .feature import DocumentLinkContext
+from .feature import HoverContext
+from .feature import HoverTrigger
 from .feature import LanguageFeature
 from .server import EsbonioLanguageServer
 from .server import EsbonioWorkspace
@@ -35,6 +37,8 @@ __all__ = (
     "EsbonioLanguageServer",
     "EsbonioWorkspace",
     "EventSource",
+    "HoverContext",
+    "HoverTrigger",
     "LanguageFeature",
     "Uri",
     "create_language_server",

--- a/lib/esbonio/esbonio/server/feature.py
+++ b/lib/esbonio/esbonio/server/feature.py
@@ -40,6 +40,11 @@ if typing.TYPE_CHECKING:
         Coroutine[Any, Any, Optional[list[types.DocumentSymbol]]],
     ]
 
+    HoverResult = Union[
+        Optional[types.Hover],
+        Coroutine[Any, Any, Optional[types.Hover]],
+    ]
+
     MaybeAsyncNone = Union[
         None,
         Coroutine[Any, Any, None],
@@ -103,6 +108,11 @@ class LanguageFeature:
 
     def definition(self, context: DefinitionContext) -> DefinitionResult:
         """Called when a definition request matches one of the specified triggers."""
+
+    hover_trigger: HoverTrigger | None = None
+
+    def hover(self, context: HoverContext) -> HoverResult:
+        """Called when a hover request matches one of the specified triggers."""
 
     def document_link(self, context: DocumentLinkContext) -> DocumentLinkResult:
         """Called when a document link request is recieved."""
@@ -351,16 +361,16 @@ class DefinitionTrigger:
         Parameters
         ----------
         uri
-           The uri of the document in which the completion request was made
+           The uri of the document in which the request was made
 
         params
            The definition params sent from the client
 
         document
-           The document in which the completion request was made
+           The document in which the request was made
 
         language
-           The language at the point where the definition request was made
+           The language at the point where the request was made
 
         client_capabilities
            The client's capabilities
@@ -449,3 +459,138 @@ class DocumentLinkContext:
             "text_document.document_link.tooltip_support",
             False,
         )
+
+
+@attrs.define
+class HoverTrigger:
+    """Define when the feature's hover method should be called."""
+
+    patterns: list[re.Pattern]
+    """A list of regular expressions to try"""
+
+    languages: set[str] = attrs.field(factory=set)
+    """Languages in which the trigger should fire.
+
+    If empty, the document's language will be ignored.
+    """
+
+    def __call__(
+        self,
+        uri: Uri,
+        params: types.HoverParams,
+        document: TextDocument,
+        language: str,
+        client_capabilities: types.ClientCapabilities,
+    ) -> HoverContext | None:
+        """Determine if this hover trigger should fire.
+
+        Parameters
+        ----------
+        uri
+           The uri of the document in which the request was made
+
+        params
+           The definition params sent from the client
+
+        document
+           The document in which the request was made
+
+        language
+           The language at the point where the request was made
+
+        client_capabilities
+           The client's capabilities
+
+        Returns
+        -------
+        Optional[HoverContext]
+           A hover context, if this trigger has fired
+        """
+
+        if len(self.languages) > 0 and language not in self.languages:
+            return None
+
+        try:
+            line = document.lines[params.position.line]
+        except IndexError:
+            line = ""
+
+        for pattern in self.patterns:
+            for match in pattern.finditer(line):
+                # Only trigger if the position of the request is within the match.
+                start, stop = match.span()
+                if not (start <= params.position.character <= stop):
+                    continue
+
+                return HoverContext(
+                    uri=uri,
+                    doc=document,
+                    match=match,
+                    position=params.position,
+                    language=language,
+                    capabilities=client_capabilities,
+                )
+
+        return None
+
+
+@attrs.define
+class HoverContext:
+    """Captures the context within which a hover request has been made."""
+
+    uri: Uri
+    """The uri for the document in which the hover request was made"""
+
+    doc: TextDocument
+    """The document within which the hover request was made"""
+
+    match: re.Match
+    """The match object describing the site of the hover request."""
+
+    position: types.Position
+    """The position at which the hover request was made."""
+
+    language: str
+    """The language where the hover request was made."""
+
+    capabilities: types.ClientCapabilities
+    """The client's capabilities."""
+
+    def __repr__(self):
+        p = f"{self.position.line}:{self.position.character}"
+        return f"HoverContext<{self.uri}:{p} ({self.language}) -- {self.match}>"
+
+    @property
+    def content_format(self) -> list[types.MarkupKind]:
+        """The list of supported markup formats the client supports (if known).
+        Order indicates the client's preference"""
+
+        hover: types.HoverClientCapabilities | None
+        hover = get_capability(self.capabilities, "text_document.hover", None)
+        if hover is None:
+            return []
+
+        return list(hover.content_format or [])
+
+    @property
+    def markdown_parser(self) -> tuple[str, str | None] | None:
+        """The markdown parser used by the client (if known)"""
+
+        markdown: types.MarkdownClientCapabilities | None
+        markdown = get_capability(self.capabilities, "general.markdown", None)
+        if markdown is None:
+            return None
+
+        return (markdown.parser, markdown.version)
+
+    @property
+    def markdown_allowed_tags(self) -> list[str]:
+        """The list of allowed html tags the client will allow in markdown text (if
+        known)"""
+
+        markdown: types.MarkdownClientCapabilities | None
+        markdown = get_capability(self.capabilities, "general.markdown", None)
+        if markdown is None:
+            return []
+
+        return list(markdown.allowed_tags or [])

--- a/lib/esbonio/esbonio/server/features/myst/roles.py
+++ b/lib/esbonio/esbonio/server/features/myst/roles.py
@@ -164,6 +164,39 @@ class MystRoles(server.LanguageFeature):
 
         return links if len(links) > 0 else None
 
+    hover_trigger = server.HoverTrigger(
+        patterns=[MYST_ROLE],
+        languages={"markdown"},
+    )
+
+    async def hover(self, context: server.HoverContext) -> types.Hover | None:
+        """Find the hover text of the requested item"""
+        role = context.match.group("name")
+        target = context.match.group("target")
+        label = context.match.group("label")
+
+        if not label:
+            return None
+
+        idx = context.match.group(0).index(target)
+        start = context.match.start() + idx
+        end = start + len(target)
+
+        if start <= context.position.character <= end:
+            if (text := await self.roles.hover_target(context, role, label)) is None:
+                return None
+        else:
+            return None
+
+        linum = context.position.line
+        return types.Hover(
+            contents=types.MarkupContent(kind=types.MarkupKind.Markdown, value=text),
+            range=types.Range(
+                start=types.Position(line=linum, character=start),
+                end=types.Position(line=linum, character=end),
+            ),
+        )
+
 
 def esbonio_setup(esbonio: server.EsbonioLanguageServer, roles: RolesFeature):
     rst_roles = MystRoles(roles, esbonio)

--- a/lib/esbonio/esbonio/server/features/roles/__init__.py
+++ b/lib/esbonio/esbonio/server/features/roles/__init__.py
@@ -142,6 +142,59 @@ class RolesFeature(server.LanguageFeature):
 
         return None
 
+    async def hover_target(
+        self, context: server.HoverContext, role_name: str, target: str
+    ) -> str | None:
+        """Return the hover text for the role's target.
+
+        Parameters
+        ----------
+        context
+           The hover context
+
+        role_name
+           The role to get the hover text for
+
+        target
+           The role's target
+
+        Returns
+        -------
+        str | None
+           The target's hover, if known
+        """
+        if (role := await self.get_role(context.uri, role_name)) is None:
+            self.logger.debug("Unknown role '%s'", role_name)
+            return None
+
+        if not role.target_providers:
+            return None
+
+        self.logger.debug(
+            "Finding target hover for role: '%s' (%s)",
+            role.name,
+            role.implementation,
+        )
+
+        for spec in role.target_providers:
+            if (provider := self._target_providers.get(spec.name)) is None:
+                self.logger.error("Unknown target provider: '%s'", spec.name)
+                continue
+
+            try:
+                result = provider.hover_target(context, target, **spec.kwargs)
+                if inspect.isawaitable(result):
+                    result = await result
+
+                if result is not None:
+                    return result
+
+            except Exception:
+                name = type(provider).__name__
+                self.logger.error("Error in '%s.hover_target'", name, exc_info=True)
+
+        return None
+
     async def find_target_definition(
         self, context: server.DefinitionContext, role_name: str, target: str
     ) -> list[lsp.Location] | None:

--- a/lib/esbonio/esbonio/server/features/roles/providers.py
+++ b/lib/esbonio/esbonio/server/features/roles/providers.py
@@ -20,6 +20,12 @@ class RoleTargetProvider:
         self.converter = esbonio.converter
         self.logger = esbonio.logger.getChild(self.__class__.__name__)
 
+    def hover_target(
+        self, context: server.HoverContext, target: str, **kwargs
+    ) -> str | None | Coroutine[Any, Any, str | None]:
+        """Return the hover text for the given target"""
+        return None
+
     def suggest_targets(
         self, context: server.CompletionContext, **kwargs
     ) -> (

--- a/lib/esbonio/esbonio/server/features/rst/roles.py
+++ b/lib/esbonio/esbonio/server/features/rst/roles.py
@@ -29,6 +29,11 @@ class RstRoles(server.LanguageFeature):
         languages={"rst"},
     )
 
+    hover_trigger = server.HoverTrigger(
+        patterns=[RST_ROLE],
+        languages={"rst"},
+    )
+
     def initialized(self, params: types.InitializedParams):
         """Called once the initial handshake between client and server has finished."""
         self.configuration.subscribe(
@@ -148,6 +153,34 @@ class RstRoles(server.LanguageFeature):
             return await self.roles.find_target_definition(context, role, label)
 
         return None
+
+    async def hover(self, context: server.HoverContext) -> types.Hover | None:
+        """Find the hover text of the requested item"""
+        role = context.match.group("name")
+        target = context.match.group("target")
+        label = context.match.group("label")
+
+        if not label:
+            return None
+
+        idx = context.match.group(0).index(target)
+        start = context.match.start() + idx
+        end = start + len(target)
+
+        if start <= context.position.character <= end:
+            if (text := await self.roles.hover_target(context, role, label)) is None:
+                return None
+        else:
+            return None
+
+        linum = context.position.line
+        return types.Hover(
+            contents=types.MarkupContent(kind=types.MarkupKind.Markdown, value=text),
+            range=types.Range(
+                start=types.Position(line=linum, character=start),
+                end=types.Position(line=linum, character=end),
+            ),
+        )
 
     async def document_link(
         self, context: server.DocumentLinkContext

--- a/lib/esbonio/esbonio/server/features/sphinx_support/roles.py
+++ b/lib/esbonio/esbonio/server/features/sphinx_support/roles.py
@@ -100,6 +100,49 @@ class ObjectsProvider(roles.RoleTargetProvider):
 
         return locations
 
+    async def hover_target(  # type: ignore
+        self,
+        context: server.HoverContext,
+        target: str,
+        *,
+        obj_types: list[str] | None,
+        projects: list[str] | None,
+        **kwargs,
+    ) -> str | None:
+        """Find the hover text for the given role target."""
+        if obj_types is None:
+            self.logger.debug("Unable to find hover text, missing object types!")
+            return None
+
+        if (project := self.manager.get_project(context.uri)) is None:
+            return None
+
+        self.logger.debug("%r, %r, %r, %r", context, target, obj_types, projects)
+        db = await project.get_db()
+        query = (
+            "SELECT "  # noqa: S608
+            "  description "
+            "FROM objects "
+            f'WHERE printf("%s:%s", objects.domain, objects.objtype) in ({", ".join("?" for _ in obj_types)})'
+            "       AND objects.name = ?"
+        )
+
+        # Hack for absolute docnames...
+        if "std:doc" in obj_types and target.startswith("/"):
+            target = target[1:]
+
+        cursor = await db.execute(query, (*obj_types, target))
+        if (result := await cursor.fetchall()) is None:
+            return None
+
+        for item, *_ in result:
+            if item is None:
+                continue
+
+            return item
+
+        return None
+
     async def resolve_target_link(
         self,
         context: server.DocumentLinkContext,

--- a/lib/esbonio/esbonio/server/setup.py
+++ b/lib/esbonio/esbonio/server/setup.py
@@ -38,7 +38,7 @@ def create_language_server(
 
     _register_lsp_methods(server)
     _register_completion(server)
-
+    _register_hover(server)
     return server
 
 
@@ -333,6 +333,48 @@ def _register_pull_diagnostics(server: EsbonioLanguageServer):
             )
 
         return types.WorkspaceDiagnosticReport(items=reports)
+
+
+def _register_hover(server: EsbonioLanguageServer):
+    """Configure the handlers for documentation hovers."""
+
+    @server.feature(types.TEXT_DOCUMENT_HOVER)
+    async def on_hover(ls: EsbonioLanguageServer, params: types.HoverParams):
+        uri = params.text_document.uri
+        pos = params.position
+        doc = ls.workspace.get_text_document(uri)
+        language = ls.get_language_at(doc, pos)
+
+        for cls, feature in ls:
+            if not feature.hover_trigger:
+                continue
+
+            context = feature.hover_trigger(
+                uri=Uri.parse(uri),
+                params=params,
+                document=doc,
+                language=language,
+                client_capabilities=ls.client_capabilities,
+            )
+
+            if context is None:
+                continue
+
+            ls.logger.debug("%s", context)
+            name = f"{cls.__name__}"
+
+            try:
+                result = feature.hover(context)
+                if inspect.isawaitable(result):
+                    result = await result
+            except Exception:
+                ls.logger.exception("Error in '%s.hover' handler", name)
+                continue
+
+            if result is not None:
+                return result
+
+        return None
 
 
 async def call_features(ls: EsbonioLanguageServer, method: str, *args, **kwargs):

--- a/lib/esbonio/esbonio/sphinx_agent/handlers/domains.py
+++ b/lib/esbonio/esbonio/sphinx_agent/handlers/domains.py
@@ -115,7 +115,7 @@ class DomainObjects:
                 )
 
         app.esbonio.db.insert_values(OBJECTS_TABLE, rows)
-        self._info.clear()
+        # self._info.clear()
 
     def _get_object_details(
         self, app: Sphinx, objname: str, domain: str, objtype: str, docname: str

--- a/lib/esbonio/tests/e2e/test_e2e_roles.py
+++ b/lib/esbonio/tests/e2e/test_e2e_roles.py
@@ -843,3 +843,109 @@ async def test_role_target_definitions(
             expected_uri = location.uri.replace("${ROOT}", root_uri)
             assert expected_uri == actual.uri
             assert location.range == actual.range
+
+
+@pytest.mark.asyncio(loop_scope="session")
+@pytest.mark.parametrize(
+    "filename,position,expected",
+    [
+        (
+            ["workspaces", "demo", "rst", "roles.rst"],
+            # Requests for the role itself should return nothing
+            types.Position(line=60, character=10),
+            None,
+        ),
+        (
+            ["workspaces", "demo", "rst", "roles.rst"],
+            # Requests for the role itself should return nothing
+            types.Position(line=60, character=26),
+            types.Hover(
+                contents=types.MarkupContent(
+                    kind=types.MarkupKind.Markdown,
+                    value="This counter implementation counts",
+                ),
+                range=types.Range(
+                    start=types.Position(line=60, character=14),
+                    end=types.Position(line=60, character=47),
+                ),
+            ),
+        ),
+        (
+            ["workspaces", "demo", "rst", "roles.rst"],
+            # Requests for the role itself should return nothing
+            types.Position(line=61, character=10),
+            types.Hover(
+                contents=types.MarkupContent(
+                    kind=types.MarkupKind.Markdown,
+                    value="Helper for creating a PatternCounter",
+                ),
+                range=types.Range(
+                    start=types.Position(line=61, character=10),
+                    end=types.Position(line=61, character=51),
+                ),
+            ),
+        ),
+        (
+            ["workspaces", "demo", "rst", "roles.rst"],
+            # Requests for the role itself should return nothing
+            types.Position(line=62, character=43),
+            types.Hover(
+                contents=types.MarkupContent(
+                    kind=types.MarkupKind.Markdown,
+                    value="The default pattern used",
+                ),
+                range=types.Range(
+                    start=types.Position(line=62, character=9),
+                    end=types.Position(line=62, character=43),
+                ),
+            ),
+        ),
+    ],
+)
+async def test_role_target_hover(
+    client: LanguageClient,
+    uri_for,
+    filename: list[str],
+    position: types.Position,
+    expected: types.Hover | None,
+):
+    """Ensure that we handle ``textDocument/hover`` requests correctly for
+    role targets."""
+
+    root_uri = str(uri_for("workspaces", "demo"))
+    test_uri = uri_for(*filename)
+
+    fpath = pathlib.Path(test_uri)
+    contents = fpath.read_text()
+
+    # Open the file - needed so that esbonio can correctly determine the language_id of
+    # the document. Strictly speaking, you could probably consider the fact that this is
+    # necessary to be a bug... but 99% of the time I'm fairly sure the client will have
+    # done this before making the hover call.
+    client.text_document_did_open(
+        types.DidOpenTextDocumentParams(
+            text_document=types.TextDocumentItem(
+                uri=str(test_uri),
+                language_id="restructuredtext"
+                if fpath.suffix == ".rst"
+                else "markdown",
+                version=1,
+                text=contents,
+            )
+        )
+    )
+
+    hover = await client.text_document_hover_async(
+        types.HoverParams(
+            text_document=types.TextDocumentIdentifier(uri=str(test_uri)),
+            position=position,
+        )
+    )
+
+    if expected is None:
+        assert hover is None
+
+    else:
+        assert hover.contents.value.startswith(expected.contents.value)
+        assert hover.contents.kind is expected.contents.kind
+        assert hover.range == expected.range

--- a/lib/esbonio/tests/e2e/test_e2e_roles.py
+++ b/lib/esbonio/tests/e2e/test_e2e_roles.py
@@ -856,6 +856,12 @@ async def test_role_target_definitions(
             None,
         ),
         (
+            ["workspaces", "demo", "myst", "roles.md"],
+            # Requests for the role itself should return nothing
+            types.Position(line=53, character=10),
+            None,
+        ),
+        (
             ["workspaces", "demo", "rst", "roles.rst"],
             # Requests for the role itself should return nothing
             types.Position(line=60, character=26),
@@ -867,6 +873,21 @@ async def test_role_target_definitions(
                 range=types.Range(
                     start=types.Position(line=60, character=14),
                     end=types.Position(line=60, character=47),
+                ),
+            ),
+        ),
+        (
+            ["workspaces", "demo", "myst", "roles.md"],
+            # Requests for the role itself should return nothing
+            types.Position(line=53, character=26),
+            types.Hover(
+                contents=types.MarkupContent(
+                    kind=types.MarkupKind.Markdown,
+                    value="This counter implementation counts",
+                ),
+                range=types.Range(
+                    start=types.Position(line=53, character=14),
+                    end=types.Position(line=53, character=47),
                 ),
             ),
         ),
@@ -886,6 +907,21 @@ async def test_role_target_definitions(
             ),
         ),
         (
+            ["workspaces", "demo", "myst", "roles.md"],
+            # Requests for the role itself should return nothing
+            types.Position(line=54, character=15),
+            types.Hover(
+                contents=types.MarkupContent(
+                    kind=types.MarkupKind.Markdown,
+                    value="Helper for creating a PatternCounter",
+                ),
+                range=types.Range(
+                    start=types.Position(line=54, character=13),
+                    end=types.Position(line=54, character=54),
+                ),
+            ),
+        ),
+        (
             ["workspaces", "demo", "rst", "roles.rst"],
             # Requests for the role itself should return nothing
             types.Position(line=62, character=43),
@@ -897,6 +933,21 @@ async def test_role_target_definitions(
                 range=types.Range(
                     start=types.Position(line=62, character=9),
                     end=types.Position(line=62, character=43),
+                ),
+            ),
+        ),
+        (
+            ["workspaces", "demo", "myst", "roles.md"],
+            # Requests for the role itself should return nothing
+            types.Position(line=55, character=43),
+            types.Hover(
+                contents=types.MarkupContent(
+                    kind=types.MarkupKind.Markdown,
+                    value="The default pattern used",
+                ),
+                range=types.Range(
+                    start=types.Position(line=55, character=12),
+                    end=types.Position(line=55, character=46),
                 ),
             ),
         ),

--- a/lib/esbonio/tests/workspaces/demo/myst/roles.md
+++ b/lib/esbonio/tests/workspaces/demo/myst/roles.md
@@ -42,3 +42,17 @@ Esbonio supports GoTo Definition requests for role targets, including
 - Documents {doc}`/myst/roles`
 - References {ref}`rst-roles-completion`
 - Python objects {py:class}`counters.pattern.PatternCounter`
+
+Try invoking GoTo Definition on any of the above targets.
+
+## Hover
+
+Esbonio provides documentation hovers for role targets, including:
+
+- Local Python objects, for example:
+
+  - {py:class}`counters.pattern.PatternCounter`
+  - {py:meth}`counters.pattern.PatternCounter.fromstr`
+  - {py:obj}`counters.pattern.DEFAULT_PATTERN`
+
+Hover over any of the above targets to see their associated content.

--- a/lib/esbonio/tests/workspaces/demo/rst/roles.rst
+++ b/lib/esbonio/tests/workspaces/demo/rst/roles.rst
@@ -48,3 +48,18 @@ Esbonio supports GoTo Definition requests for role targets, including
 - Documents :doc:`/myst/roles`
 - References :ref:`myst-roles-completion`
 - Python objects :py:class:`counters.pattern.PatternCounter`
+
+Try invoking GoTo Definition on any of the above targets
+
+Hover
+-----
+
+Esbonio provides documentation hovers for role targets, including
+
+- Local Python objects, for example
+
+  - :py:class:`counters.pattern.PatternCounter`
+  - :meth:`counters.pattern.PatternCounter.fromstr`
+  - :obj:`counters.pattern.DEFAULT_PATTERN`
+
+Hover over any of the above targets to see their associated content


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/aac0d140-ada8-4e2a-8c17-fb23d20d8384)

This brings an initial re-implementation of support hover requests. However unlike `0.16`, the support is currently for Sphinx domain objects, rather than documentation for roles/directives themselves.
