### PR TITLE
lsp: Introduce cli subcommands

### DIFF
--- a/docs/usage/howto/migrate-to-v2.rst
+++ b/docs/usage/howto/migrate-to-v2.rst
@@ -10,6 +10,31 @@ Sphinx v6 No Longer Supported
 
 Inline with the :ref:`about-versioning` policy, while Esbonio ``v2.x`` adds support for Sphinx v9, support for Sphinx v6 has been removed.
 
+Command Line Changes
+--------------------
+
+The langugage server is no longer launched using the ``esbonio`` command, instead it has been pushed down into the ``esbonio server`` subcommand::
+
+   $ esbonio
+   usage: esbonio [-h] [--version] {server} ...
+
+   The Esbonio language server
+
+   options:
+   -h, --help  show this help message and exit
+   --version   print the current version and exit.
+
+   commands:
+   {server}
+      server    launch the esbonio language server
+
+This is to create space for additional utility commands that may be added in future releases.
+Alternatively, the server can be launched by invokng the ``esbonio.server`` module directly with Python::
+
+   $ python -m esbonio.server
+
+Which is how the VSCode extension invokes the server.
+
 Configuration Changes
 ---------------------
 

--- a/lib/esbonio/changes/1098.breaking.md
+++ b/lib/esbonio/changes/1098.breaking.md
@@ -1,0 +1,1 @@
+The `esbonio` command no longer starts the server, instead the server is launched by running `esbonio server`, or by invoking the `python -m esbonio.server`

--- a/lib/esbonio/esbonio/__main__.py
+++ b/lib/esbonio/esbonio/__main__.py
@@ -1,8 +1,6 @@
-"""Default startup module, identical to calling ``python -m esbonio.server``"""
-
 import sys
 
-from esbonio.server.cli import main
+from esbonio.cli import main
 
 if __name__ == "__main__":
     sys.exit(main())

