### PR TITLE
staging/sphinx9: Add support to sphinx 9

### DIFF
--- a/lib/esbonio/esbonio/server/features/sphinx_manager/config.py
+++ b/lib/esbonio/esbonio/server/features/sphinx_manager/config.py
@@ -427,6 +427,9 @@ def sphinx_config_struct_hooks(field_name: str):
         if isinstance(obj, list):
             return typ(command=obj)
 
+        if isinstance(obj, str):
+            return typ(command=[obj])
+
         return typ(**obj)
 
     return _structure_list_or_subprocess

--- a/lib/esbonio/esbonio/server/features/sphinx_manager/config.py
+++ b/lib/esbonio/esbonio/server/features/sphinx_manager/config.py
@@ -389,7 +389,11 @@ def register_structure_hooks(converter: cattrs.Converter):
         for a in attrs.fields(SphinxConfig)
     }
 
-    hook = cattrs.gen.make_dict_structure_fn(SphinxConfig, converter, **fields)
+    hook = cattrs.gen.make_dict_structure_fn(
+        SphinxConfig,
+        converter,
+        **fields,  # type: ignore[arg-type]
+    )
 
     def _structure_sphinx_config(obj, typ):
         """A wrapper around the ``cattrs.gen`` hook to implement multiple names mapping

--- a/lib/esbonio/esbonio/sphinx_agent/app.py
+++ b/lib/esbonio/esbonio/sphinx_agent/app.py
@@ -6,6 +6,8 @@ import pathlib
 import sys
 import typing
 
+from packaging.version import Version
+from sphinx import __version__ as __sphinx_version__
 from sphinx.application import Sphinx as _Sphinx
 from sphinx.errors import ThemeError
 from sphinx.util import console
@@ -15,6 +17,8 @@ from sphinx.util.logging import NAMESPACE as SPHINX_LOG_NAMESPACE
 from . import types
 from .database import Database
 from .log import DiagnosticFilter
+
+_SPHINX_9 = Version(__sphinx_version__) >= Version("9.0.0")
 
 if typing.TYPE_CHECKING:
     from typing import IO
@@ -35,9 +39,12 @@ logger = sphinx_logger.getChild("esbonio")
 sphinx_log_setup = sphinx_logging_module.setup
 
 
-def setup_logging(app: Sphinx, status: IO, warning: IO):
+def setup_logging(app: Sphinx, status: IO, warning: IO, verbosity=None):
     # Run the usual setup
-    sphinx_log_setup(app, status, warning)
+    if _SPHINX_9:
+        sphinx_log_setup(app, status, warning, verbosity=verbosity)
+    else:
+        sphinx_log_setup(app, status, warning)
 
     # Attach our diagnostic filter to the warning handler.
     for handler in sphinx_logger.handlers:

--- a/lib/esbonio/esbonio/sphinx_agent/config.py
+++ b/lib/esbonio/esbonio/sphinx_agent/config.py
@@ -113,7 +113,7 @@ class SphinxConfig:
         # Sphinx 8.1 changed the way arguments are passed to the `Sphinx` class.
         # See: https://github.com/swyddfa/esbonio/issues/912
         if len(values) == 0:
-            sphinx_args = m_Sphinx.call_args.kwargs
+            sphinx_args = dict(m_Sphinx.call_args.kwargs)
 
         if sphinx_args is None:
             return None

--- a/lib/esbonio/esbonio/sphinx_agent/handlers/symbols.py
+++ b/lib/esbonio/esbonio/sphinx_agent/handlers/symbols.py
@@ -3,15 +3,11 @@ import typing
 from typing import IO
 
 from docutils import nodes
-from docutils.core import Publisher
-from docutils.io import NullOutput
-from docutils.io import StringInput
 from docutils.parsers.rst import Directive
 from docutils.parsers.rst import directives
-from docutils.readers.standalone import Reader
-from docutils.utils import Reporter
+from packaging.version import Version
+from sphinx import __version__ as __sphinx_version__
 from sphinx.config import Config
-from sphinx.io import SphinxDummyWriter
 from sphinx.util import get_filetype
 from sphinx.util.docutils import CustomReSTDispatcher
 
@@ -20,6 +16,18 @@ from ..app import Database
 from ..app import Sphinx
 from ..util import as_json
 from . import sphinx_logger
+
+_SPHINX_9 = Version(__sphinx_version__) >= Version("9.0.0")
+
+if _SPHINX_9:
+    from sphinx.util.docutils import _parse_str_to_doctree
+else:
+    from docutils.core import Publisher
+    from docutils.io import NullOutput
+    from docutils.io import StringInput
+    from docutils.readers.standalone import Reader
+    from docutils.utils import Reporter
+    from sphinx.io import SphinxDummyWriter
 
 SYMBOLS_TABLE = Database.Table(
     "symbols",
@@ -50,25 +58,52 @@ def update_symbols(app: Sphinx, docname: str, source):
     filename = app.env.doc2path(docname)
     filetype = get_filetype(app.config.source_suffix, filename)
 
+    parser = app.registry.create_source_parser(filetype, config=app.config, env=app.env)
+
+    with disable_roles_and_directives():
+        document = _parse_str_to_doctree(
+            "\n".join(source),
+            filename=filename,
+            default_settings=app.env.settings,
+            env=app.env,
+            parser=parser,
+        )
+
+    visitor = SymbolVisitor(document)
+    document.walkabout(visitor)  # type: ignore[union-attr]
+
+    uri = str(types.Uri.for_file(app.env.doc2path(docname, base=True)).resolve())
+    symbols = [(uri, *s) for s in visitor.symbols]
+
+    app.esbonio.db.clear_table(SYMBOLS_TABLE, uri=uri)
+    app.esbonio.db.insert_values(SYMBOLS_TABLE, symbols)
+
+
+def update_symbols_legacy(app: Sphinx, docname: str, source):
+    """Update the symbols defined in the given file, Sphinx < 9."""
+
+    filename = app.env.doc2path(docname)
+    filetype = get_filetype(app.config.source_suffix, filename)
+
     reader = LoggingDoctreeReader(sphinx_logger)
-    parser = app.registry.create_source_parser(app, filetype)
+    parser = app.registry.create_source_parser(app, filetype)  # type: ignore[arg-type,call-arg,misc]
 
     # Reuse the settings from Sphinx's publisher.
-    sphinx_pub = app.registry.get_publisher(app, filetype)
+    sphinx_pub = app.registry.get_publisher(app, filetype)  # type: ignore[attr-defined]
     settings = sphinx_pub.settings
 
     with disable_roles_and_directives():
         publisher = Publisher(
             parser=parser,
             reader=reader,
-            writer=SphinxDummyWriter(),
+            writer=SphinxDummyWriter(),  # type: ignore[abstract]
             source_class=StringInput,
             destination=NullOutput(),
         )
         publisher.settings = settings
         publisher.set_source(source="\n".join(source), source_path=str(filename))
         publisher.publish()
-        document = publisher.document
+        document = publisher.document  # type: ignore[assignment]
 
     visitor = SymbolVisitor(document)
     document.walkabout(visitor)  # type: ignore[union-attr]
@@ -89,7 +124,11 @@ def setup(app: Sphinx):
     # The only handler with a higher priority (i.e. 0), should be the handler we use
     # to override the contents of the file so that we stay in sync with the language
     # client.
-    app.connect("source-read", update_symbols, priority=1)
+    app.connect(
+        "source-read",
+        update_symbols if _SPHINX_9 else update_symbols_legacy,
+        priority=1,
+    )
 
     # TODO: Sphinx 7.x+ support
     # app.connect("include-read")
@@ -317,50 +356,55 @@ class SymbolVisitor(nodes.NodeVisitor):
         pass
 
 
-class LogStream:
-    def __init__(self, logger: logging.Logger):
-        self.logger = logger
+if not _SPHINX_9:
 
-    def write(self, text: str):
-        self.logger.debug(text)
+    class LogStream:
+        def __init__(self, logger: logging.Logger):
+            self.logger = logger
 
+        def write(self, text: str):
+            self.logger.debug(text)
 
-class LogReporter(Reporter):
-    """A docutils reporter that writes to the given logger."""
+    class LogReporter(Reporter):
+        """A docutils reporter that writes to the given logger."""
 
-    def __init__(
-        self,
-        logger: logging.Logger,
-        source: str,
-        report_level: int,
-        halt_level: int,
-        debug: bool,
-        error_handler: str,
-    ) -> None:
-        stream = typing.cast(IO, LogStream(logger))
-        super().__init__(
-            source, report_level, halt_level, stream, debug, error_handler=error_handler
-        )  # type: ignore
+        def __init__(
+            self,
+            logger: logging.Logger,
+            source: str,
+            report_level: int,
+            halt_level: int,
+            debug: bool,
+            error_handler: str,
+        ) -> None:
+            stream = typing.cast(IO, LogStream(logger))
+            super().__init__(
+                source,
+                report_level,
+                halt_level,
+                stream,
+                debug,
+                error_handler=error_handler,
+            )  # type: ignore
 
+    class LoggingDoctreeReader(Reader):
+        """A reader that replaces the default reporter with one that redirects."""
 
-class LoggingDoctreeReader(Reader):
-    """A reader that replaces the default reporter with one that redirects."""
+        def __init__(self, logger: logging.Logger, *args, **kwargs):
+            self.logger = logger
+            super().__init__(*args, **kwargs)
 
-    def __init__(self, logger: logging.Logger, *args, **kwargs):
-        self.logger = logger
-        super().__init__(*args, **kwargs)
+        def new_document(self) -> nodes.document:
+            document = super().new_document()
 
-    def new_document(self) -> nodes.document:
-        document = super().new_document()
+            reporter = document.reporter
+            document.reporter = LogReporter(
+                self.logger,
+                reporter.source,
+                reporter.report_level,
+                reporter.halt_level,
+                reporter.debug_flag,
+                reporter.error_handler,
+            )
 
-        reporter = document.reporter
-        document.reporter = LogReporter(
-            self.logger,
-            reporter.source,
-            reporter.report_level,
-            reporter.halt_level,
-            reporter.debug_flag,
-            reporter.error_handler,
-        )
-
-        return document
+            return document

--- a/lib/esbonio/tests/e2e/test_e2e_diagnostics.py
+++ b/lib/esbonio/tests/e2e/test_e2e_diagnostics.py
@@ -74,16 +74,31 @@ async def test_workspace_diagnostic(client: LanguageClient, uri_for):
     message = f"undefined label: 'not-a-real-reference'{category}"
 
     workspace_uri = uri_for("workspaces", "demo")
+
+    expected_conf_py = (
+        "no theme named 'furo' found",
+        "Could not import extension sphinx_design (exception: "
+        "No module named 'sphinx_design')",
+    )
+    if sphinx_version[0] >= 9:
+        expected_conf_py = (*expected_conf_py, "unknown role name: external")
+
     expected = {
-        str(workspace_uri / "conf.py"): (
-            "no theme named 'furo' found",
-            "Could not import extension sphinx_design (exception: "
-            "No module named 'sphinx_design')",
-        ),
-        str(workspace_uri / "index.rst"): ('Unknown directive type "grid"'),
+        str(workspace_uri / "conf.py"): expected_conf_py,
+        str(workspace_uri / "index.rst"): ('Unknown directive type "grid"',),
         str(workspace_uri / "rst" / "diagnostics.rst"): (message,),
         str(workspace_uri / "myst" / "diagnostics.md"): (message,),
     }
+
+    if sphinx_version[0] >= 9:
+        expected.update(
+            {
+                str(workspace_uri / "rst" / "domains" / "python.rst"): (
+                    "duplicate object description of counters.pattern",
+                )
+            }
+        )
+
     assert len(report.items) == len(expected)
     for item in report.items:
         for diagnostic in item.items:

--- a/lib/esbonio/tests/sphinx-agent/handlers/test_diagnostics.py
+++ b/lib/esbonio/tests/sphinx-agent/handlers/test_diagnostics.py
@@ -5,6 +5,7 @@ from typing import Any
 
 import pytest
 from pygls.protocol import default_converter
+from sphinx import version_info as sphinx_version
 
 from esbonio.server import Uri
 from esbonio.server.features.project_manager import Project
@@ -23,17 +24,24 @@ def check_diagnostics(
     for k, ex_diags in expected.items():
         actual_diags = [converter.structure(d, types.Diagnostic) for d in actual[k]]
 
-        assert len(ex_diags) == len(actual_diags)
+        assert len(ex_diags) == len(actual_diags), (
+            f"Expected {len(ex_diags)} diagnostics for {k}, got {len(actual_diags)}"
+        )
 
-        for actual_diagnostic in actual_diags:
-            # Assumes ranges are unique
-            matches = [e for e in ex_diags if e.range == actual_diagnostic.range]
-            assert len(matches) == 1
+        for expected_diagnostic in ex_diags:
+            # Match by message prefix (diagnostics may be in the same range (line/column))
+            matches = [
+                a
+                for a in actual_diags
+                if a.message.startswith(expected_diagnostic.message)
+            ]
+            assert len(matches) == 1, (
+                f"Expected exactly one match for '{expected_diagnostic.message}' in {k}"
+            )
 
-            expected_diagnostic = matches[0]
-            assert actual_diagnostic.range == expected_diagnostic.range
+            actual_diagnostic = matches[0]
             assert actual_diagnostic.severity == expected_diagnostic.severity
-            assert actual_diagnostic.message.startswith(expected_diagnostic.message)
+            assert actual_diagnostic.range == expected_diagnostic.range
 
 
 @pytest.mark.asyncio
@@ -44,6 +52,7 @@ async def test_diagnostics(client: SphinxClient, project: Project, uri_for):
     myst_diagnostics_uri = uri_for("workspaces/demo/myst/diagnostics.md")
     index_uri = uri_for("workspaces/demo/index.rst")
     conf_uri = uri_for("workspaces/demo/conf.py")
+    python_uri = uri_for("workspaces/demo/rst/domains/python.rst")
 
     message = "undefined label: 'not-a-real-reference'"
 
@@ -97,6 +106,113 @@ async def test_diagnostics(client: SphinxClient, project: Project, uri_for):
             ),
         ],
     }
+    conf_diags_v9 = [
+        types.Diagnostic(
+            message="unknown role name: external+myst:std:ref",
+            severity=types.DiagnosticSeverity.Warning,
+            range=types.Range(
+                start=types.Position(line=0, character=0),
+                end=types.Position(line=1, character=0),
+            ),
+        ),
+        types.Diagnostic(
+            message="unknown role name: external:std:ref",
+            severity=types.DiagnosticSeverity.Warning,
+            range=types.Range(
+                start=types.Position(line=0, character=0),
+                end=types.Position(line=1, character=0),
+            ),
+        ),
+        types.Diagnostic(
+            message="unknown role name: external:rst:role",
+            severity=types.DiagnosticSeverity.Warning,
+            range=types.Range(
+                start=types.Position(line=0, character=0),
+                end=types.Position(line=1, character=0),
+            ),
+        ),
+        types.Diagnostic(
+            message="unknown role name: external+sphinx:rst:dir",
+            severity=types.DiagnosticSeverity.Warning,
+            range=types.Range(
+                start=types.Position(line=0, character=0),
+                end=types.Position(line=1, character=0),
+            ),
+        ),
+    ]
+    python_diags_v9 = [
+        types.Diagnostic(
+            message="duplicate object description of counters.pattern,",
+            severity=types.DiagnosticSeverity.Warning,
+            range=types.Range(
+                start=types.Position(line=40, character=0),
+                end=types.Position(line=41, character=0),
+            ),
+        ),
+        types.Diagnostic(
+            message="duplicate object description of counters.pattern.NoMatchesError,",
+            severity=types.DiagnosticSeverity.Warning,
+            range=types.Range(
+                start=types.Position(line=42, character=0),
+                end=types.Position(line=43, character=0),
+            ),
+        ),
+        types.Diagnostic(
+            message="duplicate object description of counters.pattern.count_numbers,",
+            severity=types.DiagnosticSeverity.Warning,
+            range=types.Range(
+                start=types.Position(line=71, character=0),
+                end=types.Position(line=72, character=0),
+            ),
+        ),
+        types.Diagnostic(
+            message="duplicate object description of counters.pattern.PatternCounter.pattern,",
+            severity=types.DiagnosticSeverity.Warning,
+            range=types.Range(
+                start=types.Position(line=61, character=0),
+                end=types.Position(line=62, character=0),
+            ),
+        ),
+        types.Diagnostic(
+            message="duplicate object description of counters.pattern.DEFAULT_PATTERN,",
+            severity=types.DiagnosticSeverity.Warning,
+            range=types.Range(
+                start=types.Position(line=46, character=0),
+                end=types.Position(line=47, character=0),
+            ),
+        ),
+        types.Diagnostic(
+            message="duplicate object description of counters.pattern.PatternCounter.count,",
+            severity=types.DiagnosticSeverity.Warning,
+            range=types.Range(
+                start=types.Position(line=66, character=0),
+                end=types.Position(line=67, character=0),
+            ),
+        ),
+        types.Diagnostic(
+            message="duplicate object description of counters.pattern.PatternCounter.fromstr,",
+            severity=types.DiagnosticSeverity.Warning,
+            range=types.Range(
+                start=types.Position(line=57, character=0),
+                end=types.Position(line=58, character=0),
+            ),
+        ),
+        types.Diagnostic(
+            message="duplicate object description of counters.pattern.PatternCounter,",
+            severity=types.DiagnosticSeverity.Warning,
+            range=types.Range(
+                start=types.Position(line=52, character=0),
+                end=types.Position(line=53, character=0),
+            ),
+        ),
+    ]
+    if sphinx_version[0] >= 9:
+        expected[conf_uri].extend(conf_diags_v9)
+        expected.update(
+            {
+                python_uri: python_diags_v9,
+            }
+        )
 
     actual = await project.get_diagnostics()
     check_diagnostics(expected, actual)


### PR DESCRIPTION
Map changes from sphinx > 9 and add support to it.
Top~ commit reverts backward-compatibility.
Ignoring white space, the changes are clearer:
```
git diff 516cb70784b3b1b8cd441e8976add76f372f7227..@ -w
```

To solve #1071
