### PR TITLE
Change some default config values

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.*~
 
 .coverage
+.dir-locals.el
 .env
 .ipynb_checkpoints
 .tox

--- a/docs/usage/howto/migrate-to-v2.rst
+++ b/docs/usage/howto/migrate-to-v2.rst
@@ -9,3 +9,10 @@ Sphinx v6 No Longer Supported
 -----------------------------
 
 Inline with the :ref:`about-versioning` policy, while Esbonio v2 adds support for Sphinx v9, support for Sphinx v6 has been removed.
+
+Configuration Changes
+---------------------
+
+The default values for the following configuration options have been changed.
+
+``esbonio.logging.level`` now defaults to ``info``

--- a/docs/usage/howto/migrate-to-v2.rst
+++ b/docs/usage/howto/migrate-to-v2.rst
@@ -15,4 +15,5 @@ Configuration Changes
 
 The default values for the following configuration options have been changed.
 
-``esbonio.logging.level`` now defaults to ``info``
+- :esbonio:conf:`esbonio.logging.level` now defaults to ``info``
+- :esbonio:conf:`esbonio.server.completion.preferredInsertBehavior` now defaults to ``insert``

--- a/docs/usage/reference/configuration.rst
+++ b/docs/usage/reference/configuration.rst
@@ -56,13 +56,13 @@ The following options affect completion suggestions.
 
    Controls how completions behave when accepted, the following values are supported.
 
-   - ``replace`` (default)
+   - ``replace``
 
      Accepted completions will replace existing text, allowing the server to rewrite the current line in place.
      This allows the server to return all possible completions within the current context.
      In this mode the server will set the ``textEdit`` field of a ``CompletionItem``.
 
-   - ``insert``
+   - ``insert`` (default)
 
      Accepted completions will append to existing text rather than replacing it.
      Since rewriting is not possible, only the completions that are compatible with any existing text will be returned.

--- a/docs/usage/reference/configuration.rst
+++ b/docs/usage/reference/configuration.rst
@@ -124,9 +124,9 @@ The following options control the logging output of the language server.
 
    - ``critical``
    - ``fatal``
-   - ``error`` (default)
+   - ``error``
    - ``warning``
-   - ``info``
+   - ``info`` (default)
    - ``debug``
 
 .. esbonio:config:: esbonio.logging.format

--- a/lib/esbonio/esbonio/server/feature.py
+++ b/lib/esbonio/esbonio/server/feature.py
@@ -226,7 +226,7 @@ class CompletionConfig:
     """Configuration options that control completion behavior."""
 
     preferred_insert_behavior: Literal["insert", "replace"] = attrs.field(
-        default="replace"
+        default="insert"
     )
     """This option indicates if the user prefers we use ``insertText`` or ``textEdit``
     when rendering ``CompletionItems``."""

--- a/lib/esbonio/esbonio/server/features/log.py
+++ b/lib/esbonio/esbonio/server/features/log.py
@@ -222,7 +222,7 @@ class LoggingConfigBuilder:
 class LoggingConfig:
     """Configuration options for server logging."""
 
-    level: str = attrs.field(default="error")
+    level: str = attrs.field(default="info")
     """The default logging level."""
 
     format: str = attrs.field(default="[%(name)s] %(message)s")

--- a/lib/esbonio/tests/e2e/conftest.py
+++ b/lib/esbonio/tests/e2e/conftest.py
@@ -24,7 +24,17 @@ async def client(lsp_client: LanguageClient, uri_for, tmp_path_factory):
 
     # Override the project configuration so that builds are written into a temporary folder
     build_dir = tmp_path_factory.mktemp("build")
-    lsp_client.set_configuration({"logging": {"level": "debug"}}, section="esbonio")
+    lsp_client.set_configuration(
+        {
+            "logging": {"level": "debug"},
+            "server": {
+                "completion": {
+                    "preferredInsertBehavior": "replace",
+                }
+            },
+        },
+        section="esbonio",
+    )
     lsp_client.set_configuration(
         {
             "buildCommand": [

--- a/lib/esbonio/tests/server/features/test_logging.py
+++ b/lib/esbonio/tests/server/features/test_logging.py
@@ -37,7 +37,7 @@ SERVER = server.EsbonioLanguageServer
                 ),
                 loggers=dict(
                     esbonio=dict(
-                        level="ERROR",
+                        level="INFO",
                         propagate=False,
                         handlers=["stderr01"],
                     ),
@@ -104,7 +104,7 @@ SERVER = server.EsbonioLanguageServer
                 ),
                 loggers=dict(
                     esbonio=dict(
-                        level="ERROR",
+                        level="INFO",
                         propagate=False,
                         handlers=["stderr01"],
                     ),
@@ -141,7 +141,7 @@ SERVER = server.EsbonioLanguageServer
                 ),
                 loggers=dict(
                     esbonio=dict(
-                        level="ERROR",
+                        level="INFO",
                         propagate=False,
                         handlers=["window01"],
                     ),
@@ -178,7 +178,7 @@ SERVER = server.EsbonioLanguageServer
                 ),
                 loggers=dict(
                     esbonio=dict(
-                        level="ERROR",
+                        level="INFO",
                         propagate=False,
                         handlers=["file01"],
                     ),
@@ -239,7 +239,7 @@ SERVER = server.EsbonioLanguageServer
                 ),
                 loggers=dict(
                     esbonio=dict(
-                        level="ERROR",
+                        level="INFO",
                         propagate=False,
                         handlers=["file01", "stderr02", "window03"],
                     ),
@@ -278,7 +278,7 @@ SERVER = server.EsbonioLanguageServer
                 ),
                 loggers={
                     "esbonio": dict(
-                        level="ERROR",
+                        level="INFO",
                         propagate=False,
                         handlers=["stderr01"],
                     ),


### PR DESCRIPTION
The default values for the following configuration options have been changed.

- `esbonio.logging.level` now defaults to `info`
- `esbonio.server.completion.preferredInsertBehavior` now defaults to `insert`