--- a/lib/esbonio/esbonio/cli/__init__.py
+++ b/lib/esbonio/esbonio/cli/__init__.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import argparse
+import importlib
+import logging
+import typing
+
+from esbonio.server import __version__
+
+if typing.TYPE_CHECKING:
+    from collections.abc import Sequence
+
+logger = logging.getLogger(__name__)
+
+BUILTIN_COMMANDS = [
+    "esbonio.cli.server",
+]
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Return an argument parser with the default command line options required for
+    main.
+    """
+
+    cli = argparse.ArgumentParser(description="The Esbonio language server")
+
+    _ = cli.add_argument(
+        "--version",
+        action="version",
+        version=__version__,
+        help="print the current version and exit.",
+    )
+
+    commands = cli.add_subparsers(title="commands")
+
+    for module in BUILTIN_COMMANDS:
+        load_command(commands, module)
+
+    return cli
+
+
+def load_command(commands: argparse._SubParsersAction, name: str):
+    """Load the cli command(s) exposed by the given module name"""
+    try:
+        mod = importlib.import_module(name)
+    except Exception:
+        logger.exception("Unable to load commands from module '%s'\n", name)
+        return
+
+    if not hasattr(mod, "setup_cli"):
+        logger.error(
+            "Unable to load commands from module '%s': missing 'setup_cli' function",
+            name,
+        )
+        return
+
+    try:
+        mod.setup_cli(commands)
+    except Exception:
+        logger.exception("Unable to load commands from module '%s'", name)
+        return
+
+
+def main(argv: Sequence[str] | None = None):
+    cli = build_parser()
+    args = cli.parse_args(argv)
+
+    if hasattr(args, "run"):
+        try:
+            return args.run(args)
+        except Exception:
+            logger.exception("Error running command")
+            return -1
+
+    cli.print_help()
+    return 0

--- a/lib/esbonio/esbonio/cli/server.py
+++ b/lib/esbonio/esbonio/cli/server.py
@@ -1,40 +1,36 @@
+from __future__ import annotations
+
 import argparse
 import logging
 import sys
 import warnings
-from collections.abc import Sequence
 from logging.handlers import MemoryHandler
 
 from pygls.protocol import default_converter
 
 from esbonio.server import EsbonioLanguageServer
 from esbonio.server import LSProtocol
-from esbonio.server import __version__
 from esbonio.server.features.log import LSPInfoFilter
 from esbonio.server.setup import create_language_server
 
 
-def build_parser() -> argparse.ArgumentParser:
-    """Return an argument parser with the default command line options required for
-    main.
-    """
+def setup_cli(commands: argparse._SubParsersAction):
+    """Configure the cli commands provided by this module."""
 
-    cli = argparse.ArgumentParser(description="The Esbonio language server")
-    _ = cli.add_argument(
+    command = commands.add_parser("server", help="launch the esbonio language server")
+    setup_cli_args(command)
+
+
+def setup_cli_args(parser: argparse.ArgumentParser):
+    _ = parser.add_argument(
         "-p",
         "--port",
         type=int,
         default=None,
         help="start a TCP instance of the language server listening on the given port.",
     )
-    _ = cli.add_argument(
-        "--version",
-        action="version",
-        version=__version__,
-        help="print the current version and exit.",
-    )
 
-    modules = cli.add_argument_group(
+    modules = parser.add_argument_group(
         "modules", "include/exclude language server modules."
     )
     _ = modules.add_argument(
@@ -55,13 +51,11 @@ def build_parser() -> argparse.ArgumentParser:
         dest="excluded_modules",
         help="exclude a module from the server configuration, can be given multiple times.",
     )
+    parser.set_defaults(run=run_server)
 
-    return cli
 
-
-def main(argv: Sequence[str] | None = None):
-    cli = build_parser()
-    args = cli.parse_args(argv)
+def run_server(args):
+    """Run the language server."""
 
     # Order matters!
     modules = [

--- a/lib/esbonio/esbonio/server/__main__.py
+++ b/lib/esbonio/esbonio/server/__main__.py
@@ -1,5 +1,26 @@
+"""Equivalent to calling esbonio server through the top-level cli."""
+
+import argparse
+import logging
 import sys
 
-from esbonio.server.cli import main
+from esbonio.cli.server import setup_cli_args
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    setup_cli_args(parser)
+
+    args = parser.parse_args()
+    if hasattr(args, "run"):
+        try:
+            return args.run(args)
+        except Exception:
+            logging.exception("Error running command")
+            return -1
+
+    parser.print_help()
+    return 0
+
 
 sys.exit(main())

--- a/lib/esbonio/pyproject.toml
+++ b/lib/esbonio/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
 "Source Code" = "https://github.com/swyddfa/esbonio"
 
 [project.scripts]
-esbonio = "esbonio.server.cli:main"
+esbonio = "esbonio.cli:main"
 
 [project.optional-dependencies]
 typecheck = ["mypy", "pytest-lsp>=1.0", "types-docutils", "types-pygments"]

--- a/lib/esbonio/tests/e2e/conftest.py
+++ b/lib/esbonio/tests/e2e/conftest.py
@@ -7,7 +7,7 @@ from lsprotocol import types
 from pytest_lsp import ClientServerConfig
 from pytest_lsp import LanguageClient
 
-SERVER_CMD = ["-m", "esbonio"]
+SERVER_CMD = ["-m", "esbonio.server"]
 TEST_DIR = pathlib.Path(__file__).parent.parent
 
 

--- a/lib/esbonio/tests/e2e/test_e2e_diagnostics.py
+++ b/lib/esbonio/tests/e2e/test_e2e_diagnostics.py
@@ -9,7 +9,7 @@ from pytest_lsp import ClientServerConfig
 from pytest_lsp import LanguageClient
 from sphinx import version_info as sphinx_version
 
-SERVER_CMD = ["-m", "esbonio"]
+SERVER_CMD = ["-m", "esbonio.server"]
 TEST_DIR = pathlib.Path(__file__).parent.parent
 
 


### PR DESCRIPTION
Ok, one more breaking change before releasing `v2`.

Launching the server is now done via a `server` subcommand rather than the top-level `esbonio` cli command. This is to create space for additional cli utilities that can be introduced in future releases.

Alternatively, the server can also be launched via `python -m esbonio.server` which is how the VSCode extension works.