### PR TITLE
Adjust logging approach 

### DIFF
--- a/code/changes/1095.enhancement.md
+++ b/code/changes/1095.enhancement.md
@@ -1,0 +1,1 @@
+Update Esbonio output window syntax highlighting to align with logging changes in the `esbonio` language server.

--- a/code/changes/1095.feature.md
+++ b/code/changes/1095.feature.md
@@ -1,0 +1,1 @@
+Expose `esbonio.logging.enabledMethods` configuration option.

--- a/code/package.json
+++ b/code/package.json
@@ -342,6 +342,15 @@
                         "default": false,
                         "description": "If set, send log messages as window/logMessage notifications"
                     },
+                    "esbonio.logging.enabledMethods": {
+                        "scope": "window",
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "default": null,
+                        "description": "If set, only log messages related to the given LSP methods (e.g. `textDocument/completion`)"
+                    },
                     "esbonio.logging.config": {
                         "scope": "window",
                         "type": "object",

--- a/code/syntaxes/esbonio-log-output.tmLanguage.json
+++ b/code/syntaxes/esbonio-log-output.tmLanguage.json
@@ -13,10 +13,16 @@
     ],
     "repository": {
         "log-line": {
-            "match": "^\\[([.a-zA-Z]+)\\]",
+            "match": "^(\\[([./$a-zA-Z]+)\\(([\\d]+)?\\)\\])?\\[([.a-zA-Z]+)\\]",
             "captures": {
-                "1": {
-                    "name": "storage.type.namespace"
+                "2": {
+                    "name": "keyword.control"
+                },
+                "3": {
+                    "name": "constant.numeric"
+                },
+                "4": {
+                    "name": "entity.name.class"
                 }
             }
         },

--- a/docs/usage/howto/migrate-to-v2.rst
+++ b/docs/usage/howto/migrate-to-v2.rst
@@ -8,7 +8,7 @@ This guide covers the breaking changes between the ``v1.x`` and ``v2.x`` version
 Sphinx v6 No Longer Supported
 -----------------------------
 
-Inline with the :ref:`about-versioning` policy, while Esbonio v2 adds support for Sphinx v9, support for Sphinx v6 has been removed.
+Inline with the :ref:`about-versioning` policy, while Esbonio ``v2.x`` adds support for Sphinx v9, support for Sphinx v6 has been removed.
 
 Configuration Changes
 ---------------------
@@ -16,4 +16,238 @@ Configuration Changes
 The default values for the following configuration options have been changed.
 
 - :esbonio:conf:`esbonio.logging.level` now defaults to ``info``
+- :esbonio:conf:`esbonio.logging.format` now defaults to ``[%(method)s(%(msgid)s)][%(name)s] %(message)s``
 - :esbonio:conf:`esbonio.server.completion.preferredInsertBehavior` now defaults to ``insert``
+
+Logging Changes
+---------------
+
+When turned up to ``debug``, esbonio's log output can become *very* verbose.
+
+Unfortunately, this doesn't necessarily mean that diagnosing issues with the server is easy, especially if you're not famaliar with the server's internals.
+This is despite the fact the server already provides a rich set of logging options (see :esbonio:conf:`esbonio.logging.config`), allowing you to tailor the output from specific components of the server.
+
+The issue is that this flexibility was along the wrong axis, requiring you to be familiar with the internal architecture of the server in order to decide which components to pay attention to.
+
+This release attempts to rectify this by introducing a series of changes to the logging system.
+Consider the following output from a ``v1.x`` version of the server:
+
+.. raw:: html
+
+   <style>
+   .limit-height div.highlight pre {
+      max-height: 300px;
+      overflow: auto;
+   }
+   </style>
+
+.. code-block:: none
+   :class: limit-height
+
+   [esbonio.Configuration] ConfigurationContext(file_scope='', workspace_scope='')
+   [esbonio.Configuration] esbonio.server.completion: {
+   "preferredInsertBehavior": "replace"
+   }
+   [esbonio.Configuration] CompletionConfig(preferred_insert_behavior='replace')
+   [esbonio.Configuration] Previous: None
+   [esbonio.Configuration] Current: CompletionConfig(preferred_insert_behavior='replace')
+   [esbonio.Configuration] ConfigChangeEvent(scope='', value=CompletionConfig(preferred_insert_behavior='replace'), previous=None)
+   [esbonio] Task finished: <Task finished name='Task-23' coro=<PreviewManager.show_preview_uri() done, defined at /workspaces/develop/.vscode/extensions/esbonio/bundled/libs/esbonio/server/features/preview_manager/__init__.py:187> result=None>
+   [esbonio.ProjectManager] No applicable project for uri: file:///workspaces/develop/docs/usage/howto/migrate-to-v2.rst
+   Running Sphinx v9.1.0
+   loading translations [en]... done
+   The configuration has changed (2 options: 'html_static_path', 'pygments_dark_style')
+   loading pickled environment... done
+   myst v5.0.0: MdParserConfig(commonmark_only=False, gfm_only=False, enable_extensions=set(), disable_syntax=[], all_links_external=False, links_external_new_tab=False, url_schemes=('http', 'https', 'mailto', 'ftp'), ref_domains=None, fence_as_directive=set(), number_code_blocks=[], title_to_header=False, heading_anchors=0, heading_slug_func=None, html_meta={}, footnote_sort=True, footnote_transition=True, words_per_minute=200, substitutions={}, linkify_fuzzy_links=True, dmath_allow_labels=True, dmath_allow_space=True, dmath_allow_digits=True, dmath_double_inline=False, update_mathjax=True, mathjax_classes='tex2jax_process|mathjax_process|math|output_area', enable_checkboxes=False, suppress_warnings=[], highlight_code_blocks=True)
+   /workspaces/develop/.vscode/extensions/esbonio/bundled/libs/esbonio/sphinx_agent/handlers/domains.py:281: RemovedInSphinx10Warning: The iter() interface for _InventoryItem objects is deprecated. Please access the `project_name`, `project_version`, `uri`, and `displayname` attributes directly.
+   (name, version, _, _) = next(iter(next(iter(project.values())).values()))
+   /workspaces/develop/.vscode/extensions/esbonio/bundled/libs/esbonio/sphinx_agent/handlers/domains.py:303: RemovedInSphinx10Warning: The iter() interface for _InventoryItem objects is deprecated. Please access the `project_name`, `project_version`, `uri`, and `displayname` attributes directly.
+   for objname, (_, _, item_uri, display) in items.items():
+   [esbonio.SphinxManager] SphinxClient[0f684895-d015-46f9-ac3b-623c654a720b]: ClientState.Starting -> ClientState.Running
+   [esbonio.ProjectManager] Registered project for scope 'file:///workspaces/develop/docs': '/home/vscode/.cache/esbonio/20e782cab5bb1a14bf2d7b72e76dae1a/dirhtml/esbonio.db'
+   [client] sphinx/appCreated: {
+   "version": "9.1.0",
+   "python": "3.14.3",
+   "conf_dir": "/workspaces/develop/docs",
+   "build_dir": "/home/vscode/.cache/esbonio/20e782cab5bb1a14bf2d7b72e76dae1a/dirhtml",
+   "builder_name": "dirhtml",
+   "src_dir": "/workspaces/develop/docs",
+   "dbpath": "/home/vscode/.cache/esbonio/20e782cab5bb1a14bf2d7b72e76dae1a/dirhtml/esbonio.db"
+   }
+   [esbonio] Task finished: <Task finished name='Task-17' coro=<SphinxManager._create_or_replace_client() done, defined at /workspaces/develop/.vscode/extensions/esbonio/bundled/libs/esbonio/server/features/sphinx_manager/manager.py:316> result=None>
+   [esbonio.PreviewManager] Previewing file: 'file:///workspaces/develop/docs/usage/reference/configuration.rst'
+   [esbonio] DocumentLinkContext<file:///workspaces/develop/docs/usage/reference/configuration.rst>
+   [esbonio.DirectiveFeature] Resolving argument link for directive: 'highlight' (sphinx.directives.code.Highlight)
+   [esbonio.DirectiveFeature] Resolving argument link for directive: 'code-block' (sphinx.directives.code.CodeBlock)
+   [esbonio.DirectiveFeature] Resolving argument link for directive: 'code-block' (sphinx.directives.code.CodeBlock)
+   [esbonio.DirectiveFeature] Resolving argument link for directive: 'code-block' (sphinx.directives.code.CodeBlock)
+   [esbonio.DirectiveFeature] Resolving argument link for directive: 'code-block' (sphinx.directives.code.CodeBlock)
+   [esbonio.DirectiveFeature] Resolving argument link for directive: 'code-block' (sphinx.directives.code.CodeBlock)
+   [esbonio.RolesFeature] Resolving target link for role: 'std:ref' (sphinx.roles.XRefRole)
+   [esbonio.ObjectsProvider] DocumentLinkContext<file:///workspaces/develop/docs/usage/reference/configuration.rst> lsp-configuration-completion ['std:label'] None
+   [esbonio.RolesFeature] Resolving target link for role: 'std:ref' (sphinx.roles.XRefRole)
+   [esbonio.ObjectsProvider] DocumentLinkContext<file:///workspaces/develop/docs/usage/reference/configuration.rst> lsp-configuration-developer ['std:label'] None
+   [esbonio.RolesFeature] Resolving target link for role: 'std:ref' (sphinx.roles.XRefRole)
+   [esbonio.ObjectsProvider] DocumentLinkContext<file:///workspaces/develop/docs/usage/reference/configuration.rst> lsp-configuration-logging ['std:label'] None
+   [esbonio.RolesFeature] Resolving target link for role: 'std:ref' (sphinx.roles.XRefRole)
+   [esbonio.ObjectsProvider] DocumentLinkContext<file:///workspaces/develop/docs/usage/reference/configuration.rst> lsp-configuration-sphinx ['std:label'] None
+   [esbonio.RolesFeature] Resolving target link for role: 'std:ref' (sphinx.roles.XRefRole)
+   [esbonio.ObjectsProvider] DocumentLinkContext<file:///workspaces/develop/docs/usage/reference/configuration.rst> lsp-configuration-preview ['std:label'] None
+   [esbonio.RolesFeature] Unknown role 'external:ref'
+   [esbonio.RolesFeature] Unknown role 'external:ref'
+   [esbonio.RolesFeature] Resolving target link for role: 'esbonio:conf' (sphinx.roles.XRefRole)
+   [esbonio.ObjectsProvider] DocumentLinkContext<file:///workspaces/develop/docs/usage/reference/configuration.rst> esbonio.logging.level ['esbonio:config'] None
+   [esbonio.RolesFeature] Resolving target link for role: 'esbonio:conf' (sphinx.roles.XRefRole)
+   [esbonio.ObjectsProvider] DocumentLinkContext<file:///workspaces/develop/docs/usage/reference/configuration.rst> esbonio.logging.format ['esbonio:config'] None
+   [esbonio.RolesFeature] Resolving target link for role: 'esbonio:conf' (sphinx.roles.XRefRole)
+   [esbonio.ObjectsProvider] DocumentLinkContext<file:///workspaces/develop/docs/usage/reference/configuration.rst> esbonio.logging.filepath ['esbonio:config'] None
+   [esbonio.RolesFeature] Resolving target link for role: 'esbonio:conf' (sphinx.roles.XRefRole)
+   [esbonio.ObjectsProvider] DocumentLinkContext<file:///workspaces/develop/docs/usage/reference/configuration.rst> esbonio.logging.stderr ['esbonio:config'] None
+   [esbonio.RolesFeature] Resolving target link for role: 'esbonio:conf' (sphinx.roles.XRefRole)
+   [esbonio.ObjectsProvider] DocumentLinkContext<file:///workspaces/develop/docs/usage/reference/configuration.rst> esbonio.logging.window ['esbonio:config'] None
+   [esbonio.RolesFeature] Resolving target link for role: 'std:ref' (sphinx.roles.XRefRole)
+   [esbonio.ObjectsProvider] DocumentLinkContext<file:///workspaces/develop/docs/usage/reference/configuration.rst> lsp-configure-sphinx-build-cmd ['std:label'] None
+   [esbonio.RolesFeature] Resolving target link for role: 'esbonio:conf' (sphinx.roles.XRefRole)
+   [esbonio.ObjectsProvider] DocumentLinkContext<file:///workspaces/develop/docs/usage/reference/configuration.rst> esbonio.sphinx.buildArguments ['esbonio:config'] None
+   [esbonio.RolesFeature] Resolving target link for role: 'std:option' (sphinx.domains.std.OptionXRefRole)
+   [esbonio.ObjectsProvider] DocumentLinkContext<file:///workspaces/develop/docs/usage/reference/configuration.rst> sphinx:sphinx-build.-D ['std:cmdoption'] None
+   [esbonio.RolesFeature] Resolving target link for role: 'std:option' (sphinx.domains.std.OptionXRefRole)
+   [esbonio.ObjectsProvider] DocumentLinkContext<file:///workspaces/develop/docs/usage/reference/configuration.rst> sphinx:sphinx-build.-A ['std:cmdoption'] None
+   [esbonio.RolesFeature] Resolving target link for role: 'std:ref' (sphinx.roles.XRefRole)
+   [esbonio.ObjectsProvider] DocumentLinkContext<file:///workspaces/develop/docs/usage/reference/configuration.rst> lsp-configure-sphinx-build-cmd ['std:label'] None
+   [esbonio.RolesFeature] Resolving target link for role: 'std:ref' (sphinx.roles.XRefRole)
+   [esbonio.ObjectsProvider] DocumentLinkContext<file:///workspaces/develop/docs/usage/reference/configuration.rst> lsp-configure-sphinx-build-env ['std:label'] None
+   [esbonio.PreviewManager] Preview available at: http://localhost:40535/usage/reference/configuration/?ws=ws%3A%2F%2Flocalhost%3A43647
+   [esbonio.PreviewManager] window/showDocument: ShowDocumentResult(success=True)
+
+There is a *lot* going on here, and if you're trying to debug issues with your Sphinx setup, most of it is irrelevant!
+
+In esbonio ``v2.x`` log messages will be prefixed with the LSP method they are associated with, as shown in the equivalent ``v2.x`` output below:
+
+.. code-block:: none
+   :class: limit-height
+
+   [initialized()][esbonio.Configuration] ConfigurationContext(file_scope='', workspace_scope='')
+   [initialized()][esbonio.Configuration] esbonio.server.completion: {
+   "preferredInsertBehavior": "replace"
+   }
+   [initialized()][esbonio.Configuration] CompletionConfig(preferred_insert_behavior='replace')
+   [initialized()][esbonio.Configuration] Previous: None
+   [initialized()][esbonio.Configuration] Current: CompletionConfig(preferred_insert_behavior='replace')
+   [initialized()][esbonio.Configuration] ConfigChangeEvent(scope='', value=CompletionConfig(preferred_insert_behavior='replace'), previous=None)
+   [initialized()][esbonio] Task finished: <Task finished name='Task-23' coro=<PreviewManager.show_preview_uri() done, defined at /workspaces/develop/.vscode/extensions/esbonio/bundled/libs/esbonio/server/features/preview_manager/__init__.py:187> result=None>
+   [textDocument/documentSymbol(8)][esbonio.ProjectManager] No applicable project for uri: file:///workspaces/develop/docs/usage/howto/migrate-to-v2.rst
+   Running Sphinx v9.1.0
+   loading translations [en]... done
+   The configuration has changed (2 options: 'html_static_path', 'pygments_dark_style')
+   loading pickled environment... done
+   myst v5.0.0: MdParserConfig(commonmark_only=False, gfm_only=False, enable_extensions=set(), disable_syntax=[], all_links_external=False, links_external_new_tab=False, url_schemes=('http', 'https', 'mailto', 'ftp'), ref_domains=None, fence_as_directive=set(), number_code_blocks=[], title_to_header=False, heading_anchors=0, heading_slug_func=None, html_meta={}, footnote_sort=True, footnote_transition=True, words_per_minute=200, substitutions={}, linkify_fuzzy_links=True, dmath_allow_labels=True, dmath_allow_space=True, dmath_allow_digits=True, dmath_double_inline=False, update_mathjax=True, mathjax_classes='tex2jax_process|mathjax_process|math|output_area', enable_checkboxes=False, suppress_warnings=[], highlight_code_blocks=True)
+   /workspaces/develop/.vscode/extensions/esbonio/bundled/libs/esbonio/sphinx_agent/handlers/domains.py:281: RemovedInSphinx10Warning: The iter() interface for _InventoryItem objects is deprecated. Please access the `project_name`, `project_version`, `uri`, and `displayname` attributes directly.
+   (name, version, _, _) = next(iter(next(iter(project.values())).values()))
+   /workspaces/develop/.vscode/extensions/esbonio/bundled/libs/esbonio/sphinx_agent/handlers/domains.py:303: RemovedInSphinx10Warning: The iter() interface for _InventoryItem objects is deprecated. Please access the `project_name`, `project_version`, `uri`, and `displayname` attributes directly.
+   for objname, (_, _, item_uri, display) in items.items():
+   [initialized()][esbonio.SphinxManager] SphinxClient[0f684895-d015-46f9-ac3b-623c654a720b]: ClientState.Starting -> ClientState.Running
+   [initialized()][esbonio.ProjectManager] Registered project for scope 'file:///workspaces/develop/docs': '/home/vscode/.cache/esbonio/20e782cab5bb1a14bf2d7b72e76dae1a/dirhtml/esbonio.db'
+   [client] sphinx/appCreated: {
+   "version": "9.1.0",
+   "python": "3.14.3",
+   "conf_dir": "/workspaces/develop/docs",
+   "build_dir": "/home/vscode/.cache/esbonio/20e782cab5bb1a14bf2d7b72e76dae1a/dirhtml",
+   "builder_name": "dirhtml",
+   "src_dir": "/workspaces/develop/docs",
+   "dbpath": "/home/vscode/.cache/esbonio/20e782cab5bb1a14bf2d7b72e76dae1a/dirhtml/esbonio.db"
+   }
+   [initialized()][esbonio] Task finished: <Task finished name='Task-17' coro=<SphinxManager._create_or_replace_client() done, defined at /workspaces/develop/.vscode/extensions/esbonio/bundled/libs/esbonio/server/features/sphinx_manager/manager.py:316> result=None>
+   [workspace/executeCommand(21)][esbonio.PreviewManager] Previewing file: 'file:///workspaces/develop/docs/usage/reference/configuration.rst'
+   [textDocument/documentLink(23)][esbonio] DocumentLinkContext<file:///workspaces/develop/docs/usage/reference/configuration.rst>
+   [textDocument/documentLink(23)][esbonio.DirectiveFeature] Resolving argument link for directive: 'highlight' (sphinx.directives.code.Highlight)
+   [textDocument/documentLink(23)][esbonio.DirectiveFeature] Resolving argument link for directive: 'code-block' (sphinx.directives.code.CodeBlock)
+   [textDocument/documentLink(23)][esbonio.DirectiveFeature] Resolving argument link for directive: 'code-block' (sphinx.directives.code.CodeBlock)
+   [textDocument/documentLink(23)][esbonio.DirectiveFeature] Resolving argument link for directive: 'code-block' (sphinx.directives.code.CodeBlock)
+   [textDocument/documentLink(23)][esbonio.DirectiveFeature] Resolving argument link for directive: 'code-block' (sphinx.directives.code.CodeBlock)
+   [textDocument/documentLink(23)][esbonio.DirectiveFeature] Resolving argument link for directive: 'code-block' (sphinx.directives.code.CodeBlock)
+   [textDocument/documentLink(23)][esbonio.RolesFeature] Resolving target link for role: 'std:ref' (sphinx.roles.XRefRole)
+   [textDocument/documentLink(23)][esbonio.ObjectsProvider] DocumentLinkContext<file:///workspaces/develop/docs/usage/reference/configuration.rst> lsp-configuration-completion ['std:label'] None
+   [textDocument/documentLink(23)][esbonio.RolesFeature] Resolving target link for role: 'std:ref' (sphinx.roles.XRefRole)
+   [textDocument/documentLink(23)][esbonio.ObjectsProvider] DocumentLinkContext<file:///workspaces/develop/docs/usage/reference/configuration.rst> lsp-configuration-developer ['std:label'] None
+   [textDocument/documentLink(23)][esbonio.RolesFeature] Resolving target link for role: 'std:ref' (sphinx.roles.XRefRole)
+   [textDocument/documentLink(23)][esbonio.ObjectsProvider] DocumentLinkContext<file:///workspaces/develop/docs/usage/reference/configuration.rst> lsp-configuration-logging ['std:label'] None
+   [textDocument/documentLink(23)][esbonio.RolesFeature] Resolving target link for role: 'std:ref' (sphinx.roles.XRefRole)
+   [textDocument/documentLink(23)][esbonio.ObjectsProvider] DocumentLinkContext<file:///workspaces/develop/docs/usage/reference/configuration.rst> lsp-configuration-sphinx ['std:label'] None
+   [textDocument/documentLink(23)][esbonio.RolesFeature] Resolving target link for role: 'std:ref' (sphinx.roles.XRefRole)
+   [textDocument/documentLink(23)][esbonio.ObjectsProvider] DocumentLinkContext<file:///workspaces/develop/docs/usage/reference/configuration.rst> lsp-configuration-preview ['std:label'] None
+   [textDocument/documentLink(23)][esbonio.RolesFeature] Unknown role 'external:ref'
+   [textDocument/documentLink(23)][esbonio.RolesFeature] Unknown role 'external:ref'
+   [textDocument/documentLink(23)][esbonio.RolesFeature] Resolving target link for role: 'esbonio:conf' (sphinx.roles.XRefRole)
+   [textDocument/documentLink(23)][esbonio.ObjectsProvider] DocumentLinkContext<file:///workspaces/develop/docs/usage/reference/configuration.rst> esbonio.logging.level ['esbonio:config'] None
+   [textDocument/documentLink(23)][esbonio.RolesFeature] Resolving target link for role: 'esbonio:conf' (sphinx.roles.XRefRole)
+   [textDocument/documentLink(23)][esbonio.ObjectsProvider] DocumentLinkContext<file:///workspaces/develop/docs/usage/reference/configuration.rst> esbonio.logging.format ['esbonio:config'] None
+   [textDocument/documentLink(23)][esbonio.RolesFeature] Resolving target link for role: 'esbonio:conf' (sphinx.roles.XRefRole)
+   [textDocument/documentLink(23)][esbonio.ObjectsProvider] DocumentLinkContext<file:///workspaces/develop/docs/usage/reference/configuration.rst> esbonio.logging.filepath ['esbonio:config'] None
+   [textDocument/documentLink(23)][esbonio.RolesFeature] Resolving target link for role: 'esbonio:conf' (sphinx.roles.XRefRole)
+   [textDocument/documentLink(23)][esbonio.ObjectsProvider] DocumentLinkContext<file:///workspaces/develop/docs/usage/reference/configuration.rst> esbonio.logging.stderr ['esbonio:config'] None
+   [textDocument/documentLink(23)][esbonio.RolesFeature] Resolving target link for role: 'esbonio:conf' (sphinx.roles.XRefRole)
+   [textDocument/documentLink(23)][esbonio.ObjectsProvider] DocumentLinkContext<file:///workspaces/develop/docs/usage/reference/configuration.rst> esbonio.logging.window ['esbonio:config'] None
+   [textDocument/documentLink(23)][esbonio.RolesFeature] Resolving target link for role: 'std:ref' (sphinx.roles.XRefRole)
+   [textDocument/documentLink(23)][esbonio.ObjectsProvider] DocumentLinkContext<file:///workspaces/develop/docs/usage/reference/configuration.rst> lsp-configure-sphinx-build-cmd ['std:label'] None
+   [textDocument/documentLink(23)][esbonio.RolesFeature] Resolving target link for role: 'esbonio:conf' (sphinx.roles.XRefRole)
+   [textDocument/documentLink(23)][esbonio.ObjectsProvider] DocumentLinkContext<file:///workspaces/develop/docs/usage/reference/configuration.rst> esbonio.sphinx.buildArguments ['esbonio:config'] None
+   [textDocument/documentLink(23)][esbonio.RolesFeature] Resolving target link for role: 'std:option' (sphinx.domains.std.OptionXRefRole)
+   [textDocument/documentLink(23)][esbonio.ObjectsProvider] DocumentLinkContext<file:///workspaces/develop/docs/usage/reference/configuration.rst> sphinx:sphinx-build.-D ['std:cmdoption'] None
+   [textDocument/documentLink(23)][esbonio.RolesFeature] Resolving target link for role: 'std:option' (sphinx.domains.std.OptionXRefRole)
+   [textDocument/documentLink(23)][esbonio.ObjectsProvider] DocumentLinkContext<file:///workspaces/develop/docs/usage/reference/configuration.rst> sphinx:sphinx-build.-A ['std:cmdoption'] None
+   [textDocument/documentLink(23)][esbonio.RolesFeature] Resolving target link for role: 'std:ref' (sphinx.roles.XRefRole)
+   [textDocument/documentLink(23)][esbonio.ObjectsProvider] DocumentLinkContext<file:///workspaces/develop/docs/usage/reference/configuration.rst> lsp-configure-sphinx-build-cmd ['std:label'] None
+   [textDocument/documentLink(23)][esbonio.RolesFeature] Resolving target link for role: 'std:ref' (sphinx.roles.XRefRole)
+   [textDocument/documentLink(23)][esbonio.ObjectsProvider] DocumentLinkContext<file:///workspaces/develop/docs/usage/reference/configuration.rst> lsp-configure-sphinx-build-env ['std:label'] None
+   [workspace/executeCommand(21)][esbonio.PreviewManager] Preview available at: http://localhost:40535/usage/reference/configuration/?ws=ws%3A%2F%2Flocalhost%3A43647
+   [workspace/executeCommand(21)][esbonio.PreviewManager] window/showDocument: ShowDocumentResult(success=True)
+
+Already that should be somewhat easier to parse and you can probably guess that the messages tagged with ``initialized()`` are the ones to pay attention to.
+
+However, since the majority of issues with esbonio appear to be related to Sphinx configs and environment setup, ``v2.x`` goes one step further and by default only shows messages associated with the following LSP methods:
+
+- ``initialize``
+- ``initialized``
+- ``textDocument/didOpen``
+- ``workspace/didChangeConfiguration``
+
+Which results in the following output
+
+.. code-block:: none
+   :class: limit-height
+
+   [initialized()][esbonio.Configuration] ConfigurationContext(file_scope='', workspace_scope='')
+   [initialized()][esbonio.Configuration] esbonio.server.completion: {
+   "preferredInsertBehavior": "replace"
+   }
+   [initialized()][esbonio.Configuration] CompletionConfig(preferred_insert_behavior='replace')
+   [initialized()][esbonio.Configuration] Previous: None
+   [initialized()][esbonio.Configuration] Current: CompletionConfig(preferred_insert_behavior='replace')
+   [initialized()][esbonio.Configuration] ConfigChangeEvent(scope='', value=CompletionConfig(preferred_insert_behavior='replace'), previous=None)
+   [initialized()][esbonio] Task finished: <Task finished name='Task-23' coro=<PreviewManager.show_preview_uri() done, defined at /workspaces/develop/.vscode/extensions/esbonio/bundled/libs/esbonio/server/features/preview_manager/__init__.py:187> result=None>
+   Running Sphinx v9.1.0
+   loading translations [en]... done
+   The configuration has changed (2 options: 'html_static_path', 'pygments_dark_style')
+   loading pickled environment... done
+   myst v5.0.0: MdParserConfig(commonmark_only=False, gfm_only=False, enable_extensions=set(), disable_syntax=[], all_links_external=False, links_external_new_tab=False, url_schemes=('http', 'https', 'mailto', 'ftp'), ref_domains=None, fence_as_directive=set(), number_code_blocks=[], title_to_header=False, heading_anchors=0, heading_slug_func=None, html_meta={}, footnote_sort=True, footnote_transition=True, words_per_minute=200, substitutions={}, linkify_fuzzy_links=True, dmath_allow_labels=True, dmath_allow_space=True, dmath_allow_digits=True, dmath_double_inline=False, update_mathjax=True, mathjax_classes='tex2jax_process|mathjax_process|math|output_area', enable_checkboxes=False, suppress_warnings=[], highlight_code_blocks=True)
+   /workspaces/develop/.vscode/extensions/esbonio/bundled/libs/esbonio/sphinx_agent/handlers/domains.py:281: RemovedInSphinx10Warning: The iter() interface for _InventoryItem objects is deprecated. Please access the `project_name`, `project_version`, `uri`, and `displayname` attributes directly.
+   (name, version, _, _) = next(iter(next(iter(project.values())).values()))
+   /workspaces/develop/.vscode/extensions/esbonio/bundled/libs/esbonio/sphinx_agent/handlers/domains.py:303: RemovedInSphinx10Warning: The iter() interface for _InventoryItem objects is deprecated. Please access the `project_name`, `project_version`, `uri`, and `displayname` attributes directly.
+   for objname, (_, _, item_uri, display) in items.items():
+   [initialized()][esbonio.SphinxManager] SphinxClient[0f684895-d015-46f9-ac3b-623c654a720b]: ClientState.Starting -> ClientState.Running
+   [initialized()][esbonio.ProjectManager] Registered project for scope 'file:///workspaces/develop/docs': '/home/vscode/.cache/esbonio/20e782cab5bb1a14bf2d7b72e76dae1a/dirhtml/esbonio.db'
+   [client] sphinx/appCreated: {
+   "version": "9.1.0",
+   "python": "3.14.3",
+   "conf_dir": "/workspaces/develop/docs",
+   "build_dir": "/home/vscode/.cache/esbonio/20e782cab5bb1a14bf2d7b72e76dae1a/dirhtml",
+   "builder_name": "dirhtml",
+   "src_dir": "/workspaces/develop/docs",
+   "dbpath": "/home/vscode/.cache/esbonio/20e782cab5bb1a14bf2d7b72e76dae1a/dirhtml/esbonio.db"
+   }
+   [initialized()][esbonio] Task finished: <Task finished name='Task-17' coro=<SphinxManager._create_or_replace_client() done, defined at /workspaces/develop/.vscode/extensions/esbonio/bundled/libs/esbonio/server/features/sphinx_manager/manager.py:316> result=None>
+
+While it is far from perfect, hopefully these changes are at least the start of making the process of diagnosing issues with esbonio more approachable.
+
+Finally, ``v2.x`` introduces the :esbonio:conf:`esbonio.logging.enabledMethods` option which can be used to change the list of LSP methods to show messages for.

--- a/docs/usage/reference/configuration.rst
+++ b/docs/usage/reference/configuration.rst
@@ -136,7 +136,7 @@ The following options control the logging output of the language server.
    Sets the default format string to apply to log messages.
    This can be any valid :external:ref:`%-style <old-string-formatting>` format string, referencing valid :external:ref:`logrecord-attributes`
 
-   **Default value:** ``[%(name)s]: %(message)s``
+   **Default value:** ``[%(method)s(%(msgid)s)][%(name)s]: %(message)s``
 
 .. esbonio:config:: esbonio.logging.filepath
    :scope: global
@@ -155,6 +155,20 @@ The following options control the logging output of the language server.
    :type: boolean
 
    If ``True``, the server will send messages to the client as :lsp:`window/logMessage` notifications
+
+.. esbonio:config:: esbonio.logging.enabledMethods
+   :scope: global
+   :type: string[]
+
+   Only log messages for the given list of LSP method names will be emitted.
+   If not given, the following list of method names will be used by default
+
+   - ``initialize``
+   - ``initialized``
+   - ``textDocument/didOpen``
+   - ``workspace/didChangeConfiguration``
+
+   **Note:** This only applies to log messages emitted from the ``esbonio`` logger, or any of its child loggers.
 
 .. esbonio:config:: esbonio.logging.config
    :scope: global
@@ -179,9 +193,15 @@ The following is equivalent to the server's default logging configuration::
    {
      "esbonio": {
        "logging": {
-         "level": "error",
-         "format": "[%(name)s]: %(message)s",
+         "level": "info",
+         "format": "[%(method)s(%(msgid)s)][%(name)s]: %(message)s",
          "stderr": true,
+         "enabledMethods": [
+            "initialize",
+            "initialized",
+            "textDocument/didOpen",
+            "workspace/didChangeConfiguration",
+         ],
          "config": {
            "sphinx": {
              "level": "info",

--- a/lib/esbonio/changes/1094.breaking.md
+++ b/lib/esbonio/changes/1094.breaking.md
@@ -1,0 +1,4 @@
+The default values for the following configuration options have been changed.
+
+- `esbonio.logging.level` now defaults to `info`
+- `esbonio.server.completion.preferredInsertBehavior` now defaults to `insert`

--- a/lib/esbonio/changes/1095.breaking.md
+++ b/lib/esbonio/changes/1095.breaking.md
@@ -1,0 +1,5 @@
+The default values for the following configuration options have been changed.
+
+- `esbonio.logging.format` now defaults to `[%(method)s(%(msgid)s)][%(name)s] %(message)s`
+
+Only log messages associated with the LSP methods `initialize`, `initialized`, `textDocument/didOpen` and `workspace/didChangeConfiguration` are shown by default, regardless of logging level.

--- a/lib/esbonio/changes/1095.feature.md
+++ b/lib/esbonio/changes/1095.feature.md
@@ -1,0 +1,1 @@
+Introduce the `esbonio.logging.enabledMethods` option which can be used to override the list of LSP methods for which log messages are shown.

--- a/lib/esbonio/esbonio/server/__init__.py
+++ b/lib/esbonio/esbonio/server/__init__.py
@@ -18,6 +18,7 @@ from .feature import HoverTrigger
 from .feature import LanguageFeature
 from .server import EsbonioLanguageServer
 from .server import EsbonioWorkspace
+from .server import LSProtocol
 from .server import __version__
 from .setup import create_language_server
 
@@ -40,6 +41,7 @@ __all__ = (
     "HoverContext",
     "HoverTrigger",
     "LanguageFeature",
+    "LSProtocol",
     "Uri",
     "create_language_server",
 )

--- a/lib/esbonio/esbonio/server/cli.py
+++ b/lib/esbonio/esbonio/server/cli.py
@@ -7,9 +7,11 @@ from logging.handlers import MemoryHandler
 
 from pygls.protocol import default_converter
 
-from .server import EsbonioLanguageServer
-from .server import __version__
-from .setup import create_language_server
+from esbonio.server import EsbonioLanguageServer
+from esbonio.server import LSProtocol
+from esbonio.server import __version__
+from esbonio.server.features.log import LSPInfoFilter
+from esbonio.server.setup import create_language_server
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -18,14 +20,14 @@ def build_parser() -> argparse.ArgumentParser:
     """
 
     cli = argparse.ArgumentParser(description="The Esbonio language server")
-    cli.add_argument(
+    _ = cli.add_argument(
         "-p",
         "--port",
         type=int,
         default=None,
         help="start a TCP instance of the language server listening on the given port.",
     )
-    cli.add_argument(
+    _ = cli.add_argument(
         "--version",
         action="version",
         version=__version__,
@@ -35,7 +37,7 @@ def build_parser() -> argparse.ArgumentParser:
     modules = cli.add_argument_group(
         "modules", "include/exclude language server modules."
     )
-    modules.add_argument(
+    _ = modules.add_argument(
         "-i",
         "--include",
         metavar="MOD",
@@ -44,7 +46,7 @@ def build_parser() -> argparse.ArgumentParser:
         dest="included_modules",
         help="include an additional module in the server configuration, can be given multiple times.",
     )
-    modules.add_argument(
+    _ = modules.add_argument(
         "-e",
         "--exclude",
         metavar="MOD",
@@ -94,17 +96,20 @@ def main(argv: Sequence[str] | None = None):
 
     # Setup a temporary logging handler that can cache messages until the language server
     # is ready to forward them onto the client.
+    memory_handler = MemoryHandler(999999, flushLevel=logging.CRITICAL)
     logging.basicConfig(
         level=logging.DEBUG,
-        handlers=[MemoryHandler(999999, flushLevel=logging.CRITICAL)],
+        handlers=[memory_handler],
     )
 
     server = create_language_server(
         EsbonioLanguageServer,
         modules,
         logger=logging.getLogger("esbonio"),
+        protocol_cls=LSProtocol,
         converter_factory=default_converter,
     )
+    memory_handler.addFilter(LSPInfoFilter(server))
 
     if args.port:
         server.start_tcp("localhost", args.port)

--- a/lib/esbonio/esbonio/server/features/log.py
+++ b/lib/esbonio/esbonio/server/features/log.py
@@ -11,7 +11,9 @@ from typing import Any
 import attrs
 from lsprotocol import types
 
-from esbonio import server
+from esbonio.server import ConfigChangeEvent
+from esbonio.server import EsbonioLanguageServer
+from esbonio.server import LanguageFeature
 
 LOG_LEVELS = {"CRITICAL", "FATAL", "ERROR", "WARN", "WARNING", "INFO", "DEBUG"}
 
@@ -22,7 +24,7 @@ class WindowLogMessageHandler(logging.Handler):
 
     def __init__(
         self,
-        server: server.EsbonioLanguageServer,
+        server: EsbonioLanguageServer,
     ):
         super().__init__()
         self.server = server
@@ -41,20 +43,40 @@ class WindowLogMessageHandler(logging.Handler):
 
 
 class LSPInfoFilter(logging.Filter):
-    """A logging filter for adding LSP specific information to log messages."""
+    """A logging filter for adding LSP specific information to log messages.
 
-    def __init__(self, server: server.EsbonioLanguageServer, *args, **kwargs):
+    It will also exclude messages from the log depending on the set of enabled methods.
+    """
+
+    def __init__(
+        self,
+        server: EsbonioLanguageServer,
+        enabled_methods: list[str] | None = None,
+        *args,
+        **kwargs,
+    ):
         super().__init__(*args, **kwargs)
-        self.server: server.EsbonioLanguageServer = server
+
+        self.server: EsbonioLanguageServer = server
+        self.enabled_methods: set[str] = set(enabled_methods or [])
 
     def filter(self, record: logging.LogRecord):
+        # Only touch records coming from esbonio
+        if "esbonio" not in record.name:
+            return True
+
         msg_id = self.server.protocol.msg_id or ""
         msg_method = self.server.protocol.msg_method or ""
 
         record.msgid = msg_id
         record.method = msg_method
 
-        return True
+        # Don't exclude messages without a method.
+        if msg_method == "":
+            return True
+
+        # Only include messages for enabled method names
+        return msg_method in self.enabled_methods
 
 
 @attrs.define
@@ -151,9 +173,7 @@ class LoggingConfigBuilder:
 
         return key
 
-    def _get_window_handler(
-        self, server: server.EsbonioLanguageServer, formatter: str
-    ) -> str:
+    def _get_window_handler(self, server: EsbonioLanguageServer, formatter: str) -> str:
         """Return the name of the handler that will send messages as
         ``window/logMessage`` notificaitions, using the given formatter name.
 
@@ -186,7 +206,7 @@ class LoggingConfigBuilder:
         format: str,
         filepath: str | None,
         stderr: bool,
-        window: server.EsbonioLanguageServer | None,
+        window: EsbonioLanguageServer | None,
     ):
         """Add a configuration for the given logger
 
@@ -228,11 +248,23 @@ class LoggingConfigBuilder:
 
         self.loggers[name] = dict(level=level, propagate=False, handlers=handlers)
 
-    def create_lsp_filter(self, server: server.EsbonioLanguageServer):
+    def create_lsp_filter(
+        self, server: EsbonioLanguageServer, enabled_methods: list[str]
+    ):
         """Create the filter instance that adds lsp message info to the log."""
+
+        if len(enabled_methods) == 0:
+            enabled_methods = [
+                types.INITIALIZE,
+                types.INITIALIZED,
+                types.TEXT_DOCUMENT_DID_OPEN,
+                types.WORKSPACE_DID_CHANGE_CONFIGURATION,
+            ]
+
         self.filters["lsp-filter"] = {
             "()": LSPInfoFilter,
             "server": server,
+            "enabled_methods": enabled_methods,
         }
 
     def finish(self) -> dict[str, Any]:
@@ -269,10 +301,13 @@ class LoggingConfig:
     config: dict[str, LoggerConfiguration] = attrs.field(factory=dict)
     """Configuration of individual loggers"""
 
+    enabled_methods: list[str] = attrs.field(factory=list)
+    """Only show log messages for the listed lsp methods."""
+
     show_deprecation_warnings: bool = attrs.field(default=False)
     """Developer flag to enable deprecation warnings."""
 
-    def to_logging_config(self, server: server.EsbonioLanguageServer) -> dict[str, Any]:
+    def to_logging_config(self, server: EsbonioLanguageServer) -> dict[str, Any]:
         """Convert the user's config into a config dict that can be passed to the
         ``logging.config.dictConfig()`` function.
 
@@ -283,7 +318,7 @@ class LoggingConfig:
         """
 
         builder = LoggingConfigBuilder()
-        builder.create_lsp_filter(server)
+        builder.create_lsp_filter(server, self.enabled_methods)
 
         # Ensure that there is at least an esbonio logger and a sphinx logger present in
         # the config.
@@ -334,7 +369,7 @@ class LoggingConfig:
         return builder.finish()
 
 
-class LogManager(server.LanguageFeature):
+class LogManager(LanguageFeature):
     """Manages the logging setup for the server."""
 
     def initialized(self, params: types.InitializedParams):
@@ -343,7 +378,7 @@ class LogManager(server.LanguageFeature):
             "esbonio.logging", LoggingConfig, self.setup_logging
         )
 
-    def setup_logging(self, event: server.ConfigChangeEvent[LoggingConfig]):
+    def setup_logging(self, event: ConfigChangeEvent[LoggingConfig]):
         """Setup logging according to the given config.
 
         Parameters
@@ -393,6 +428,6 @@ def dump(obj) -> str:
     return json.dumps(obj, default=default, indent=2)
 
 
-def esbonio_setup(server: server.EsbonioLanguageServer):
+def esbonio_setup(server: EsbonioLanguageServer):
     manager = LogManager(server)
     server.add_feature(manager)

--- a/lib/esbonio/esbonio/server/features/log.py
+++ b/lib/esbonio/esbonio/server/features/log.py
@@ -40,6 +40,23 @@ class WindowLogMessageHandler(logging.Handler):
         )
 
 
+class LSPInfoFilter(logging.Filter):
+    """A logging filter for adding LSP specific information to log messages."""
+
+    def __init__(self, server: server.EsbonioLanguageServer, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.server: server.EsbonioLanguageServer = server
+
+    def filter(self, record: logging.LogRecord):
+        msg_id = self.server.protocol.msg_id or ""
+        msg_method = self.server.protocol.msg_method or ""
+
+        record.msgid = msg_id
+        record.method = msg_method
+
+        return True
+
+
 @attrs.define
 class LoggerConfiguration:
     """Configuration options for a given logger."""
@@ -65,6 +82,7 @@ class LoggingConfigBuilder:
     """Helper class for converting the user's config into the logging config."""
 
     def __init__(self):
+        self.filters = {}
         self.formatters = {}
         self.handlers = {}
         self.loggers = {}
@@ -103,6 +121,7 @@ class LoggingConfigBuilder:
             "class": "logging.FileHandler",
             "level": "DEBUG",  # this way we can handle logs from loggers at any level
             "formatter": formatter,
+            "filters": list(self.filters.keys()),
             "filename": filepath,
         }
 
@@ -126,6 +145,7 @@ class LoggingConfigBuilder:
             "class": "logging.StreamHandler",
             "level": "DEBUG",  # this way we can handle logs from loggers at any level
             "formatter": formatter,
+            "filters": list(self.filters.keys()),
             "stream": "ext://sys.stderr",
         }
 
@@ -153,6 +173,7 @@ class LoggingConfigBuilder:
             "()": handler_class,
             "level": "DEBUG",  # this way we can handle logs from loggers at any level
             "formatter": formatter,
+            "filters": list(self.filters.keys()),
             "server": server,
         }
 
@@ -207,6 +228,13 @@ class LoggingConfigBuilder:
 
         self.loggers[name] = dict(level=level, propagate=False, handlers=handlers)
 
+    def create_lsp_filter(self, server: server.EsbonioLanguageServer):
+        """Create the filter instance that adds lsp message info to the log."""
+        self.filters["lsp-filter"] = {
+            "()": LSPInfoFilter,
+            "server": server,
+        }
+
     def finish(self) -> dict[str, Any]:
         """Return the final configuration."""
         return dict(
@@ -215,6 +243,7 @@ class LoggingConfigBuilder:
             formatters=self.formatters,
             handlers=self.handlers,
             loggers=self.loggers,
+            filters=self.filters,
         )
 
 
@@ -225,7 +254,7 @@ class LoggingConfig:
     level: str = attrs.field(default="info")
     """The default logging level."""
 
-    format: str = attrs.field(default="[%(name)s] %(message)s")
+    format: str = attrs.field(default="[%(method)s(%(msgid)s)][%(name)s] %(message)s")
     """The log format string to use."""
 
     filepath: str | None = attrs.field(default=None)
@@ -254,6 +283,7 @@ class LoggingConfig:
         """
 
         builder = LoggingConfigBuilder()
+        builder.create_lsp_filter(server)
 
         # Ensure that there is at least an esbonio logger and a sphinx logger present in
         # the config.

--- a/lib/esbonio/esbonio/server/server.py
+++ b/lib/esbonio/esbonio/server/server.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import collections
+import contextvars
 import inspect
 import logging
 import platform
@@ -15,6 +16,7 @@ import cattrs
 from lsprotocol import types
 from pygls.capabilities import get_capability
 from pygls.lsp.server import LanguageServer
+from pygls.protocol import LanguageServerProtocol
 from pygls.workspace import TextDocument
 from pygls.workspace import Workspace
 
@@ -59,10 +61,43 @@ class EsbonioWorkspace(Workspace):
         return super().update_text_document(text_doc, change)
 
 
+class LSProtocol(LanguageServerProtocol):
+    """A slightly modified ``LanguageServerProtocol`` implementation for use with esbonio."""
+
+    def __init__(self, server: LanguageServer, converter: cattrs.Converter):
+        self._ctx_msg_method: contextvars.ContextVar[str | None] = (
+            contextvars.ContextVar("msg_method", default=None)
+        )
+
+        # Needs to come last as parent constructor calls _register_builtin_features which
+        # walks all the properties of the class
+        super().__init__(server, converter)
+
+    @property
+    def msg_method(self) -> str | None:
+        ctx = contextvars.copy_context()
+        return ctx.get(self._ctx_msg_method)
+
+    def _handle_request(self, msg_id: str | int, method_name: str, params: Any):
+        _ = self._ctx_msg_method.set(method_name)
+        return super()._handle_request(msg_id, method_name, params)
+
+    def _handle_notification(self, method_name: str, params: Any):
+        _ = self._ctx_msg_method.set(method_name)
+        return super()._handle_notification(method_name, params)
+
+
 class EsbonioLanguageServer(LanguageServer):
     """The Esbonio language server"""
 
-    def __init__(self, logger: logging.Logger | None = None, *args, **kwargs):
+    protocol: LSProtocol
+
+    def __init__(
+        self,
+        logger: logging.Logger | None = None,
+        *args,
+        **kwargs,
+    ):
         if "name" not in kwargs:
             kwargs["name"] = "esbonio"
 
@@ -83,7 +118,7 @@ class EsbonioLanguageServer(LanguageServer):
         self._ready: Future[bool] = Future()
         """Indicates if the server is ready."""
 
-        self._tasks: set[asyncio.Task] = set()
+        self._tasks: set[asyncio.Task[Any]] = set()
         """Used to hold running tasks"""
 
         self.logger = logger or logging.getLogger(__name__)

--- a/lib/esbonio/tests/server/features/test_logging.py
+++ b/lib/esbonio/tests/server/features/test_logging.py
@@ -1,12 +1,17 @@
 from __future__ import annotations
 
+import typing
+
 import pytest
+from lsprotocol import types
 
 from esbonio import server
 from esbonio.server.features.log import LoggerConfiguration
 from esbonio.server.features.log import LoggingConfig
+from esbonio.server.features.log import LSPInfoFilter
 
-SERVER = server.EsbonioLanguageServer
+if typing.TYPE_CHECKING:
+    from typing import Any
 
 
 @pytest.mark.parametrize(
@@ -17,8 +22,20 @@ SERVER = server.EsbonioLanguageServer
             dict(
                 version=1,
                 disable_existing_loggers=True,
+                filters={
+                    "lsp-filter": {
+                        "()": LSPInfoFilter,
+                        "server": server.EsbonioLanguageServer,
+                        "enabled_methods": [
+                            types.INITIALIZE,
+                            types.INITIALIZED,
+                            types.TEXT_DOCUMENT_DID_OPEN,
+                            types.WORKSPACE_DID_CHANGE_CONFIGURATION,
+                        ],
+                    }
+                },
                 formatters=dict(
-                    fmt01=dict(format="[%(name)s] %(message)s"),
+                    fmt01=dict(format="[%(method)s(%(msgid)s)][%(name)s] %(message)s"),
                     fmt02=dict(format="%(message)s"),
                 ),
                 handlers=dict(
@@ -26,12 +43,18 @@ SERVER = server.EsbonioLanguageServer
                         "class": "logging.StreamHandler",
                         "level": "DEBUG",
                         "formatter": "fmt01",
+                        "filters": [
+                            "lsp-filter",
+                        ],
                         "stream": "ext://sys.stderr",
                     },
                     stderr02={
                         "class": "logging.StreamHandler",
                         "level": "DEBUG",
                         "formatter": "fmt02",
+                        "filters": [
+                            "lsp-filter",
+                        ],
                         "stream": "ext://sys.stderr",
                     },
                 ),
@@ -54,8 +77,20 @@ SERVER = server.EsbonioLanguageServer
             dict(
                 version=1,
                 disable_existing_loggers=True,
+                filters={
+                    "lsp-filter": {
+                        "()": LSPInfoFilter,
+                        "server": server.EsbonioLanguageServer,
+                        "enabled_methods": [
+                            types.INITIALIZE,
+                            types.INITIALIZED,
+                            types.TEXT_DOCUMENT_DID_OPEN,
+                            types.WORKSPACE_DID_CHANGE_CONFIGURATION,
+                        ],
+                    }
+                },
                 formatters=dict(
-                    fmt01=dict(format="[%(name)s] %(message)s"),
+                    fmt01=dict(format="[%(method)s(%(msgid)s)][%(name)s] %(message)s"),
                     fmt02=dict(format="%(message)s"),
                 ),
                 handlers=dict(
@@ -63,12 +98,18 @@ SERVER = server.EsbonioLanguageServer
                         "class": "logging.StreamHandler",
                         "level": "DEBUG",
                         "formatter": "fmt01",
+                        "filters": [
+                            "lsp-filter",
+                        ],
                         "stream": "ext://sys.stderr",
                     },
                     stderr02={
                         "class": "logging.StreamHandler",
                         "level": "DEBUG",
                         "formatter": "fmt02",
+                        "filters": [
+                            "lsp-filter",
+                        ],
                         "stream": "ext://sys.stderr",
                     },
                 ),
@@ -91,6 +132,18 @@ SERVER = server.EsbonioLanguageServer
             dict(
                 version=1,
                 disable_existing_loggers=True,
+                filters={
+                    "lsp-filter": {
+                        "()": LSPInfoFilter,
+                        "server": server.EsbonioLanguageServer,
+                        "enabled_methods": [
+                            types.INITIALIZE,
+                            types.INITIALIZED,
+                            types.TEXT_DOCUMENT_DID_OPEN,
+                            types.WORKSPACE_DID_CHANGE_CONFIGURATION,
+                        ],
+                    }
+                },
                 formatters=dict(
                     fmt01=dict(format="%(message)s"),
                 ),
@@ -99,6 +152,9 @@ SERVER = server.EsbonioLanguageServer
                         "class": "logging.StreamHandler",
                         "level": "DEBUG",
                         "formatter": "fmt01",
+                        "filters": [
+                            "lsp-filter",
+                        ],
                         "stream": "ext://sys.stderr",
                     },
                 ),
@@ -121,8 +177,20 @@ SERVER = server.EsbonioLanguageServer
             dict(
                 version=1,
                 disable_existing_loggers=True,
+                filters={
+                    "lsp-filter": {
+                        "()": LSPInfoFilter,
+                        "server": server.EsbonioLanguageServer,
+                        "enabled_methods": [
+                            types.INITIALIZE,
+                            types.INITIALIZED,
+                            types.TEXT_DOCUMENT_DID_OPEN,
+                            types.WORKSPACE_DID_CHANGE_CONFIGURATION,
+                        ],
+                    }
+                },
                 formatters=dict(
-                    fmt01=dict(format="[%(name)s] %(message)s"),
+                    fmt01=dict(format="[%(method)s(%(msgid)s)][%(name)s] %(message)s"),
                     fmt02=dict(format="%(message)s"),
                 ),
                 handlers=dict(
@@ -130,13 +198,19 @@ SERVER = server.EsbonioLanguageServer
                         "()": "esbonio.server.features.log.WindowLogMessageHandler",
                         "level": "DEBUG",
                         "formatter": "fmt01",
-                        "server": SERVER,
+                        "filters": [
+                            "lsp-filter",
+                        ],
+                        "server": server.EsbonioLanguageServer,
                     },
                     window02={
                         "()": "esbonio.server.features.log.WindowLogMessageHandler",
                         "level": "DEBUG",
                         "formatter": "fmt02",
-                        "server": SERVER,
+                        "filters": [
+                            "lsp-filter",
+                        ],
+                        "server": server.EsbonioLanguageServer,
                     },
                 ),
                 loggers=dict(
@@ -158,8 +232,20 @@ SERVER = server.EsbonioLanguageServer
             dict(
                 version=1,
                 disable_existing_loggers=True,
+                filters={
+                    "lsp-filter": {
+                        "()": LSPInfoFilter,
+                        "server": server.EsbonioLanguageServer,
+                        "enabled_methods": [
+                            types.INITIALIZE,
+                            types.INITIALIZED,
+                            types.TEXT_DOCUMENT_DID_OPEN,
+                            types.WORKSPACE_DID_CHANGE_CONFIGURATION,
+                        ],
+                    }
+                },
                 formatters=dict(
-                    fmt01=dict(format="[%(name)s] %(message)s"),
+                    fmt01=dict(format="[%(method)s(%(msgid)s)][%(name)s] %(message)s"),
                     fmt02=dict(format="%(message)s"),
                 ),
                 handlers=dict(
@@ -167,12 +253,18 @@ SERVER = server.EsbonioLanguageServer
                         "class": "logging.FileHandler",
                         "level": "DEBUG",
                         "formatter": "fmt01",
+                        "filters": [
+                            "lsp-filter",
+                        ],
                         "filename": "esbonio.log",
                     },
                     file02={
                         "class": "logging.FileHandler",
                         "level": "DEBUG",
                         "formatter": "fmt02",
+                        "filters": [
+                            "lsp-filter",
+                        ],
                         "filename": "esbonio.log",
                     },
                 ),
@@ -195,8 +287,20 @@ SERVER = server.EsbonioLanguageServer
             dict(
                 version=1,
                 disable_existing_loggers=True,
+                filters={
+                    "lsp-filter": {
+                        "()": LSPInfoFilter,
+                        "server": server.EsbonioLanguageServer,
+                        "enabled_methods": [
+                            types.INITIALIZE,
+                            types.INITIALIZED,
+                            types.TEXT_DOCUMENT_DID_OPEN,
+                            types.WORKSPACE_DID_CHANGE_CONFIGURATION,
+                        ],
+                    }
+                },
                 formatters=dict(
-                    fmt01=dict(format="[%(name)s] %(message)s"),
+                    fmt01=dict(format="[%(method)s(%(msgid)s)][%(name)s] %(message)s"),
                     fmt02=dict(format="%(message)s"),
                 ),
                 handlers=dict(
@@ -204,37 +308,55 @@ SERVER = server.EsbonioLanguageServer
                         "class": "logging.FileHandler",
                         "level": "DEBUG",
                         "formatter": "fmt01",
+                        "filters": [
+                            "lsp-filter",
+                        ],
                         "filename": "esbonio.log",
                     },
                     stderr02={
                         "class": "logging.StreamHandler",
                         "level": "DEBUG",
                         "formatter": "fmt01",
+                        "filters": [
+                            "lsp-filter",
+                        ],
                         "stream": "ext://sys.stderr",
                     },
                     window03={
                         "()": "esbonio.server.features.log.WindowLogMessageHandler",
                         "level": "DEBUG",
                         "formatter": "fmt01",
-                        "server": SERVER,
+                        "filters": [
+                            "lsp-filter",
+                        ],
+                        "server": server.EsbonioLanguageServer,
                     },
                     file04={
                         "class": "logging.FileHandler",
                         "level": "DEBUG",
                         "formatter": "fmt02",
+                        "filters": [
+                            "lsp-filter",
+                        ],
                         "filename": "esbonio.log",
                     },
                     stderr05={
                         "class": "logging.StreamHandler",
                         "level": "DEBUG",
                         "formatter": "fmt02",
+                        "filters": [
+                            "lsp-filter",
+                        ],
                         "stream": "ext://sys.stderr",
                     },
                     window06={
                         "()": "esbonio.server.features.log.WindowLogMessageHandler",
                         "level": "DEBUG",
                         "formatter": "fmt02",
-                        "server": SERVER,
+                        "filters": [
+                            "lsp-filter",
+                        ],
+                        "server": server.EsbonioLanguageServer,
                     },
                 ),
                 loggers=dict(
@@ -258,8 +380,20 @@ SERVER = server.EsbonioLanguageServer
             dict(
                 version=1,
                 disable_existing_loggers=True,
+                filters={
+                    "lsp-filter": {
+                        "()": LSPInfoFilter,
+                        "server": server.EsbonioLanguageServer,
+                        "enabled_methods": [
+                            types.INITIALIZE,
+                            types.INITIALIZED,
+                            types.TEXT_DOCUMENT_DID_OPEN,
+                            types.WORKSPACE_DID_CHANGE_CONFIGURATION,
+                        ],
+                    }
+                },
                 formatters=dict(
-                    fmt01=dict(format="[%(name)s] %(message)s"),
+                    fmt01=dict(format="[%(method)s(%(msgid)s)][%(name)s] %(message)s"),
                     fmt02=dict(format="%(message)s"),
                 ),
                 handlers=dict(
@@ -267,12 +401,18 @@ SERVER = server.EsbonioLanguageServer
                         "class": "logging.StreamHandler",
                         "level": "DEBUG",
                         "formatter": "fmt01",
+                        "filters": [
+                            "lsp-filter",
+                        ],
                         "stream": "ext://sys.stderr",
                     },
                     stderr02={
                         "class": "logging.StreamHandler",
                         "level": "DEBUG",
                         "formatter": "fmt02",
+                        "filters": [
+                            "lsp-filter",
+                        ],
                         "stream": "ext://sys.stderr",
                     },
                 ),
@@ -295,11 +435,66 @@ SERVER = server.EsbonioLanguageServer
                 },
             ),
         ),
+        (  # The user should be able to customize the lsp methods that are logged
+            LoggingConfig(
+                level="debug",
+                enabled_methods=[types.TEXT_DOCUMENT_DOCUMENT_LINK],
+            ),
+            dict(
+                version=1,
+                disable_existing_loggers=True,
+                filters={
+                    "lsp-filter": {
+                        "()": LSPInfoFilter,
+                        "server": server.EsbonioLanguageServer,
+                        "enabled_methods": [
+                            types.TEXT_DOCUMENT_DOCUMENT_LINK,
+                        ],
+                    }
+                },
+                formatters=dict(
+                    fmt01=dict(format="[%(method)s(%(msgid)s)][%(name)s] %(message)s"),
+                    fmt02=dict(format="%(message)s"),
+                ),
+                handlers=dict(
+                    stderr01={
+                        "class": "logging.StreamHandler",
+                        "level": "DEBUG",
+                        "formatter": "fmt01",
+                        "filters": [
+                            "lsp-filter",
+                        ],
+                        "stream": "ext://sys.stderr",
+                    },
+                    stderr02={
+                        "class": "logging.StreamHandler",
+                        "level": "DEBUG",
+                        "formatter": "fmt02",
+                        "filters": [
+                            "lsp-filter",
+                        ],
+                        "stream": "ext://sys.stderr",
+                    },
+                ),
+                loggers={
+                    "esbonio": dict(
+                        level="DEBUG",
+                        propagate=False,
+                        handlers=["stderr01"],
+                    ),
+                    "sphinx": dict(
+                        level="INFO",
+                        propagate=False,
+                        handlers=["stderr02"],
+                    ),
+                },
+            ),
+        ),
     ],
 )
-def test_logging_config(config: LoggingConfig, expected: dict):
+def test_logging_config(config: LoggingConfig, expected: dict[str, Any]):
     """Ensure that we can convert the user's config into the config we can pass to the
     ``logging.config`` module correctly."""
 
     # SERVER in this case is a class, at runtime this will be an actual instance.
-    assert config.to_logging_config(SERVER) == expected
+    assert config.to_logging_config(server.EsbonioLanguageServer) == expected


### PR DESCRIPTION
Unless you are familiar with esbonio's internals, interpreting the server's debug log output can be quite challenging. This PR is the first step in an attempt to make the messages easier to follow.

Currently logs look something like this
```
[esbonio.Configuration] ConfigurationContext(file_scope='', workspace_scope='')
[esbonio.Configuration] esbonio.server.completion: {
"preferredInsertBehavior": "replace"
}
[esbonio.Configuration] CompletionConfig(preferred_insert_behavior='replace')
[esbonio.Configuration] Previous: None
[esbonio.Configuration] Current: CompletionConfig(preferred_insert_behavior='replace')
[esbonio.Configuration] ConfigChangeEvent(scope='', value=CompletionConfig(preferred_insert_behavior='replace'), previous=None)
[esbonio] Task finished: <Task finished name='Task-23' coro=<PreviewManager.show_preview_uri() done, defined at /workspaces/develop/.vscode/extensions/esbonio/bundled/libs/esbonio/server/features/preview_manager/__init__.py:187> result=None>
[esbonio.ProjectManager] No applicable project for uri: file:///workspaces/develop/docs/usage/howto/migrate-to-v2.rst
Running Sphinx v9.1.0
loading translations [en]... done
The configuration has changed (2 options: 'html_static_path', 'pygments_dark_style')
loading pickled environment... done
myst v5.0.0: MdParserConfig(commonmark_only=False, gfm_only=False, enable_extensions=set(), disable_syntax=[], all_links_external=False, links_external_new_tab=False, url_schemes=('http', 'https', 'mailto', 'ftp'), ref_domains=None, fence_as_directive=set(), number_code_blocks=[], title_to_header=False, heading_anchors=0, heading_slug_func=None, html_meta={}, footnote_sort=True, footnote_transition=True, words_per_minute=200, substitutions={}, linkify_fuzzy_links=True, dmath_allow_labels=True, dmath_allow_space=True, dmath_allow_digits=True, dmath_double_inline=False, update_mathjax=True, mathjax_classes='tex2jax_process|mathjax_process|math|output_area', enable_checkboxes=False, suppress_warnings=[], highlight_code_blocks=True)
/workspaces/develop/.vscode/extensions/esbonio/bundled/libs/esbonio/sphinx_agent/handlers/domains.py:281: RemovedInSphinx10Warning: The iter() interface for _InventoryItem objects is deprecated. Please access the `project_name`, `project_version`, `uri`, and `displayname` attributes directly.
(name, version, _, _) = next(iter(next(iter(project.values())).values()))
/workspaces/develop/.vscode/extensions/esbonio/bundled/libs/esbonio/sphinx_agent/handlers/domains.py:303: RemovedInSphinx10Warning: The iter() interface for _InventoryItem objects is deprecated. Please access the `project_name`, `project_version`, `uri`, and `displayname` attributes directly.
for objname, (_, _, item_uri, display) in items.items():
[esbonio.SphinxManager] SphinxClient[0f684895-d015-46f9-ac3b-623c654a720b]: ClientState.Starting -> ClientState.Running
[esbonio.ProjectManager] Registered project for scope 'file:///workspaces/develop/docs': '/home/vscode/.cache/esbonio/20e782cab5bb1a14bf2d7b72e76dae1a/dirhtml/esbonio.db'
[client] sphinx/appCreated: {
"version": "9.1.0",
"python": "3.14.3",
"conf_dir": "/workspaces/develop/docs",
"build_dir": "/home/vscode/.cache/esbonio/20e782cab5bb1a14bf2d7b72e76dae1a/dirhtml",
"builder_name": "dirhtml",
"src_dir": "/workspaces/develop/docs",
"dbpath": "/home/vscode/.cache/esbonio/20e782cab5bb1a14bf2d7b72e76dae1a/dirhtml/esbonio.db"
}
[esbonio] Task finished: <Task finished name='Task-17' coro=<SphinxManager._create_or_replace_client() done, defined at /workspaces/develop/.vscode/extensions/esbonio/bundled/libs/esbonio/server/features/sphinx_manager/manager.py:316> result=None>
[esbonio.PreviewManager] Previewing file: 'file:///workspaces/develop/docs/usage/reference/configuration.rst'
[esbonio] DocumentLinkContext<file:///workspaces/develop/docs/usage/reference/configuration.rst>
[esbonio.DirectiveFeature] Resolving argument link for directive: 'highlight' (sphinx.directives.code.Highlight)
[esbonio.DirectiveFeature] Resolving argument link for directive: 'code-block' (sphinx.directives.code.CodeBlock)
[esbonio.DirectiveFeature] Resolving argument link for directive: 'code-block' (sphinx.directives.code.CodeBlock)
[esbonio.DirectiveFeature] Resolving argument link for directive: 'code-block' (sphinx.directives.code.CodeBlock)
[esbonio.DirectiveFeature] Resolving argument link for directive: 'code-block' (sphinx.directives.code.CodeBlock)
[esbonio.DirectiveFeature] Resolving argument link for directive: 'code-block' (sphinx.directives.code.CodeBlock)
[esbonio.RolesFeature] Resolving target link for role: 'std:ref' (sphinx.roles.XRefRole)
[esbonio.ObjectsProvider] DocumentLinkContext<file:///workspaces/develop/docs/usage/reference/configuration.rst> lsp-configuration-completion ['std:label'] None
[esbonio.RolesFeature] Resolving target link for role: 'std:ref' (sphinx.roles.XRefRole)
[esbonio.ObjectsProvider] DocumentLinkContext<file:///workspaces/develop/docs/usage/reference/configuration.rst> lsp-configuration-developer ['std:label'] None
[esbonio.RolesFeature] Resolving target link for role: 'std:ref' (sphinx.roles.XRefRole)
[esbonio.ObjectsProvider] DocumentLinkContext<file:///workspaces/develop/docs/usage/reference/configuration.rst> lsp-configuration-logging ['std:label'] None
[esbonio.RolesFeature] Resolving target link for role: 'std:ref' (sphinx.roles.XRefRole)
[esbonio.ObjectsProvider] DocumentLinkContext<file:///workspaces/develop/docs/usage/reference/configuration.rst> lsp-configuration-sphinx ['std:label'] None
[esbonio.RolesFeature] Resolving target link for role: 'std:ref' (sphinx.roles.XRefRole)
[esbonio.ObjectsProvider] DocumentLinkContext<file:///workspaces/develop/docs/usage/reference/configuration.rst> lsp-configuration-preview ['std:label'] None
[esbonio.RolesFeature] Unknown role 'external:ref'
[esbonio.RolesFeature] Unknown role 'external:ref'
[esbonio.RolesFeature] Resolving target link for role: 'esbonio:conf' (sphinx.roles.XRefRole)
[esbonio.ObjectsProvider] DocumentLinkContext<file:///workspaces/develop/docs/usage/reference/configuration.rst> esbonio.logging.level ['esbonio:config'] None
[esbonio.RolesFeature] Resolving target link for role: 'esbonio:conf' (sphinx.roles.XRefRole)
[esbonio.ObjectsProvider] DocumentLinkContext<file:///workspaces/develop/docs/usage/reference/configuration.rst> esbonio.logging.format ['esbonio:config'] None
[esbonio.RolesFeature] Resolving target link for role: 'esbonio:conf' (sphinx.roles.XRefRole)
[esbonio.ObjectsProvider] DocumentLinkContext<file:///workspaces/develop/docs/usage/reference/configuration.rst> esbonio.logging.filepath ['esbonio:config'] None
[esbonio.RolesFeature] Resolving target link for role: 'esbonio:conf' (sphinx.roles.XRefRole)
[esbonio.ObjectsProvider] DocumentLinkContext<file:///workspaces/develop/docs/usage/reference/configuration.rst> esbonio.logging.stderr ['esbonio:config'] None
[esbonio.RolesFeature] Resolving target link for role: 'esbonio:conf' (sphinx.roles.XRefRole)
[esbonio.ObjectsProvider] DocumentLinkContext<file:///workspaces/develop/docs/usage/reference/configuration.rst> esbonio.logging.window ['esbonio:config'] None
[esbonio.RolesFeature] Resolving target link for role: 'std:ref' (sphinx.roles.XRefRole)
[esbonio.ObjectsProvider] DocumentLinkContext<file:///workspaces/develop/docs/usage/reference/configuration.rst> lsp-configure-sphinx-build-cmd ['std:label'] None
[esbonio.RolesFeature] Resolving target link for role: 'esbonio:conf' (sphinx.roles.XRefRole)
[esbonio.ObjectsProvider] DocumentLinkContext<file:///workspaces/develop/docs/usage/reference/configuration.rst> esbonio.sphinx.buildArguments ['esbonio:config'] None
[esbonio.RolesFeature] Resolving target link for role: 'std:option' (sphinx.domains.std.OptionXRefRole)
[esbonio.ObjectsProvider] DocumentLinkContext<file:///workspaces/develop/docs/usage/reference/configuration.rst> sphinx:sphinx-build.-D ['std:cmdoption'] None
[esbonio.RolesFeature] Resolving target link for role: 'std:option' (sphinx.domains.std.OptionXRefRole)
[esbonio.ObjectsProvider] DocumentLinkContext<file:///workspaces/develop/docs/usage/reference/configuration.rst> sphinx:sphinx-build.-A ['std:cmdoption'] None
[esbonio.RolesFeature] Resolving target link for role: 'std:ref' (sphinx.roles.XRefRole)
[esbonio.ObjectsProvider] DocumentLinkContext<file:///workspaces/develop/docs/usage/reference/configuration.rst> lsp-configure-sphinx-build-cmd ['std:label'] None
[esbonio.RolesFeature] Resolving target link for role: 'std:ref' (sphinx.roles.XRefRole)
[esbonio.ObjectsProvider] DocumentLinkContext<file:///workspaces/develop/docs/usage/reference/configuration.rst> lsp-configure-sphinx-build-env ['std:label'] None
[esbonio.PreviewManager] Preview available at: http://localhost:40535/usage/reference/configuration/?ws=ws%3A%2F%2Flocalhost%3A43647
[esbonio.PreviewManager] window/showDocument: ShowDocumentResult(success=True)
```
Configuration, server/sphinx setup, previews and regular LSP traffic are all intermixed, so unless you already know how the server works, it's hard to tell which messages to pay attention to.

This PR adjusts it so that log messages are tagged with the LSP message they are associated with
```
[initialized()][esbonio.Configuration] ConfigurationContext(file_scope='', workspace_scope='')
[initialized()][esbonio.Configuration] esbonio.server.completion: {
"preferredInsertBehavior": "replace"
}
[initialized()][esbonio.Configuration] CompletionConfig(preferred_insert_behavior='replace')
[initialized()][esbonio.Configuration] Previous: None
[initialized()][esbonio.Configuration] Current: CompletionConfig(preferred_insert_behavior='replace')
[initialized()][esbonio.Configuration] ConfigChangeEvent(scope='', value=CompletionConfig(preferred_insert_behavior='replace'), previous=None)
[initialized()][esbonio] Task finished: <Task finished name='Task-23' coro=<PreviewManager.show_preview_uri() done, defined at /workspaces/develop/.vscode/extensions/esbonio/bundled/libs/esbonio/server/features/preview_manager/__init__.py:187> result=None>
[textDocument/documentSymbol(8)][esbonio.ProjectManager] No applicable project for uri: file:///workspaces/develop/docs/usage/howto/migrate-to-v2.rst
Running Sphinx v9.1.0
loading translations [en]... done
The configuration has changed (2 options: 'html_static_path', 'pygments_dark_style')
loading pickled environment... done
myst v5.0.0: MdParserConfig(commonmark_only=False, gfm_only=False, enable_extensions=set(), disable_syntax=[], all_links_external=False, links_external_new_tab=False, url_schemes=('http', 'https', 'mailto', 'ftp'), ref_domains=None, fence_as_directive=set(), number_code_blocks=[], title_to_header=False, heading_anchors=0, heading_slug_func=None, html_meta={}, footnote_sort=True, footnote_transition=True, words_per_minute=200, substitutions={}, linkify_fuzzy_links=True, dmath_allow_labels=True, dmath_allow_space=True, dmath_allow_digits=True, dmath_double_inline=False, update_mathjax=True, mathjax_classes='tex2jax_process|mathjax_process|math|output_area', enable_checkboxes=False, suppress_warnings=[], highlight_code_blocks=True)
/workspaces/develop/.vscode/extensions/esbonio/bundled/libs/esbonio/sphinx_agent/handlers/domains.py:281: RemovedInSphinx10Warning: The iter() interface for _InventoryItem objects is deprecated. Please access the `project_name`, `project_version`, `uri`, and `displayname` attributes directly.
(name, version, _, _) = next(iter(next(iter(project.values())).values()))
/workspaces/develop/.vscode/extensions/esbonio/bundled/libs/esbonio/sphinx_agent/handlers/domains.py:303: RemovedInSphinx10Warning: The iter() interface for _InventoryItem objects is deprecated. Please access the `project_name`, `project_version`, `uri`, and `displayname` attributes directly.
for objname, (_, _, item_uri, display) in items.items():
[initialized()][esbonio.SphinxManager] SphinxClient[0f684895-d015-46f9-ac3b-623c654a720b]: ClientState.Starting -> ClientState.Running
[initialized()][esbonio.ProjectManager] Registered project for scope 'file:///workspaces/develop/docs': '/home/vscode/.cache/esbonio/20e782cab5bb1a14bf2d7b72e76dae1a/dirhtml/esbonio.db'
[client] sphinx/appCreated: {
"version": "9.1.0",
"python": "3.14.3",
"conf_dir": "/workspaces/develop/docs",
"build_dir": "/home/vscode/.cache/esbonio/20e782cab5bb1a14bf2d7b72e76dae1a/dirhtml",
"builder_name": "dirhtml",
"src_dir": "/workspaces/develop/docs",
"dbpath": "/home/vscode/.cache/esbonio/20e782cab5bb1a14bf2d7b72e76dae1a/dirhtml/esbonio.db"
}
[initialized()][esbonio] Task finished: <Task finished name='Task-17' coro=<SphinxManager._create_or_replace_client() done, defined at /workspaces/develop/.vscode/extensions/esbonio/bundled/libs/esbonio/server/features/sphinx_manager/manager.py:316> result=None>
[workspace/executeCommand(21)][esbonio.PreviewManager] Previewing file: 'file:///workspaces/develop/docs/usage/reference/configuration.rst'
[textDocument/documentLink(23)][esbonio] DocumentLinkContext<file:///workspaces/develop/docs/usage/reference/configuration.rst>
[textDocument/documentLink(23)][esbonio.DirectiveFeature] Resolving argument link for directive: 'highlight' (sphinx.directives.code.Highlight)
[textDocument/documentLink(23)][esbonio.DirectiveFeature] Resolving argument link for directive: 'code-block' (sphinx.directives.code.CodeBlock)
[textDocument/documentLink(23)][esbonio.DirectiveFeature] Resolving argument link for directive: 'code-block' (sphinx.directives.code.CodeBlock)
[textDocument/documentLink(23)][esbonio.DirectiveFeature] Resolving argument link for directive: 'code-block' (sphinx.directives.code.CodeBlock)
[textDocument/documentLink(23)][esbonio.DirectiveFeature] Resolving argument link for directive: 'code-block' (sphinx.directives.code.CodeBlock)
[textDocument/documentLink(23)][esbonio.DirectiveFeature] Resolving argument link for directive: 'code-block' (sphinx.directives.code.CodeBlock)
[textDocument/documentLink(23)][esbonio.RolesFeature] Resolving target link for role: 'std:ref' (sphinx.roles.XRefRole)
[textDocument/documentLink(23)][esbonio.ObjectsProvider] DocumentLinkContext<file:///workspaces/develop/docs/usage/reference/configuration.rst> lsp-configuration-completion ['std:label'] None
[textDocument/documentLink(23)][esbonio.RolesFeature] Resolving target link for role: 'std:ref' (sphinx.roles.XRefRole)
[textDocument/documentLink(23)][esbonio.ObjectsProvider] DocumentLinkContext<file:///workspaces/develop/docs/usage/reference/configuration.rst> lsp-configuration-developer ['std:label'] None
[textDocument/documentLink(23)][esbonio.RolesFeature] Resolving target link for role: 'std:ref' (sphinx.roles.XRefRole)
[textDocument/documentLink(23)][esbonio.ObjectsProvider] DocumentLinkContext<file:///workspaces/develop/docs/usage/reference/configuration.rst> lsp-configuration-logging ['std:label'] None
[textDocument/documentLink(23)][esbonio.RolesFeature] Resolving target link for role: 'std:ref' (sphinx.roles.XRefRole)
[textDocument/documentLink(23)][esbonio.ObjectsProvider] DocumentLinkContext<file:///workspaces/develop/docs/usage/reference/configuration.rst> lsp-configuration-sphinx ['std:label'] None
[textDocument/documentLink(23)][esbonio.RolesFeature] Resolving target link for role: 'std:ref' (sphinx.roles.XRefRole)
[textDocument/documentLink(23)][esbonio.ObjectsProvider] DocumentLinkContext<file:///workspaces/develop/docs/usage/reference/configuration.rst> lsp-configuration-preview ['std:label'] None
[textDocument/documentLink(23)][esbonio.RolesFeature] Unknown role 'external:ref'
[textDocument/documentLink(23)][esbonio.RolesFeature] Unknown role 'external:ref'
[textDocument/documentLink(23)][esbonio.RolesFeature] Resolving target link for role: 'esbonio:conf' (sphinx.roles.XRefRole)
[textDocument/documentLink(23)][esbonio.ObjectsProvider] DocumentLinkContext<file:///workspaces/develop/docs/usage/reference/configuration.rst> esbonio.logging.level ['esbonio:config'] None
[textDocument/documentLink(23)][esbonio.RolesFeature] Resolving target link for role: 'esbonio:conf' (sphinx.roles.XRefRole)
[textDocument/documentLink(23)][esbonio.ObjectsProvider] DocumentLinkContext<file:///workspaces/develop/docs/usage/reference/configuration.rst> esbonio.logging.format ['esbonio:config'] None
[textDocument/documentLink(23)][esbonio.RolesFeature] Resolving target link for role: 'esbonio:conf' (sphinx.roles.XRefRole)
[textDocument/documentLink(23)][esbonio.ObjectsProvider] DocumentLinkContext<file:///workspaces/develop/docs/usage/reference/configuration.rst> esbonio.logging.filepath ['esbonio:config'] None
[textDocument/documentLink(23)][esbonio.RolesFeature] Resolving target link for role: 'esbonio:conf' (sphinx.roles.XRefRole)
[textDocument/documentLink(23)][esbonio.ObjectsProvider] DocumentLinkContext<file:///workspaces/develop/docs/usage/reference/configuration.rst> esbonio.logging.stderr ['esbonio:config'] None
[textDocument/documentLink(23)][esbonio.RolesFeature] Resolving target link for role: 'esbonio:conf' (sphinx.roles.XRefRole)
[textDocument/documentLink(23)][esbonio.ObjectsProvider] DocumentLinkContext<file:///workspaces/develop/docs/usage/reference/configuration.rst> esbonio.logging.window ['esbonio:config'] None
[textDocument/documentLink(23)][esbonio.RolesFeature] Resolving target link for role: 'std:ref' (sphinx.roles.XRefRole)
[textDocument/documentLink(23)][esbonio.ObjectsProvider] DocumentLinkContext<file:///workspaces/develop/docs/usage/reference/configuration.rst> lsp-configure-sphinx-build-cmd ['std:label'] None
[textDocument/documentLink(23)][esbonio.RolesFeature] Resolving target link for role: 'esbonio:conf' (sphinx.roles.XRefRole)
[textDocument/documentLink(23)][esbonio.ObjectsProvider] DocumentLinkContext<file:///workspaces/develop/docs/usage/reference/configuration.rst> esbonio.sphinx.buildArguments ['esbonio:config'] None
[textDocument/documentLink(23)][esbonio.RolesFeature] Resolving target link for role: 'std:option' (sphinx.domains.std.OptionXRefRole)
[textDocument/documentLink(23)][esbonio.ObjectsProvider] DocumentLinkContext<file:///workspaces/develop/docs/usage/reference/configuration.rst> sphinx:sphinx-build.-D ['std:cmdoption'] None
[textDocument/documentLink(23)][esbonio.RolesFeature] Resolving target link for role: 'std:option' (sphinx.domains.std.OptionXRefRole)
[textDocument/documentLink(23)][esbonio.ObjectsProvider] DocumentLinkContext<file:///workspaces/develop/docs/usage/reference/configuration.rst> sphinx:sphinx-build.-A ['std:cmdoption'] None
[textDocument/documentLink(23)][esbonio.RolesFeature] Resolving target link for role: 'std:ref' (sphinx.roles.XRefRole)
[textDocument/documentLink(23)][esbonio.ObjectsProvider] DocumentLinkContext<file:///workspaces/develop/docs/usage/reference/configuration.rst> lsp-configure-sphinx-build-cmd ['std:label'] None
[textDocument/documentLink(23)][esbonio.RolesFeature] Resolving target link for role: 'std:ref' (sphinx.roles.XRefRole)
[textDocument/documentLink(23)][esbonio.ObjectsProvider] DocumentLinkContext<file:///workspaces/develop/docs/usage/reference/configuration.rst> lsp-configure-sphinx-build-env ['std:label'] None
[workspace/executeCommand(21)][esbonio.PreviewManager] Preview available at: http://localhost:40535/usage/reference/configuration/?ws=ws%3A%2F%2Flocalhost%3A43647
[workspace/executeCommand(21)][esbonio.PreviewManager] window/showDocument: ShowDocumentResult(success=True)
```
It does require the reader to have some familiarity with the LSP protocol, but hopefully it helps categorise the messages.

However, seeing as most of the reported issues are related to Sphinx configs and environments, the server by default will filter out the majority of LSP messages and only include those likely to influence the Sphinx config.
```
[initialized()][esbonio.Configuration] ConfigurationContext(file_scope='', workspace_scope='')
[initialized()][esbonio.Configuration] esbonio.server.completion: {
"preferredInsertBehavior": "replace"
}
[initialized()][esbonio.Configuration] CompletionConfig(preferred_insert_behavior='replace')
[initialized()][esbonio.Configuration] Previous: None
[initialized()][esbonio.Configuration] Current: CompletionConfig(preferred_insert_behavior='replace')
[initialized()][esbonio.Configuration] ConfigChangeEvent(scope='', value=CompletionConfig(preferred_insert_behavior='replace'), previous=None)
[initialized()][esbonio] Task finished: <Task finished name='Task-23' coro=<PreviewManager.show_preview_uri() done, defined at /workspaces/develop/.vscode/extensions/esbonio/bundled/libs/esbonio/server/features/preview_manager/__init__.py:187> result=None>
Running Sphinx v9.1.0
loading translations [en]... done
The configuration has changed (2 options: 'html_static_path', 'pygments_dark_style')
loading pickled environment... done
myst v5.0.0: MdParserConfig(commonmark_only=False, gfm_only=False, enable_extensions=set(), disable_syntax=[], all_links_external=False, links_external_new_tab=False, url_schemes=('http', 'https', 'mailto', 'ftp'), ref_domains=None, fence_as_directive=set(), number_code_blocks=[], title_to_header=False, heading_anchors=0, heading_slug_func=None, html_meta={}, footnote_sort=True, footnote_transition=True, words_per_minute=200, substitutions={}, linkify_fuzzy_links=True, dmath_allow_labels=True, dmath_allow_space=True, dmath_allow_digits=True, dmath_double_inline=False, update_mathjax=True, mathjax_classes='tex2jax_process|mathjax_process|math|output_area', enable_checkboxes=False, suppress_warnings=[], highlight_code_blocks=True)
/workspaces/develop/.vscode/extensions/esbonio/bundled/libs/esbonio/sphinx_agent/handlers/domains.py:281: RemovedInSphinx10Warning: The iter() interface for _InventoryItem objects is deprecated. Please access the `project_name`, `project_version`, `uri`, and `displayname` attributes directly.
(name, version, _, _) = next(iter(next(iter(project.values())).values()))
/workspaces/develop/.vscode/extensions/esbonio/bundled/libs/esbonio/sphinx_agent/handlers/domains.py:303: RemovedInSphinx10Warning: The iter() interface for _InventoryItem objects is deprecated. Please access the `project_name`, `project_version`, `uri`, and `displayname` attributes directly.
for objname, (_, _, item_uri, display) in items.items():
[initialized()][esbonio.SphinxManager] SphinxClient[0f684895-d015-46f9-ac3b-623c654a720b]: ClientState.Starting -> ClientState.Running
[initialized()][esbonio.ProjectManager] Registered project for scope 'file:///workspaces/develop/docs': '/home/vscode/.cache/esbonio/20e782cab5bb1a14bf2d7b72e76dae1a/dirhtml/esbonio.db'
[client] sphinx/appCreated: {
"version": "9.1.0",
"python": "3.14.3",
"conf_dir": "/workspaces/develop/docs",
"build_dir": "/home/vscode/.cache/esbonio/20e782cab5bb1a14bf2d7b72e76dae1a/dirhtml",
"builder_name": "dirhtml",
"src_dir": "/workspaces/develop/docs",
"dbpath": "/home/vscode/.cache/esbonio/20e782cab5bb1a14bf2d7b72e76dae1a/dirhtml/esbonio.db"
}
[initialized()][esbonio] Task finished: <Task finished name='Task-17' coro=<SphinxManager._create_or_replace_client() done, defined at /workspaces/develop/.vscode/extensions/esbonio/bundled/libs/esbonio/server/features/sphinx_manager/manager.py:316> result=None>
```
A new config option `esbonio.logging.enabledMethods` can be used to change the default list of methods