### PR TITLE
lsp: Stop testing on Sphinx v6, start testing on Sphinx v9

### DIFF
--- a/lib/esbonio/changes/1086.breaking.md
+++ b/lib/esbonio/changes/1086.breaking.md
@@ -1,0 +1,1 @@
+Drop support for Sphinx v6.

--- a/lib/esbonio/hatch.toml
+++ b/lib/esbonio/hatch.toml
@@ -20,16 +20,21 @@ UV_PRERELEASE="allow"
 python = ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
 [[envs.hatch-test.matrix]]
-python = ["3.10", "3.11", "3.12", "3.13", "3.14"]
-sphinx = ["6", "7", "8"]
+python = ["3.10"]
+sphinx = ["7", "8"]
+
+
+[[envs.hatch-test.matrix]]
+python = ["3.11", "3.12", "3.13", "3.14"]
+sphinx = ["7", "8", "9"]
 
 
 [envs.hatch-test.overrides]
 matrix.sphinx.dependencies = [
     "myst-parser",
-    { value = "sphinx>=6,<7", if = ["6"] },
     { value = "sphinx>=7,<8", if = ["7"] },
     { value = "sphinx>=8,<9", if = ["8"] },
+    { value = "sphinx>=9,<10", if = ["9"] },
 ]
 
 [envs.hatch-test.overrides.matrix.sphinx.default-args]


### PR DESCRIPTION
In preparation for #1085, this drops Sphinx v6 support inline with the [versioning policy](https://docs.esbon.io/en/latest/about/versioning.html#supported-sphinx-versions) and adds v9 to the test matrix