### PR TITLE
code: Fix typo in package.json (Language)

### DIFF
--- a/code/package.json
+++ b/code/package.json
@@ -157,7 +157,7 @@
                         "scope": "window",
                         "type": "string",
                         "default": null,
-                        "description": "The path to the Python interpreter to use when running the Langague Server.\n\nBy default this extension will try to use the interpreter configured via the Python Extension. If you do not use the Python Extension or you wish to use a different environment, then this option can be used to override the default behavior."
+                        "description": "The path to the Python interpreter to use when running the Language Server.\n\nBy default this extension will try to use the interpreter configured via the Python Extension. If you do not use the Python Extension or you wish to use a different environment, then this option can be used to override the default behavior."
                     }
                 }
             },


### PR DESCRIPTION
Just spotted this while browsing the extension settings.

Signed-off-by: 林博仁(Buo-ren Lin) <buo.ren.lin@gmail.com>