### PR TITLE
docs: Fix typo in python argument (`-M` -> `-m`)

### DIFF
--- a/docs/lsp/howto/configure-the-sphinx-build-env.rst
+++ b/docs/lsp/howto/configure-the-sphinx-build-env.rst
@@ -9,7 +9,7 @@ This of course, requires ``esbonio`` being able to execute this process within t
 Since there are many ways to define and manage Python environments, ``esbonio`` needs you to tell it how to run the ``python`` command so that it has access to the correct dependencies.
 This is typically done by setting the :esbonio:conf:`esbonio.sphinx.pythonCommand` option in your project's ``pyproject.toml`` file.
 
-If the command is not ``python``, then it must accept additional parameters (e.g. ``-M sphinx``) and pass these to the Python interpreter.
+If the command is not ``python``, then it must accept additional parameters (e.g. ``-m sphinx``) and pass these to the Python interpreter.
 
 ``esbonio`` sets the environment variable ``PYTHONPATH`` for the python interpreter, therefore, the command must not replace or clear ``PYTHONPATH``.
 It may, however, extend the environment variable with additional entries.

--- a/docs/lsp/reference/configuration.rst
+++ b/docs/lsp/reference/configuration.rst
@@ -311,7 +311,7 @@ The following options control the creation and management of background Sphinx p
 
      ["hatch", "-e", "docs", "run", "python"]
 
-   If the command is not ``python``, then it must accept additional parameters (e.g. ``-M sphinx``) and pass these to the Python interpreter.
+   If the command is not ``python``, then it must accept additional parameters (e.g. ``-m sphinx``) and pass these to the Python interpreter.
    The command must not replace or clear the environment variable ``PYTHONPATH``, it may, however, extend it with additional entries.
 
    For more examples see :ref:`lsp-configure-sphinx-build-env`


### PR DESCRIPTION
I was sure I'd fixed this oversight before reporting but alas I must have been mistaken.
