### PR TITLE
doc: Document requirements for esbonio.sphinx.pythonCommand

### DIFF
--- a/docs/lsp/howto/configure-the-sphinx-build-env.rst
+++ b/docs/lsp/howto/configure-the-sphinx-build-env.rst
@@ -9,6 +9,11 @@ This of course, requires ``esbonio`` being able to execute this process within t
 Since there are many ways to define and manage Python environments, ``esbonio`` needs you to tell it how to run the ``python`` command so that it has access to the correct dependencies.
 This is typically done by setting the :esbonio:conf:`esbonio.sphinx.pythonCommand` option in your project's ``pyproject.toml`` file.
 
+If the command is not ``python``, then it must accept additional parameters (e.g. ``-M sphinx``) and pass these to the Python interpreter.
+
+``esbonio`` sets the environment variable ``PYTHONPATH`` for the python interpreter, therefore, the command must not replace or clear ``PYTHONPATH``.
+It may, however, extend the environment variable with additional entries.
+
 Basic Usage
 -----------
 

--- a/docs/lsp/reference/configuration.rst
+++ b/docs/lsp/reference/configuration.rst
@@ -306,6 +306,9 @@ The following options control the creation and management of background Sphinx p
 
      ["hatch", "-e", "docs", "run", "python"]
 
+   If the command is not ``python``, then it must accept additional parameters (e.g. ``-M sphinx``) and pass these to the Python interpreter.
+   The command must not replace or clear the environment variable ``PYTHONPATH``, it may, however, extend it with additional entries.
+
    For more examples see :ref:`lsp-configure-sphinx-build-env`
 
 .. esbonio:config:: esbonio.sphinx.pythonCommand.cwd


### PR DESCRIPTION
My setup overwrote PYTHONPATH, so figuring this out took me about a day.
Document the requirements for the command properly, so others don't have to waste their time as I have.

Feel free to rephrase to your liking.

---

The (wrapper) to execute the python interpreter must fullfill the following requirements to be usable by esbonio:

-  Accept additional command line arguments, namely ``-m sphinx_agent``, and pass these to the Python interpreter.

-  Not filtering the environment variable ``PYTHONPATH``.  esbonio sets it to the (internal) path of the module ``sphinx_agent``. Extending the ``PYTHONPATH`` is fine.

Document these requirements in the esbonio.sphnix.pythonCommand option.