### PR TITLE
doc: Document that buildCommand must be a sphinx-build command line

### DIFF
--- a/docs/lsp/howto/configure-the-sphinx-build-cmd.rst
+++ b/docs/lsp/howto/configure-the-sphinx-build-cmd.rst
@@ -19,6 +19,9 @@ Of course, the ``sphinx-build`` command you use with your project may be differe
    [tool.esbonio.sphinx]
    buildCommand = ["sphinx-build", "-M", "html", "docs", "${defaultBuildDir}", "--nitpicky", "--verbose"]
 
+:esbonio:conf:`esbonio.sphinx.buildCommand` must be the genuine command line for ``sphinx-build``.
+Wrapper scripts around ``sphinx-build``, e.g. a Makefile, are not supported.
+
 .. admonition:: Why use ``${defaultBuildDir}``?
 
    There are two main reasons why ``esbonio`` will store its build output in your user's cache directory by default.

--- a/docs/lsp/reference/configuration.rst
+++ b/docs/lsp/reference/configuration.rst
@@ -279,8 +279,13 @@ The following options control the creation and management of background Sphinx p
    :scope: project
    :type: string[]
 
-   The ``sphinx-build`` command ``esbonio`` should use when building your documentation
+   The ``sphinx-build`` command line arguments ``esbonio`` should use when building your documentation.
    For more information, see :ref:`lsp-configure-sphinx-build-cmd`
+
+   .. note::
+
+      This must be the genuine command line for ``sphinx-build``.
+      Wrapper scripts around ``sphinx-build`` are not supported.
 
 .. esbonio:config:: esbonio.sphinx.configOverrides
    :scope: project


### PR DESCRIPTION
I used a custom build script here, which did not work.,  Be more explicit about the requirements.

Feel free to rephrase as needed.

---

Make it explicit that buildCommand is a sphinx-build command line and not a command that runs sphinx-build.  Internally, the command line arguments are passed to the sphinx.comd.build.Sphinx module, the command line itself is never executed as a command.