### PR TITLE
Add `esbonio sphinx build` cli command

### DIFF
--- a/docs/usage/reference/cli.rst
+++ b/docs/usage/reference/cli.rst
@@ -1,0 +1,96 @@
+.. _lsp-cli:
+
+Command Line Interface
+======================
+
+This page documents the command line interface provided by esbonio
+
+``esbonio server``
+------------------
+
+The :program:`esbonio server` command launches the esbonio language server.
+
+By default this start an instance of the language server configured to communicate over STDIO.
+
+.. program:: esbonio server
+
+.. option:: -p port, --port port
+
+   When given this starts an instance of the language server configured to communicate over TCP on the given port number.
+
+.. option:: -i module, --include module
+
+   Add an additional module e.g. ``esbonio.server.features.sphinx_manager`` to the server configuration.
+   To add multiple modules, this option can be given multiple times.
+
+.. option:: -e module, --exclde module
+
+   Exclude a module e.g. ``esbonio.server.features.sphinx_manager`` from the server configuration.
+   To exclude multiple modules, this option can be given multiple times.
+
+   .. note::
+
+      Excluding a module will also automatically exclude any modules that depend on it
+
+``esbonio sphinx``
+------------------
+
+Commands for interacting with Sphinx projects.
+The following options apply to all commands under the ``esbonio sphinx`` namespace.
+
+.. program:: esbonio sphinx
+
+.. option:: -c PATH, --config PATH
+
+   Read configuration values from the given path to a ``pyproject.toml`` file.
+   If not given, commands will look for a ``pyproject.toml`` file in the current directory.
+
+``esbonio sphinx build``
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+The :program:`esbonio sphinx build` command builds a sphinx project
+
+This command builds a sphinx project in the same manner as the esbonio language server,
+meaning:
+
+- Esbonio's additional sphinx extensions will be enabled
+- Resulting html files will contain the HTML and JS necessary to support sync scrolling
+- The ``esbonio.db`` file will be generated.
+
+Useful as a debugging aid for compatibility issues.
+
+In the absence of any additional command line flags, this command will look for a
+pyproject.toml file in the current working directory and use the options in the
+``[tool.esbonio.sphinx]`` section to configure the build.
+
+If the pyproject.toml file is not found, or does not contain the relevant options
+this command will attempt to derive a valid configuration, following the same
+rules as the language server.
+
+Providing additional command line flags will override this behaviour.
+
+.. program:: esbonio sphinx build
+
+.. option:: --build-args BUILD_ARGS
+
+   Override the value of :esbonio:conf:`esbonio.sphinx.buildArguments`, arguments should be passed as a single quoted string e.g. ::
+
+     $ esbonio sphinx build --build-args '-M dirhtml docs docs/_build'
+
+   See :ref:`lsp-configure-sphinx-build-cmd` for more details.
+
+.. option:: --python-cmd PYTHON_CMD
+
+   Override the value of :esbonio:conf:`esbonio.sphinx.pythonCommand`, arguments should be passed as a single quoted string e.g. ::
+
+     $ esbonio sphinx build --python-cmd 'uv run --with sphinx==9.1.0 python'
+
+   See :ref:`lsp-configure-sphinx-build-env` for more details.
+
+.. option:: --debug
+
+   .. important::
+
+      This option requires **both** ``esbonio`` and the target Sphinx environment to be using Python 3.14+
+
+   Attach a pdb debugger to the build process.

--- a/lib/esbonio/changes/1110.feature.md
+++ b/lib/esbonio/changes/1110.feature.md
@@ -1,0 +1,1 @@
+Add `esbonio sphinx build` command, which will perform a Sphinx build as if it was running as part of the language server.

--- a/lib/esbonio/esbonio/cli/__init__.py
+++ b/lib/esbonio/esbonio/cli/__init__.py
@@ -34,6 +34,14 @@ def build_parser() -> argparse.ArgumentParser:
         help="print the current version and exit.",
     )
 
+    _ = cli.add_argument(
+        "-v",
+        "--verbose",
+        action="count",
+        default=0,
+        help="increase output verbosity (can be repeated e.g. -vv)",
+    )
+
     commands = cli.add_subparsers(title="commands")
 
     for module in BUILTIN_COMMANDS:

--- a/lib/esbonio/esbonio/cli/__init__.py
+++ b/lib/esbonio/esbonio/cli/__init__.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import argparse
+import asyncio
 import importlib
+import inspect
 import logging
 import typing
 
@@ -14,6 +16,7 @@ logger = logging.getLogger(__name__)
 
 BUILTIN_COMMANDS = [
     "esbonio.cli.server",
+    "esbonio.cli.sphinx",
 ]
 
 
