### PR TITLE
lsp: Set charset=utf-8 on text/* preview responses

### DIFF
--- a/lib/esbonio/changes/1115.fix.md
+++ b/lib/esbonio/changes/1115.fix.md
@@ -1,0 +1,1 @@
+Preview server now responds with `Content-Type: text/html; charset=utf-8` (and `charset=utf-8` on other `text/*` types), so browsers consistently render UTF-8 content without falling back to a locale-dependent encoding.

--- a/lib/esbonio/esbonio/server/features/preview_manager/preview.py
+++ b/lib/esbonio/esbonio/server/features/preview_manager/preview.py
@@ -10,6 +10,7 @@ from esbonio import server
 from esbonio.server import Uri
 
 if typing.TYPE_CHECKING:
+    from os import PathLike
     from typing import Any
 
     from .config import PreviewConfig
@@ -32,6 +33,17 @@ class RequestHandler(SimpleHTTPRequestHandler):
         #      https://github.com/swyddfa/esbonio/issues/987
         self.send_header("Cache-Control", "no-store")
         return super().end_headers()
+
+    def guess_type(self, path: str | PathLike[str]) -> str:
+        # Append ``charset=utf-8`` to text/* MIME types so browsers consistently
+        # decode UTF-8 content from the build directory; Sphinx writes UTF-8 by
+        # default and Python's SimpleHTTPRequestHandler returns the bare type.
+        #
+        # See: https://github.com/swyddfa/esbonio/issues/1115
+        mimetype = super().guess_type(path)
+        if mimetype.startswith("text/") and "charset=" not in mimetype:
+            return f"{mimetype}; charset=utf-8"
+        return mimetype
 
     def log_message(self, format: str, *args: Any) -> None:
         self.logger.debug(format, *args)

--- a/lib/esbonio/tests/server/features/test_preview.py
+++ b/lib/esbonio/tests/server/features/test_preview.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import pytest
+
+from esbonio.server.features.preview_manager.preview import RequestHandler
+
+
+@pytest.fixture
+def handler() -> RequestHandler:
+    """A ``RequestHandler`` instance without invoking ``__init__``.
+
+    ``SimpleHTTPRequestHandler.__init__`` expects an active socket which we
+    don't need for unit-testing ``guess_type``, so we construct via ``__new__``.
+    """
+    return RequestHandler.__new__(RequestHandler)
+
+
+@pytest.mark.parametrize(
+    "path,expected",
+    [
+        ("foo.html", "text/html; charset=utf-8"),
+        ("foo.htm", "text/html; charset=utf-8"),
+        ("foo.css", "text/css; charset=utf-8"),
+        ("foo.txt", "text/plain; charset=utf-8"),
+    ],
+)
+def test_text_mime_types_declare_utf8_charset(
+    handler: RequestHandler, path: str, expected: str
+):
+    """Text responses should declare ``charset=utf-8`` so browsers don't fall
+    back to a locale-dependent encoding when rendering UTF-8 content."""
+    assert handler.guess_type(path) == expected
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "foo.png",
+        "foo.jpg",
+        "foo.svg",
+        "foo.woff2",
+        "foo.pdf",
+    ],
+)
+def test_non_text_mime_types_unchanged(handler: RequestHandler, path: str):
+    """Non-text MIME types should pass through without a charset suffix."""
+    assert "charset=" not in handler.guess_type(path)


### PR DESCRIPTION
Python's `SimpleHTTPRequestHandler` returns bare MIME types like `text/html` and `text/css`, so the preview server hands the browser a `Content-Type` with no charset. The browser then falls back to a locale-dependent default for the response body, and on machines where that default is not UTF-8 (the encoding Sphinx writes by default) non-ASCII characters render incorrectly.

This overrides `guess_type` on the preview `RequestHandler` to append `; charset=utf-8` to any `text/*` type that doesn't already declare one. Non-text types (images, fonts, PDFs) pass through unchanged.

Unit tests added under `tests/server/features/test_preview.py` cover the parametrized `text/*` cases (HTML, HTM, CSS, TXT) and confirm non-text types are untouched. The full server test suite passes.

Closes #1115