### PR TITLE
docs: Remove leading "sphinx-build" from buildArguments setting

### DIFF
--- a/code/guides/example-commands.md
+++ b/code/guides/example-commands.md
@@ -8,14 +8,13 @@ This can be changed by setting `esbonio.sphinx.buildArguments` in your `pyprojec
 ```toml
 [tool.esbonio.sphinx]
 buildArguments = [
-    "sphinx-build", "-M", "html", "docs", "${defaultBuildDir}", "--nitpicky", "--verbose",
+    "-M", "html", "docs", "${defaultBuildDir}", "--nitpicky", "--verbose",
 ]
 ```
 Alternatively, you can include the setting in your `.vscode/settings.json`
 ```json
 {
     "esbonio.sphinx.buildArguments": [
-        "sphinx-build",
         "-b", "html",
         "-j", "auto",
         "docs", "docs/_build"

--- a/docs/pyproject.toml
+++ b/docs/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.esbonio.sphinx]
-buildArguments = ["sphinx-build", "-M", "dirhtml", ".", "${defaultBuildDir}"]
+buildArguments = ["-M", "dirhtml", ".", "${defaultBuildDir}"]
 pythonCommand = ["hatch", "-e", "docs", "run", "python"]
 
 [tool.hatch.envs.docs]

--- a/docs/usage/howto/configure-the-sphinx-build-cmd.rst
+++ b/docs/usage/howto/configure-the-sphinx-build-cmd.rst
@@ -17,7 +17,7 @@ Of course, the ``sphinx-build`` command you use with your project may be differe
 .. code-block:: toml
 
    [tool.esbonio.sphinx]
-   buildArguments = ["sphinx-build", "-M", "html", "docs", "${defaultBuildDir}", "--nitpicky", "--verbose"]
+   buildArguments = ["-M", "html", "docs", "${defaultBuildDir}", "--nitpicky", "--verbose"]
 
 :esbonio:conf:`esbonio.sphinx.buildArguments` must be the genuine command line for ``sphinx-build``.
 Wrapper scripts around ``sphinx-build``, e.g. a Makefile, are not supported.
@@ -60,7 +60,7 @@ Then your :esbonio:conf:`esbonio.sphinx.buildArguments` might look something lik
 .. code-block:: toml
 
    [tool.esbonio.sphinx]
-   buildArguments = ["sphinx-build", "-M", "html", "docs", "${defaultBuildDir}"]
+   buildArguments = ["-M", "html", "docs", "${defaultBuildDir}"]
 
 If you set the build command using the settings in your editor, the "current directory" will be set to root of your workspace
 
@@ -75,7 +75,7 @@ For example, to override the theme used by the project
 .. code-block:: toml
 
    [tool.esbonio.sphinx]
-   buildArguments = ["sphinx-build", "-M", "dirhtml", ".", "${defaultBuildDir}"]
+   buildArguments = ["-M", "dirhtml", ".", "${defaultBuildDir}"]
    configOverrides = { html_theme = "alabaster" }
 
 Though of course, this setting probably make most sense to be set via your editor.
@@ -92,7 +92,7 @@ To override it to be ``My Custom Title`` you could use the following
 .. code-block:: toml
 
    [tool.esbonio.sphinx]
-   buildArguments = ["sphinx-build", "-M", "dirhtml", ".", "${defaultBuildDir}"]
+   buildArguments = ["-M", "dirhtml", ".", "${defaultBuildDir}"]
    configOverrides = { html_context.docstitle = "My Custom Title" }
 
 Though of course, this setting probably make most sense to be set via your editor.


### PR DESCRIPTION
https://github.com/swyddfa/esbonio/pull/1067/commits/cd0d7c989fcaffcacac188efec0e25a85da447cf introduced the setting `buildArguments`(part of https://github.com/swyddfa/esbonio/pull/1067).  Thus,

```
buildCommand = ["sphinx-build", "-M", "html", "docs", "${defaultBuildDir}", "--nitpicky", "--verbose"]
```

became

```
buildArguments = ["sphinx-build", "-M", "html", "docs", "${defaultBuildDir}", "--nitpicky", "--verbose"]
```

Note however, that the values of this setting are not arguments but a command.
To me the following would be more correct:

```
buildArguments = ["-M", "html", "docs", "${defaultBuildDir}", "--nitpicky", "--verbose"]
```

Note the missing program `sphinx-build` in the first position, i.e. all the values are arguments.

Luckily, Esbonio already treats it that way:

https://github.com/swyddfa/esbonio/blob/7d14993a594204371c0c66f90f44ab17f1639c04/lib/esbonio/esbonio/sphinx_agent/config.py#L79-L96

(at least I believe that is the location where the option is used and a potential leading `sphinx-build` is stripped)

The test suite also seems to cover this use case:

https://github.com/swyddfa/esbonio/blob/7d14993a594204371c0c66f90f44ab17f1639c04/lib/esbonio/tests/server/features/test_sphinx_config.py#L449-L471

and

https://github.com/swyddfa/esbonio/blob/7d14993a594204371c0c66f90f44ab17f1639c04/lib/esbonio/tests/sphinx-agent/test_sa_unit.py


This pull request, updates the documentation, to reflect that `buildArguments` are only arguments and `buildCommand` is the full command (not changed in this PR).

---

Sidenote:
I noticed there are these two folders:

+ `lib/esbonio/tests/server/feature`
+ `lib/esbonio/tests/server/features`

should these be the same?