@@ -67,10 +70,18 @@ def main(argv: Sequence[str] | None = None):
 
     if hasattr(args, "run"):
         try:
-            return args.run(args)
+            result = args.run(args)
+            if inspect.iscoroutine(result):
+                return asyncio.run(result)
+
+            return result
         except Exception:
             logger.exception("Error running command")
             return -1
 
-    cli.print_help()
+    elif hasattr(args, "help_fn"):
+        args.help_fn()
+    else:
+        cli.print_help()
+
     return 0

--- a/lib/esbonio/esbonio/cli/sphinx.py
+++ b/lib/esbonio/esbonio/cli/sphinx.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import pathlib
+import sys
+from functools import partial
+
+from pygls.protocol import default_converter
+
+from esbonio.server import EsbonioWorkspace
+from esbonio.server import Uri
+from esbonio.server.features.sphinx_manager import ClientState
+from esbonio.server.features.sphinx_manager import SphinxClient
+from esbonio.server.features.sphinx_manager import SphinxConfig
+from esbonio.server.features.sphinx_manager import register_structure_hooks
+
+try:
+    import tomllib as toml
+except ImportError:
+    import tomli as toml  # type: ignore[no-redef]
+
+
+def setup_cli(commands: argparse._SubParsersAction[argparse.ArgumentParser]):
+    """Configure the cli commands provided by this module."""
+
+    sphinx_cli = commands.add_parser("sphinx", help="interact with Sphinx projects")
+    sphinx_cli.set_defaults(help_fn=sphinx_cli.print_help)
+
+    _ = sphinx_cli.add_argument(
+        "-c",
+        "--config",
+        default="pyproject.toml",
+        type=pathlib.Path,
+        help="set the path to the pyproject.toml file to use.",
+    )
+    sphinx_commands = sphinx_cli.add_subparsers(title="commands")
+
+    build_cmd = sphinx_commands.add_parser("build", help="build a Sphinx project")
+    setup_build_args(build_cmd)
+
+
+def setup_build_args(parser: argparse.ArgumentParser):
+    parser.set_defaults(run=sphinx_build)
+
+
+async def handle_client(
+    future: asyncio.Future[None],
+    client: SphinxClient,
+    old_state: ClientState,
+    new_state: ClientState,
+):
+    if old_state == ClientState.Starting and new_state == ClientState.Running:
+        _ = await client.build()
+
+    if old_state == ClientState.Building and new_state == ClientState.Running:
+        await client.stop()
+        future.set_result(None)
+
+    if new_state == ClientState.Errored:
+        await client.stop()
+        future.set_exception(client.exception)
+        return
+
+
+def load_config(path: pathlib.Path, logger: logging.Logger) -> SphinxConfig | None:
+    config_uri = Uri.for_file(path)
+    workspace = EsbonioWorkspace(root_uri=(config_uri / "..").as_string())
+
+    converter = default_converter()
+    register_structure_hooks(converter)
+
+    data = toml.loads(path.read_text())
+    values = data.get("tool", {}).get("esbonio", {}).get("sphinx", {})
+
+    config = converter.structure(values, SphinxConfig)
+    return config.resolve(config_uri, workspace, logger)
+
+
+def get_sphinx_client(config: SphinxConfig, logger: logging.Logger):
+    client = SphinxClient(config, logger=logger)
+
+    @client.feature("$/progress")
+    def _(params):
+        pass
+
+    return client
+
+
+async def sphinx_build(args):
+    """Run a Sphinx build including all of esbonio's extras, just as if it was running
+    under the language server."""
+
+    handler = logging.StreamHandler()
+    handler.setLevel(logging.INFO)
+    handler.setFormatter(logging.Formatter("[%(name)s]: %(message)s"))
+
+    sphinx_log = logging.getLogger("sphinx")
+    sphinx_log.setLevel(logging.INFO)
+    sphinx_log.addHandler(handler)
+
+    logger = logging.getLogger("esbonio")
+    logger.setLevel(logging.INFO)
+    logger.addHandler(handler)
+
+    config = load_config(args.config.resolve(), logger)
+    if config is None:
+        print("Unable to generate a valid Sphinx configuration", file=sys.stderr)
+        return 1
+
+    client = get_sphinx_client(config, logger)
+
+    future = asyncio.Future()
+    client.add_listener("state-change", partial(handle_client, future))
+
+    _ = await client.start()
+    await asyncio.ensure_future(future)

--- a/lib/esbonio/esbonio/cli/sphinx.py
+++ b/lib/esbonio/esbonio/cli/sphinx.py
@@ -4,6 +4,7 @@ import argparse
 import asyncio
 import logging
 import pathlib
