### PR TITLE
Update README to include MySt Markdown support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,10 @@
 
 [reStructuredText]: https://docutils.sourceforge.io/rst.html
 [Sphinx]: https://www.sphinx-doc.org/en/master/
+[MySt Markdowm]: https://mystmd.org
 [Language Server]: https://langserver.org/
 
-Esbonio aims to make it easier to work with [Sphinx] by providing a [Language Server] to enhance your editing experience.
+Esbonio aims to make it easier to work with [Sphinx] or [MySt Markdown] by providing a [Language Server] to enhance your editing experience.
 The Esbonio project is made up from a number of sub-projects
 
 


### PR DESCRIPTION
This adds MySt support to the description in the README.md following the release of [v1.0](https://github.com/swyddfa/esbonio/discussions/1041).