### PR TITLE
code: Set `this.server` to placeholder value

### DIFF
--- a/code/.vscode-test.js
+++ b/code/.vscode-test.js
@@ -49,6 +49,24 @@ module.exports = defineConfig([
     mocha: MOCHA_ARGS,
   },
   {
+    label: 'Python Environments', // Ensure we handle the case where the Python environments extension is used, see https://github.com/swyddfa/esbonio/issues/1035.
+    files: 'dist/test/**/*.test.js',
+    workspaceFolder: createWorkspaceWithConfig(DEMO_WORKSPACE, "python-envs-extension", {
+      "esbonio.logging.level": "debug",
+      "esbonio.logging.filepath": "esbonio.log",
+      "esbonio.server.enabled": true,
+
+      "python.locator": "native",
+      "python.useEnvironmentsExtension": true,
+    }),
+    env: {
+      ESBONIO_LOG_DEST: 'console',
+      EXPECTED_SPHINX_VERSION: "8.1.3",
+      EXPECTED_SPHINX_THEME: "alabaster.css"
+    },
+    mocha: MOCHA_ARGS,
+  },
+  {
     label: 'Python 3.10', // Using uv to install esbonio under 3.10, using bundled Sphinx env.
     files: 'dist/test/**/*.test.js',
     workspaceFolder: createWorkspaceWithConfig(DEMO_WORKSPACE, "uv-3.10-bundled", {

--- a/code/changes/1035.fix.md
+++ b/code/changes/1035.fix.md
@@ -1,0 +1,1 @@
+The extension should no longer attempt to start multiple server instances, resulting in the `Error: command 'esbonio.sphinx.restart' already exists` error.

--- a/code/package-lock.json
+++ b/code/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "esbonio",
-    "version": "1.1.1",
+    "version": "2.0.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "esbonio",
-            "version": "1.1.1",
+            "version": "2.0.0",
             "license": "MIT",
             "dependencies": {
                 "@vscode/python-extension": "^1.0.6",

--- a/code/src/node/client.ts
+++ b/code/src/node/client.ts
@@ -151,7 +151,7 @@ export interface AppCreatedNotification {
 
 export class EsbonioClient {
 
-  public server?: LanguageClient
+  public server?: LanguageClient | 'starting'
 
   private handlers: Map<string, any[]>
 
@@ -180,7 +180,12 @@ export class EsbonioClient {
         return
       }
 
-      let states = [State.Running, State.Starting]
+      if (this.server === 'starting') {
+        logger.debug("Server is currently starting, ignoring Python environment change.")
+        return
+      }
+
+      let states = [State.Starting]
       logger.debug(`Server state is ${State[this.server.state]}`)
 
       if (!states.includes(this.server.state)) {
@@ -203,6 +208,11 @@ export class EsbonioClient {
    */
   async start(): Promise<void> {
 
+    if (this.server === 'starting') {
+      this.logger.debug("Server is already starting, doing nothing.")
+      return
+    }
+
     let states = [State.Running, State.Starting]
     if (this.server && states.includes(this.server.state)) {
       this.logger.debug("Server is starting or already running, doing nothing.")
@@ -210,9 +220,11 @@ export class EsbonioClient {
     }
 
     try {
+      this.server = 'starting'
       this.server = await this.getStdioClient()
     } catch (err) {
       this.logger.error(`${err}`)
+      this.server = undefined
       return
     }
 
@@ -246,6 +258,11 @@ export class EsbonioClient {
    * Stop the language server.
    */
   async stop() {
+
+    if (this.server === 'starting') {
+      this.logger.debug("Server is currently starting and cannot be stopped.")
+      return
+    }
 
     if (this.server && this.server.state === State.Running) {
       this.logger.info("Stopping Language Server")
@@ -303,7 +320,12 @@ export class EsbonioClient {
 
 
   public scrollView(uri: vscode.Uri, line: number) {
-    this.server?.sendNotification(Notifications.VIEW_SCROLL, {
+
+    if (!this.server || this.server === 'starting') {
+      return
+    }
+
+    this.server.sendNotification(Notifications.VIEW_SCROLL, {
       uri: uri.toString(), line: line
     })
   }

--- a/code/src/test/suite/extension.test.ts
+++ b/code/src/test/suite/extension.test.ts
@@ -22,23 +22,42 @@ suite('Extension Test Suite', () => {
   });
 
   test('server starts', async () => { // Language server should start
-    if (!esbonio) {
-      assert.fail("Extension not activated")
-    }
+    let promise = new Promise<void>(async (resolve, reject) => {
 
-    await esbonio.client.start()
-    assert.ok(esbonio.client.server)
-    assert.strictEqual(esbonio.client.server.state, State.Running)
+      if (!esbonio) {
+        reject("Extension not activated")
+        return
+      }
+
+      try {
+        await esbonio.client.start()
+        assert.ok(esbonio.client.server && esbonio.client.server !== 'starting')
+        assert.strictEqual(esbonio.client.server.state, State.Running)
+
+        resolve()
+      } catch(err) {
+        reject(err)
+      }
+    })
+    return promise
   });
 
   test('file open', async () => { // Opening a file should create a Sphinx client instance.
     let promise = new Promise<void>((resolve, reject) => {
+
       if (!esbonio) {
-        assert.fail("Extension not activated")
+        reject("Extension not activated")
+        return
       }
 
-      assert.ok(esbonio.client.server)
-      assert.strictEqual(esbonio.client.server.state, State.Running)
+      try {
+        assert.ok(esbonio.client.server && esbonio.client.server !== 'starting')
+        assert.strictEqual(esbonio.client.server.state, State.Running)
+      } catch(err) {
+        reject(err)
+        return
+      }
+
       esbonio.client.addHandler(Notifications.SPHINX_APP_CREATED, (params: AppCreatedNotification) => {
         try {
           assert.strictEqual(params.application.version, process.env.EXPECTED_SPHINX_VERSION)
@@ -64,11 +83,17 @@ suite('Extension Test Suite', () => {
   test('preview open', async () => { // Should be able to open preview
     let promise = new Promise<void>(async (resolve, reject) => {
       if (!esbonio) {
-        assert.fail("Extension not activated")
+        reject("Extension not activated")
+        return
       }
 
-      assert.ok(esbonio.client.server)
-      assert.strictEqual(esbonio.client.server.state, State.Running)
+      try{
+        assert.ok(esbonio.client.server && esbonio.client.server !== 'starting')
+        assert.strictEqual(esbonio.client.server.state, State.Running)
+      } catch(err) {
+        reject(err)
+        return
+      }
 
       let previewUri = vscode.Uri.joinPath(workspace.uri, 'index.rst')
 


### PR DESCRIPTION
By setting `this.server` to some value before the first `await` this ensures that other attempts at starting the server can detect that a startup attempt is in progress and abort it.

Related #1035