+import pdb
 import shlex
 import sys
 from functools import partial
@@ -72,24 +73,40 @@ def setup_build_args(parser: argparse.ArgumentParser):
     """Configure the arguments for the build command."""
     parser.set_defaults(run=sphinx_build)
 
-    parser.add_argument(
+    _ = parser.add_argument(
         "--build-args",
         default=None,
         help="override the arguments passed to sphinx-build",
     )
-    parser.add_argument(
+    _ = parser.add_argument(
         "--python-cmd",
         default=None,
         help="override the python envrionment used",
     )
+    _ = parser.add_argument(
+        "--debug",
+        action="store_true",
+        help="attach a debugger to the build process (Python 3.14+)",
+    )
 
 
 async def handle_client(
+    logger: logging.Logger,
     future: asyncio.Future[None],
+    debug: bool,
     client: SphinxClient,
     old_state: ClientState,
     new_state: ClientState,
 ):
+    if new_state == ClientState.Starting:
+        if debug:
+            try:
+                logger.info("Attaching to build process...")
+                pdb.attach(client.sphinx_pid)
+            except RuntimeError as exc:
+                await client.stop()
+                logger.error("Unable to attach to build process: %s", exc)
+
     if old_state == ClientState.Starting and new_state == ClientState.Running:
         _ = await client.build()
 
@@ -181,7 +198,6 @@ def get_sphinx_client(config: SphinxConfig, logger: logging.Logger):
 
 
 LOG_LEVELS = [
-    logging.WARNING,
     logging.INFO,
     logging.DEBUG,
 ]
@@ -218,6 +234,10 @@ async def sphinx_build(args):
 
     logger = setup_logging(args)
 
+    if args.debug and sys.version_info < (3, 14):
+        logger.error("--debug is only available on Python 3.14+")
+        return
+
     config = get_sphinx_config(
         path=args.config.resolve(),
         build_args=args.build_args,
@@ -231,7 +251,17 @@ async def sphinx_build(args):
     client = get_sphinx_client(config, logger)
 
     future = asyncio.Future()
-    client.add_listener("state-change", partial(handle_client, future))
+    client.add_listener(
+        "state-change", partial(handle_client, logger, future, args.debug)
+    )
 
-    _ = await client.start()
-    await asyncio.ensure_future(future)
+    try:
+        _ = await client.start()
+        await asyncio.ensure_future(future)
+        return 0
+    except RuntimeError as exc:
+        logger.error("%s", exc)
+        return 1
+    except Exception:
+        logger.exception("Error occured during build")
+        return 1

--- a/lib/esbonio/esbonio/cli/sphinx.py
+++ b/lib/esbonio/esbonio/cli/sphinx.py
@@ -4,6 +4,7 @@ import argparse
 import asyncio
 import logging
 import pathlib
+import shlex
 import sys
 from functools import partial
 
@@ -11,6 +12,7 @@ from pygls.protocol import default_converter
 
 from esbonio.server import EsbonioWorkspace
 from esbonio.server import Uri
+from esbonio.server import merge_configs
 from esbonio.server.features.sphinx_manager import ClientState
 from esbonio.server.features.sphinx_manager import SphinxClient
 from esbonio.server.features.sphinx_manager import SphinxConfig
@@ -25,7 +27,7 @@ except ImportError:
 def setup_cli(commands: argparse._SubParsersAction[argparse.ArgumentParser]):
     """Configure the cli commands provided by this module."""
 
-    sphinx_cli = commands.add_parser("sphinx", help="interact with Sphinx projects")
+    sphinx_cli = commands.add_parser("sphinx", help="interact with sphinx projects")
     sphinx_cli.set_defaults(help_fn=sphinx_cli.print_help)
 
     _ = sphinx_cli.add_argument(
@@ -37,12 +39,49 @@ def setup_cli(commands: argparse._SubParsersAction[argparse.ArgumentParser]):
     )
     sphinx_commands = sphinx_cli.add_subparsers(title="commands")
 
-    build_cmd = sphinx_commands.add_parser("build", help="build a Sphinx project")
+    build_cmd = sphinx_commands.add_parser(
+        "build",
+        help="build a sphinx project",
+        description="""\
+Build a sphinx project.
+
+This command builds a sphinx project in the same manner as the esbonio language server,
+meaning:
+
+- Esbonio's additional sphinx extensions will be enabled
+- Resulting html files will contain the HTML and JS necessary to support sync scrolling
+- The esbonio.db file will be generated.
+
+Useful as a debugging aid for compatibility issues.
+
+In the absence of any additional command line flags, this command will look for a
+pyproject.toml file in the current working directory and use the options in the
+`[tool.esbonio.sphinx]` section to configure the build.
+
+If the pyproject.toml file is not found, or does not contain the relevant options
+this command will attempt to derive a valid configuration, following the same
+rules as the language server.
+
+Providing additional command line flags will override this behaviour.""",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
     setup_build_args(build_cmd)
 
 
 def setup_build_args(parser: argparse.ArgumentParser):
+    """Configure the arguments for the build command."""
     parser.set_defaults(run=sphinx_build)
+
+    parser.add_argument(
+        "--build-args",
+        default=None,
+        help="override the arguments passed to sphinx-build",
+    )
+    parser.add_argument(
+        "--python-cmd",
+        default=None,
+        help="override the python envrionment used",
+    )
 
 
 async def handle_client(
@@ -64,17 +103,70 @@ async def handle_client(
         return
 
 
-def load_config(path: pathlib.Path, logger: logging.Logger) -> SphinxConfig | None:
-    config_uri = Uri.for_file(path)
-    workspace = EsbonioWorkspace(root_uri=(config_uri / "..").as_string())
+def get_sphinx_config(
+    path: pathlib.Path,
+    build_args: str | None,
+    python_cmd: str | None,
+    logger: logging.Logger,
+) -> SphinxConfig | None:
+    """Return the SphinxConfig instance to use.
+
+    This will attempt to read ``path`` as a pyproject.toml file and construct a
+    ``SphinxConfig`` instance from the ``[tool.esbonio.sphinx]`` section. If the path
+    does not exist this function will attempt to continue without it, any other error
+    will lead to an abort.
+
+    If additional parameters are given, they will override any values present in the config.
+
+    Parameters
+    ----------
+    path
+       The path to the ``pyproject.toml`` file to load configuration values from
+
+    build_args
+       If set, override ``esbonio.sphinx.buildArguments``.
+
+    python_cmd
+       If set, override ``esbonio.sphinx.pythonCommand``.
+
+    logger
+       The logger instance to use.
+
+    Returns
+    -------
+    SphinxConfig
+       The fully resolved SphinxConfig instance to use, ``None`` otherwise.
+    """
+    workspace = EsbonioWorkspace(root_uri=Uri.for_file(path.parent).as_string())
 
     converter = default_converter()
     register_structure_hooks(converter)
 
-    data = toml.loads(path.read_text())
-    values = data.get("tool", {}).get("esbonio", {}).get("sphinx", {})
+    defaults = {}
+    if path.is_file():
+        try:
+            data = toml.loads(path.read_text())
+            defaults = data.get("tool", {}).get("esbonio", {}).get("sphinx", {})
+        except Exception:
+            logging.exception("Unable to load configuration")
+            return None
 
-    config = converter.structure(values, SphinxConfig)
+    overrides = {}
+    if build_args is not None:
+        overrides["buildArguments"] = shlex.split(build_args)
+
+    if python_cmd is not None:
+        overrides["pythonCommand"] = shlex.split(python_cmd)
+
+    values = merge_configs(defaults, overrides)
+
+    try:
+        config = converter.structure(values, SphinxConfig)
+    except Exception:
+        logging.exception("Unable to parse configuration")
+        return None
+
+    config_uri = Uri.for_file(path)
     return config.resolve(config_uri, workspace, logger)
 
 
@@ -88,23 +180,50 @@ def get_sphinx_client(config: SphinxConfig, logger: logging.Logger):
     return client
 
 
+LOG_LEVELS = [
+    logging.WARNING,
+    logging.INFO,
+    logging.DEBUG,
+]
+
+
+def setup_logging(args):
+    # Sphinx output is handled separately.
+    sphinx_handler = logging.StreamHandler()
+    sphinx_handler.setLevel(logging.INFO)
+
+    sphinx_log = logging.getLogger("sphinx")
+    sphinx_log.setLevel(logging.INFO)
+    sphinx_log.addHandler(sphinx_handler)
+
+    try:
+        log_level = LOG_LEVELS[args.verbose]
+    except IndexError:
+        log_level = LOG_LEVELS[-1]
+
+    handler = logging.StreamHandler()
+    handler.setLevel(log_level)
+    handler.setFormatter(logging.Formatter("[%(name)s]: %(message)s"))
+
+    logger = logging.getLogger("esbonio")
+    logger.setLevel(log_level)
+    logger.addHandler(handler)
+
+    return logger
+
+
 async def sphinx_build(args):
     """Run a Sphinx build including all of esbonio's extras, just as if it was running
     under the language server."""
 
-    handler = logging.StreamHandler()
-    handler.setLevel(logging.INFO)
-    handler.setFormatter(logging.Formatter("[%(name)s]: %(message)s"))
+    logger = setup_logging(args)
 
-    sphinx_log = logging.getLogger("sphinx")
-    sphinx_log.setLevel(logging.INFO)
-    sphinx_log.addHandler(handler)
-
-    logger = logging.getLogger("esbonio")
-    logger.setLevel(logging.INFO)
-    logger.addHandler(handler)
-
-    config = load_config(args.config.resolve(), logger)
+    config = get_sphinx_config(
+        path=args.config.resolve(),
+        build_args=args.build_args,
+        python_cmd=args.python_cmd,
+        logger=logger,
+    )
     if config is None:
         print("Unable to generate a valid Sphinx configuration", file=sys.stderr)
         return 1

--- a/lib/esbonio/esbonio/server/__init__.py
+++ b/lib/esbonio/esbonio/server/__init__.py
@@ -6,6 +6,7 @@ from esbonio.sphinx_agent.types import Uri
 
 from ._configuration import ConfigChangeEvent
 from ._configuration import ConfigurationContext
+from ._configuration import merge_configs
 from .events import EventSource
 from .feature import CompletionConfig
 from .feature import CompletionContext
@@ -44,4 +45,5 @@ __all__ = (
     "LSProtocol",
     "Uri",
     "create_language_server",
+    "merge_configs",
 )

--- a/lib/esbonio/esbonio/server/_configuration.py
+++ b/lib/esbonio/esbonio/server/_configuration.py
@@ -379,7 +379,7 @@ class Configuration:
         workspace_config = self._workspace_config.get(context.workspace_scope, {})
 
         # Combine and resolve all the config sources - order matters!
-        config = _merge_configs(
+        config = merge_configs(
             self._initialization_options, file_config, workspace_config
         )
         # self.logger.debug("Full config: %s", json.dumps(config, indent=2))
@@ -537,7 +537,7 @@ def _uri_to_scope(known_scopes: list[str], uri: Uri | None) -> str:
     return sorted(candidates, key=len, reverse=True)[0]
 
 
-def _merge_configs(*configs: dict[str, Any]):
+def merge_configs(*configs: dict[str, Any]):
     """Recursively merge all the given configuration sources together.
 
     The last config given takes precedence.
@@ -556,7 +556,7 @@ def _merge_configs(*configs: dict[str, Any]):
         # Do we need to recurse?
         if isinstance(values[-1], dict):
             # Be sure to only pass dictionary values to _merge_configs.
-            final[k] = _merge_configs(*[v for v in values if isinstance(v, dict)])
+            final[k] = merge_configs(*[v for v in values if isinstance(v, dict)])
         else:
             final[k] = values[-1]
 

--- a/lib/esbonio/esbonio/server/features/sphinx_manager/__init__.py
+++ b/lib/esbonio/esbonio/server/features/sphinx_manager/__init__.py
@@ -8,6 +8,7 @@ from .client import SphinxClient
 from .client import make_sphinx_client
 from .config import SphinxConfig
 from .config import SubProcess
+from .config import register_structure_hooks
 from .manager import RestartSphinxParams
 from .manager import SphinxManager
 
@@ -17,6 +18,7 @@ __all__ = [
     "SphinxConfig",
     "SphinxManager",
     "SubProcess",
+    "register_structure_hooks",
 ]
 
 

--- a/lib/esbonio/esbonio/server/features/sphinx_manager/client.py
+++ b/lib/esbonio/esbonio/server/features/sphinx_manager/client.py
@@ -27,6 +27,9 @@ if typing.TYPE_CHECKING:
 class ClientState(enum.Enum):
     """The set of possible states the client may be in."""
 
+    Spawning = enum.auto()
+    """The client process is being spwaned."""
+
     Starting = enum.auto()
     """The client is starting."""
 
@@ -85,6 +88,9 @@ class SphinxClient(JsonRPCClient):
         self.logger = logger or logging.getLogger(__name__)
         """The logger instance to use."""
 
+        self.sphinx_pid: int = 0
+        """The pid of the sphinx build process (or ``0`` if not known)"""
+
         self.sphinx_info: types.SphinxInfo | None = None
         """Information about the Sphinx application the client is connected to."""
 
@@ -127,8 +133,16 @@ class SphinxClient(JsonRPCClient):
 
     @property
     def pid(self) -> int:
-        """The pid of the sphinx agent process, if no process is running this will
-        return ``0``."""
+        """The pid of the process launched by the client
+
+        .. important::
+
+           When the user uses tools like ``uv`` this may be a different process to the
+           actual Sphinx build process!. To get the pid of the sphinx build process use
+           ``sphinx_pid``
+
+        If no process is running this will return ``0``.
+        """
         if self._server is None:
             return 0
 
@@ -229,10 +243,17 @@ class SphinxClient(JsonRPCClient):
             return self
 
         try:
+            self._set_state(ClientState.Spawning)
+
             sphinx = self.config.sphinx_command
 
             self.logger.debug("Python command: %r", sphinx.command)
             await self.start_io(*sphinx.command, env=sphinx.env, cwd=sphinx.cwd)
+
+            result: types.InitializeResult = await self.protocol.send_request_async(
+                "initialize", types.InitializeParams()
+            )
+            self.sphinx_pid = result.pid
 
             self._set_state(ClientState.Starting)
 

--- a/lib/esbonio/esbonio/server/features/sphinx_manager/config.py
+++ b/lib/esbonio/esbonio/server/features/sphinx_manager/config.py
@@ -113,9 +113,7 @@ class SubProcess:
            The command to use when invoking python
         """
         if len(command := list(self.command)) == 0:
-            logger.warning(
-                "No pythonCommand configured! Reusing the server's environment."
-            )
+            logger.info("No pythonCommand configured, reusing host environment.")
             return [sys.executable]
 
         command = [_resolve_variable(c, cwd) for c in command]

--- a/lib/esbonio/esbonio/sphinx_agent/handlers/__init__.py
+++ b/lib/esbonio/esbonio/sphinx_agent/handlers/__init__.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import inspect
 import logging
+import os
 import sys
 import traceback
 import typing
@@ -102,6 +103,17 @@ class SphinxHandler:
             handlers[request_type.method] = (request_type, method_func)
 
         return handlers
+
+    def initialize(self, request: types.InitializeRequest):
+        """Currently just a hack to return the process pid to the server early-ish in
+        the program's lifecycle."""
+
+        response = types.InitializeResponse(
+            id=request.id,
+            result=types.InitializeResult(pid=os.getpid()),
+            jsonrpc=request.jsonrpc,
+        )
+        send_message(response)
 
     def create_sphinx_app(self, request: types.CreateApplicationRequest):
         """Create a new sphinx application instance."""

--- a/lib/esbonio/esbonio/sphinx_agent/server.py
+++ b/lib/esbonio/esbonio/sphinx_agent/server.py
@@ -109,6 +109,6 @@ async def main_loop(loop, executor, stop_event, rfile, proxy):
 async def main():
     loop = asyncio.get_running_loop()
     event = threading.Event()
-    executor = ThreadPoolExecutor(max_workers=2)
+    executor = ThreadPoolExecutor()
 
     await main_loop(loop, executor, event, sys.stdin.buffer, handle_message)

--- a/lib/esbonio/esbonio/sphinx_agent/types/__init__.py
+++ b/lib/esbonio/esbonio/sphinx_agent/types/__init__.py
@@ -208,6 +208,40 @@ class ProgressMessage:
 
 
 @dataclasses.dataclass
+class InitializeParams:
+    pass
+
+
+@dataclasses.dataclass
+class InitializeResult:
+    pid: int
+
+
+@dataclasses.dataclass
+class InitializeRequest:
+    """An ``initialize`` request"""
+
+    id: int | str
+
+    params: InitializeParams
+
+    method: str = "initialize"
+
+    jsonrpc: str = dataclasses.field(default="2.0")
+
+
+@dataclasses.dataclass
+class InitializeResponse:
+    """A ``initialize`` response."""
+
+    id: int | str
+
+    result: InitializeResult
+
+    jsonrpc: str = dataclasses.field(default="2.0")
+
+
+@dataclasses.dataclass
 class ExitNotification:
     """An ``exit`` notification"""
 
@@ -222,9 +256,11 @@ METHOD_TO_MESSAGE_TYPE = {
     BuildRequest.method: BuildRequest,
     ExitNotification.method: ExitNotification,
     CreateApplicationRequest.method: CreateApplicationRequest,
+    InitializeRequest.method: InitializeRequest,
 }
 METHOD_TO_RESPONSE_TYPE = {
     BuildRequest.method: BuildResponse,
     ExitNotification.method: None,
     CreateApplicationRequest.method: CreateApplicationResponse,
+    InitializeRequest.method: InitializeResponse,
 }

--- a/lib/esbonio/tests/e2e/test_sphinx_manager.py
+++ b/lib/esbonio/tests/e2e/test_sphinx_manager.py
@@ -36,6 +36,9 @@ if typing.TYPE_CHECKING:
         ) -> Coroutine[None, None, tuple[EsbonioLanguageServer, SphinxManager]]: ...
 
 
+STARTING_STATES = {None, ClientState.Starting, ClientState.Spawning}
+
+
 @pytest.fixture
 def demo_workspace(uri_for):
     return uri_for("workspaces", "demo")
@@ -144,7 +147,11 @@ async def test_get_client(
     client = manager.clients[str(demo_workspace)]
 
     assert client is not None
-    assert client.state in {ClientState.Starting, ClientState.Running}
+    assert client.state in {
+        ClientState.Spawning,
+        ClientState.Starting,
+        ClientState.Running,
+    }
 
     # Now when we ask for the client, the client should be started and we should
     # get back the same instance
@@ -256,7 +263,7 @@ async def test_get_client_with_many_uris(
 
     client = manager.clients[str(demo_workspace)]
     assert client is not None
-    assert client.state in {None, ClientState.Starting}
+    assert client.state in STARTING_STATES
 
     # Now if we do the same again we should get the same client instance for each case.
     coros = [manager.get_client(s) for s in src_uris]
@@ -339,11 +346,11 @@ async def test_get_client_with_many_uris_in_many_projects(
 
     demo_client = manager.clients[str(demo_workspace)]
     assert demo_client is not None
-    assert demo_client.state in {None, ClientState.Starting}
+    assert demo_client.state in STARTING_STATES
 
     docs_client = manager.clients[str(docs_workspace)]
     assert docs_client is not None
-    assert docs_client.state in {None, ClientState.Starting}
+    assert docs_client.state in STARTING_STATES
 
     # Now if we do the same again we should get the same client instance for each case.
     coros = [manager.get_client(s) for s in src_uris]
@@ -400,7 +407,11 @@ async def test_updated_config(
     client = manager.clients[str(demo_workspace)]
 
     assert client is not None
-    assert client.state in {ClientState.Starting, ClientState.Running}
+    assert client.state in {
+        ClientState.Spawning,
+        ClientState.Starting,
+        ClientState.Running,
+    }
 
     # Now when we ask for the client, the client should be started and we should
     # get back the same instance
@@ -430,7 +441,11 @@ async def test_updated_config(
     new_client = manager.clients[str(demo_workspace)]
 
     assert new_client is not client
-    assert new_client.state in {ClientState.Starting, ClientState.Running}
+    assert new_client.state in {
+        ClientState.Spawning,
+        ClientState.Starting,
+        ClientState.Running,
+    }
 
     # Ensure that the client has finished starting
     await new_client

--- a/lib/esbonio/tests/server/test_configuration.py
+++ b/lib/esbonio/tests/server/test_configuration.py
@@ -12,7 +12,7 @@ from pygls.workspace import Workspace
 
 from esbonio.server import EsbonioLanguageServer
 from esbonio.server import Uri
-from esbonio.server._configuration import _merge_configs
+from esbonio.server import merge_configs
 from esbonio.server._configuration import _uri_to_scope
 
 T = TypeVar("T")
@@ -602,4 +602,4 @@ def test_uri_to_scope_windows(known_scopes, setup):
 )
 def test_merge_configs(configs, expected):
     """Ensure that we can merge configurations together correctly."""
-    assert expected == _merge_configs(*configs)
+    assert expected == merge_configs(*configs)


### PR DESCRIPTION
This adds an `esbonio sphinx build` command which will build a Sphinx project as if it was being built by the esbonio language server.
```
❯ esbonio sphinx build 
warning: No `requires-python` value found in the workspace. Defaulting to `>=3.14`.
Running Sphinx v9.1.0
loading translations [en]... done
The configuration has changed (2 options: 'html_static_path', 'pygments_dark_style')
loading pickled environment... done
myst v5.0.0: MdParserConfig(commonmark_only=False, gfm_only=False, enable_extensions=set(), disable_syntax=[], all_links_external=False, links_external_new_tab=False, url_schemes=('http', 'https', 'mailto', 'ftp'), ref_domains=None, fence_as_directive=set(), number_code_blocks=[], title_to_header=False, heading_anchors=0, heading_slug_func=None, html_meta={}, footnote_sort=True, footnote_transition=True, words_per_minute=200, substitutions={}, linkify_fuzzy_links=True, dmath_allow_labels=True, dmath_allow_space=True, dmath_allow_digits=True, dmath_double_inline=False, update_mathjax=True, mathjax_classes='tex2jax_process|mathjax_process|math|output_area', enable_checkboxes=False, suppress_warnings=[], highlight_code_blocks=True)
/var/home/alex/Projects/swyddfa/esbonio/develop/lib/esbonio/esbonio/sphinx_agent/handlers/domains.py:281: RemovedInSphinx10Warning: The iter() interface for _InventoryItem objects is deprecated. Please access the `project_name`, `project_version`, `uri`, and `displayname` attributes directly.
  (name, version, _, _) = next(iter(next(iter(project.values())).values()))
/var/home/alex/Projects/swyddfa/esbonio/develop/lib/esbonio/esbonio/sphinx_agent/handlers/domains.py:303: RemovedInSphinx10Warning: The iter() interface for _InventoryItem objects is deprecated. Please access the `project_name`, `project_version`, `uri`, and `displayname` attributes directly.
  for objname, (_, _, item_uri, display) in items.items():
building [mo]: targets for 0 po files that are out of date
writing output...
building [dirhtml]: targets for 0 source files that are out of date
updating environment: 0 added, 2 changed, 0 removed
reading sources...
/var/home/alex/Projects/swyddfa/esbonio/develop/docs/integrating/getting-started.rst:6: WARNING: toctree contains reference to nonexisting document 'integrating/howto/kate' [toc.not_readable]
/var/home/alex/Projects/swyddfa/esbonio/develop/docs/integrating/howto/editors/sublime.rst:12: WARNING: Include file '/var/home/alex/Projects/swyddfa/esbonio/develop/docs/integrating/howto/editors/editors/sublimetext-lsp/LSP.sublime-settings' not found or reading it failed [docutils]
looking for now-outdated files... none found
pickling environment... done
/var/home/alex/Projects/swyddfa/esbonio/develop/docs/extensions/relevant_to.rst: WARNING: document isn't included in any toctree [toc.not_included]
/var/home/alex/Projects/swyddfa/esbonio/develop/docs/extensions/tutorial.rst: WARNING: document isn't included in any toctree [toc.not_included]
/var/home/alex/Projects/swyddfa/esbonio/develop/docs/integrating/howto/editors/kate.rst: WARNING: document isn't included in any toctree [toc.not_included]
/var/home/alex/Projects/swyddfa/esbonio/develop/docs/integrating/howto/editors/sublime.rst: WARNING: document isn't included in any toctree [toc.not_included]
/var/home/alex/Projects/swyddfa/esbonio/develop/docs/integrating/howto/editors/vim.rst: WARNING: document isn't included in any toctree [toc.not_included]
/var/home/alex/Projects/swyddfa/esbonio/develop/docs/integrating/howto/editors/vscode.rst: WARNING: document isn't included in any toctree [toc.not_included]
/var/home/alex/Projects/swyddfa/esbonio/develop/docs/integrating/reference/sphinx-processes.rst: WARNING: document isn't included in any toctree [toc.not_included]
checking consistency... done
preparing documents... done
copying downloadable files...
Writing evaluated template result to /var/home/alex/.cache/esbonio/2a2704928527920b99a262c696b44419/dirhtml/_static/basic.css
Writing evaluated template result to /var/home/alex/.cache/esbonio/2a2704928527920b99a262c696b44419/dirhtml/_static/documentation_options.js
Writing evaluated template result to /var/home/alex/.cache/esbonio/2a2704928527920b99a262c696b44419/dirhtml/_static/language_data.js
copying static files... done
copying extra files... done
copying assets... done
writing output...
/var/home/alex/Projects/swyddfa/esbonio/develop/docs/integrating/getting-started.rst:13: WARNING: unknown document: '/lsp/getting-started' [ref.doc]
genindex generating indices... done
highlighting module code...
search writing additional pages... done
dumping search index in English (code: en)... done
dumping object inventory... done
build succeeded, 10 warnings.

The HTML pages are in ../../../../../.cache/esbonio/2a2704928527920b99a262c696b44419/dirhtml.

```
By default it will look for a `pyproject.toml` file in the current directory containing the usual `[tool.esbonio.sphinx]` config options.
```toml
[tool.esbonio.sphinx]
buildArguments = ["-M", "dirhtml", ".", "${defaultBuildDir}"]
pythonCommand = ["uv", "run", "--python", "3.14", "--with-requirements", "requirements.txt", "python"]
```
Though they can be overridden with the `--build-args` and `--python-cmd` options.

The main purpose of this command is to assist with debugging build issues (e.g. #1087), so there is also a `--debug` flag that will attach a pdb debug session to the build process (requires Python 3.14+ on both sides).

**Note:** The current `--debug` flag implementation is not perfect, as it is somewhat a lottery where in the call stack the debugger will manage to attach itself. Will likely require some refactoring of the `sphinx-agent` process to fix. 